### PR TITLE
RHMAP-11703 - add new auth endpoint

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -58,18 +58,25 @@ var auth = {
    * correctly in local development/Studio Preview -
    * the js sdk dertermines envrironment mode from url string.
    * New endpoint determines environment mode from env var,
-   * sends request (req) and calls user provided function (cb).
+   * optionally sends request (localAuth - for local dev)
+   * and calls user provided function (cb).
    * @param  {object} req
-   * @param  {object} res
+   * @param  {function} localAuth - optional for local development.
    * @param  {object} cb
    */
-  performAuth: function (req, res, cb) {
+  performAuth: function (req, localAuth, cb) {
     // "FH_USE_LOCAL_DB" env var determines if the app is running in local mode.
     if (process.env.FH_USE_LOCAL_DB) {
-      // In local mode, invoke user function
-      return cb(undefined, res);
+      // In local mode, invoke user function/object
+      if (_.isFunction(localAuth)) {
+        return localAuth(req, cb);
+      } else if (_.isObject(localAuth)) {
+        return cb(undefined, localAuth);
+      } else {
+        return cb(undefined, {status: 200, body: {}});
+      }
     } else {
-      // In production mode, proxy request back to Core platform.
+            // In production mode, proxy request back to Core platform.
       return call("admin/authpolicy/auth", req.body, cb);
     }
   }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -54,16 +54,16 @@ var auth = {
     }
   },
   /**
+   * New endpoint required as autentication ($fh.auth) requests not handled
+   * correctly in local development/Studio Preview -
+   * the js sdk dertermines envrironment mode from url string.
+   * New endpoint determines environment mode from env var,
+   * sends request (req) and calls user provided function (cb).
    * @param  {object} req
    * @param  {object} res
    * @param  {object} cb
-   * New endpoint required as autentication ($fh.auth) requests not handled
-   * correctly in local development/Studio Preview - 
-   * the js sdk dertermines envrironment mode from url string.
-   * New endpoint determines environment mode from env var, 
-   * sends request (req) and calls user provided function (cb).
    */
-  getEnvironmentMode: function (req, res, cb) {
+  performAuth: function (req, res, cb) {
     // "FH_USE_LOCAL_DB" env var determines if the app is running in local mode.
     if (process.env.FH_USE_LOCAL_DB) {
       // In local mode, invoke user function

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -57,8 +57,9 @@ var auth = {
    * @param  {object} req
    * @param  {object} res
    * @param  {object} cb
-   * New endpoint required as autentication ($fh.auth) requests were sending 
-   * incorrect requests - the js sdk dertermines envrironment mode from url string.
+   * New endpoint required as autentication ($fh.auth) requests not handled
+   * correctly in local development/Studio Preview - 
+   * the js sdk dertermines envrironment mode from url string.
    * New endpoint determines environment mode from env var, 
    * sends request (req) and calls user provided function (cb).
    */

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -57,14 +57,18 @@ var auth = {
    * @param  {object} req
    * @param  {object} res
    * @param  {object} cb
+   * New endpoint required as autentication ($fh.auth) requests were sending 
+   * incorrect requests - the js sdk dertermines envrironment mode from url string.
+   * New endpoint determines environment mode from env var, 
+   * sends request (req) and calls user provided function (cb).
    */
   getEnvironmentMode: function (req, res, cb) {
-    // Use "FH_USE_LOCAL_DB" env var to determine if the app is running in local mode.
+    // "FH_USE_LOCAL_DB" env var determines if the app is running in local mode.
     if (process.env.FH_USE_LOCAL_DB) {
-      // In local mode, if user provides function invoke it
+      // In local mode, invoke user function
       return cb(undefined, res);
     } else {
-      //if it's not local mode, proxy the request back to millicore instead
+      // In production mode, proxy request back to Core platform.
       return call("admin/authpolicy/auth", req.body, cb);
     }
   }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,5 +1,5 @@
 var call, config, session;
-var _ = require("underscore");
+var _ = require('underscore');
 
 var ENDPOINT = 'admin/authpolicy/verifysession';
 var DEFAULT_OPTS = {
@@ -51,6 +51,21 @@ var auth = {
       }
     } else {
       return cb(null, false);
+    }
+  },
+  /**
+   * @param  {object} req
+   * @param  {object} res
+   * @param  {object} cb
+   */
+  getEnvironmentMode: function (req, res, cb) {
+    // Use "FH_USE_LOCAL_DB" env var to determine if the app is running in local mode.
+    if (process.env.FH_USE_LOCAL_DB) {
+      // In local mode, if user provides function invoke it
+      return cb(undefined, res);
+    } else {
+      //if it's not local mode, proxy the request back to millicore instead
+      return call("admin/authpolicy/auth", req.body, cb);
     }
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.0.3",
+  "version": "6.1.1",
   "dependencies": {
     "async": {
       "version": "0.2.9",
@@ -1042,7 +1042,7 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.0",
+  "version": "5.14.4",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "5.14.4",
+  "version": "6.0.3",
   "dependencies": {
     "async": {
       "version": "0.2.9",
@@ -563,9 +563,9 @@
       }
     },
     "fh-mbaas-express": {
-      "version": "5.6.3",
-      "from": "fh-mbaas-express@5.6.3",
-      "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.3.tgz",
+      "version": "5.6.4",
+      "from": "fh-mbaas-express@5.6.4",
+      "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.4.tgz",
       "dependencies": {
         "body-parser": {
           "version": "1.15.2",
@@ -1517,9 +1517,9 @@
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "tweetnacl": {
-                  "version": "0.14.3",
+                  "version": "0.14.4",
                   "from": "tweetnacl@>=0.14.0 <0.15.0",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.4.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1042,7 +1042,7 @@
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.0.3",
+  "version": "6.1.1",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eyes": "0.1.8",
     "fh-db": "1.2.5",
     "fh-mbaas-client": "0.15.0",
-    "fh-mbaas-express": "5.6.3",
+    "fh-mbaas-express": "5.6.4",
     "fh-security": "0.2.0",
     "fh-statsc": "0.3.0",
     "lodash-contrib": "^393.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.0",
+  "version": "6.0.3",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=5.14.4
+sonar.projectVersion=6.1.1
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=6.1.0
+sonar.projectVersion=5.14.4
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/fixtures/auth.js
+++ b/test/fixtures/auth.js
@@ -5,6 +5,14 @@ var replies = {
     return {
       isValid: true
     }
+  },
+  
+  /**
+   * @param  {String} path
+   * @param  {String} body
+   */
+  productionMode: function (path, body) {
+    return 'productionMode';
   }
 };
 module.exports = nock('https://localhost:443')
@@ -12,4 +20,6 @@ module.exports = nock('https://localhost:443')
   return '*';
 })
 .post('/box/srv/1.1/admin/authpolicy/verifysession', '*')
-.reply(200, replies.verifysession);
+.reply(200, replies.verifysession)
+.post('/box/srv/1.1/admin/authpolicy/auth', '*')
+.reply(200, replies.productionMode)

--- a/test/test_fhauth.js
+++ b/test/test_fhauth.js
@@ -1,5 +1,6 @@
 var authMock, $fh;
 var assert = require('assert');
+var _ = require('underscore')
 
 module.exports = {
   setUp: function(finish){
@@ -13,6 +14,36 @@ module.exports = {
     $fh.auth.verify(token, {expire: 60}, function(err, isValid){
       assert.ok(!err);
       assert.ok(isValid);
+      finish();
+    });
+  },
+
+  /**
+   * @param  {object} finish
+   */
+  getEnvModeLocal : function(finish) {
+    process.env.FH_USE_LOCAL_DB = 'true';
+
+    var req = _.noop;
+    var res = {body: 'test'};
+
+    $fh.auth.getEnvironmentMode(req, res, function(err, resp) {
+      assert.notEqual(resp.body, 'productionMode');
+      finish();
+    });
+  },
+  
+  /**
+   * @param  {object} finish
+   */
+  getEnvModeRemote: function(finish) {
+    process.env.FH_USE_LOCAL_DB = '';
+
+    var req = {body: 'test'};
+    var res = _.noop;
+
+    $fh.auth.getEnvironmentMode(req, res, function(err, resp) {
+      assert.equal(resp.body, 'productionMode')
       finish();
     });
   },

--- a/test/test_fhauth.js
+++ b/test/test_fhauth.js
@@ -21,13 +21,13 @@ module.exports = {
   /**
    * @param  {object} finish
    */
-  getEnvModeLocal : function(finish) {
+  performAuthLocalDev : function(finish) {
     process.env.FH_USE_LOCAL_DB = 'true';
 
     var req = _.noop;
     var res = {body: 'test'};
 
-    $fh.auth.getEnvironmentMode(req, res, function(err, resp) {
+    $fh.auth.performAuth(req, res, function(err, resp) {
       assert.notEqual(resp.body, 'productionMode');
       finish();
     });
@@ -36,13 +36,13 @@ module.exports = {
   /**
    * @param  {object} finish
    */
-  getEnvModeRemote: function(finish) {
+  performAuthProductionDev: function(finish) {
     process.env.FH_USE_LOCAL_DB = '';
 
     var req = {body: 'test'};
     var res = _.noop;
 
-    $fh.auth.getEnvironmentMode(req, res, function(err, resp) {
+    $fh.auth.performAuth(req, res, function(err, resp) {
       assert.equal(resp.body, 'productionMode')
       finish();
     });


### PR DESCRIPTION
## Motivation

The studio preview for Web Apps (Embed Apps) incorrectly sends $fh.auth requests through the Web App and not through the domain

## Solution 

Add a new auth endpoint to fh-mbaas-api which determines if the app is running in local mode. In local mode the function provided by the user should be invoked.  In production mode the user's function should be proxied back to millicore.