### PR TITLE
bump of mbaas-express to inlcude Insecure Entropy Source fix

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,21 +1,140 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "dependencies": {
+    "ansi-regex": {
+      "version": "2.0.0",
+      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "from": "asn1@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "from": "assert-plus@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+    },
     "async": {
       "version": "0.2.9",
       "from": "async@0.2.9",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "from": "aws-sign2@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+    },
+    "aws4": {
+      "version": "1.5.0",
+      "from": "aws4@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.0",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+      "optional": true
+    },
+    "bl": {
+      "version": "1.1.2",
+      "from": "bl@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
+    },
+    "boom": {
+      "version": "2.10.1",
+      "from": "boom@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "from": "caseless@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "from": "chalk@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "colors": {
       "version": "0.6.2",
       "from": "colors@0.6.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
     },
+    "combined-stream": {
+      "version": "1.0.5",
+      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+    },
+    "commander": {
+      "version": "2.9.0",
+      "from": "commander@>=2.9.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+    },
+    "connection-parse": {
+      "version": "0.0.7",
+      "from": "connection-parse@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+    },
     "cycle": {
       "version": "1.0.3",
       "from": "cycle@1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "from": "dashdash@>=1.12.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "optional": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+    },
+    "extend": {
+      "version": "3.0.0",
+      "from": "extend@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "from": "extsprintf@1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "eyes": {
       "version": "0.1.8",
@@ -29,86 +148,86 @@
       "dependencies": {
         "adm-zip": {
           "version": "0.4.7",
-          "from": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+          "from": "adm-zip@>=0.4.4 <0.5.0",
           "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz"
         },
         "archiver": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/archiver/-/archiver-1.0.0.tgz",
+          "from": "archiver@1.0.0",
           "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.0.0.tgz",
           "dependencies": {
             "archiver-utils": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.2.0.tgz",
+              "from": "archiver-utils@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.2.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.6",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
+                  "from": "graceful-fs@>=4.1.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz"
                 },
                 "lazystream": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+                  "from": "lazystream@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
                 },
                 "normalize-path": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+                  "from": "normalize-path@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                 }
               }
             },
             "buffer-crc32": {
               "version": "0.2.5",
-              "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
+              "from": "buffer-crc32@>=0.2.1 <0.3.0",
               "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
             },
             "glob": {
               "version": "7.0.6",
-              "from": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+              "from": "glob@>=7.0.0 <8.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "from": "minimatch@>=3.0.2 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.6",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "from": "balanced-match@>=0.4.1 <0.5.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -117,113 +236,113 @@
                 },
                 "once": {
                   "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "lodash": {
               "version": "4.15.0",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+              "from": "lodash@>=4.8.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
             },
             "readable-stream": {
               "version": "2.1.5",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+              "from": "readable-stream@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
               "dependencies": {
                 "buffer-shims": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                  "from": "buffer-shims@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "from": "isarray@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "tar-stream": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
+              "from": "tar-stream@>=1.5.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
               "dependencies": {
                 "bl": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                  "from": "bl@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "from": "readable-stream@>=2.0.5 <2.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "from": "isarray@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -232,48 +351,53 @@
                 },
                 "end-of-stream": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "from": "end-of-stream@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     }
                   }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "zip-stream": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.0.0.tgz",
+              "from": "zip-stream@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.0.0.tgz",
               "dependencies": {
                 "compress-commons": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.0.0.tgz",
+                  "from": "compress-commons@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.0.0.tgz",
                   "dependencies": {
                     "crc32-stream": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz",
+                      "from": "crc32-stream@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz"
                     },
                     "node-int64": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+                      "from": "node-int64@>=0.4.0 <0.5.0",
                       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
                     },
                     "normalize-path": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+                      "from": "normalize-path@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                     }
                   }
@@ -284,63 +408,63 @@
         },
         "async": {
           "version": "1.5.2",
-          "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "from": "async@1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "bson": {
           "version": "0.4.22",
-          "from": "https://registry.npmjs.org/bson/-/bson-0.4.22.tgz",
+          "from": "bson@0.4.22",
           "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.22.tgz"
         },
         "csvtojson": {
           "version": "0.3.6",
-          "from": "https://registry.npmjs.org/csvtojson/-/csvtojson-0.3.6.tgz",
+          "from": "csvtojson@0.3.6",
           "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-0.3.6.tgz"
         },
         "jcsv": {
           "version": "0.0.3",
-          "from": "https://registry.npmjs.org/jcsv/-/jcsv-0.0.3.tgz",
+          "from": "jcsv@0.0.3",
           "resolved": "https://registry.npmjs.org/jcsv/-/jcsv-0.0.3.tgz"
         },
         "lodash": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "from": "lodash@2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
         },
         "mongodb": {
           "version": "2.1.18",
-          "from": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
+          "from": "mongodb@2.1.18",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
           "dependencies": {
             "es6-promise": {
               "version": "3.0.2",
-              "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+              "from": "es6-promise@3.0.2",
               "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
             },
             "mongodb-core": {
               "version": "1.3.18",
-              "from": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
+              "from": "mongodb-core@1.3.18",
               "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
               "dependencies": {
                 "bson": {
                   "version": "0.4.23",
-                  "from": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+                  "from": "bson@>=0.4.23 <0.5.0",
                   "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
                 },
                 "require_optional": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+                  "from": "require_optional@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
                   "dependencies": {
-                    "semver": {
-                      "version": "5.3.0",
-                      "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-                    },
                     "resolve-from": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                      "from": "resolve-from@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+                    },
+                    "semver": {
+                      "version": "5.3.0",
+                      "from": "semver@>=5.1.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                     }
                   }
                 }
@@ -348,28 +472,28 @@
             },
             "readable-stream": {
               "version": "1.0.31",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+              "from": "readable-stream@1.0.31",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -377,7 +501,7 @@
         },
         "stream-buffers": {
           "version": "3.0.0",
-          "from": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.0.tgz",
+          "from": "stream-buffers@3.0.0",
           "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.0.tgz"
         }
       }
@@ -389,7 +513,7 @@
       "dependencies": {
         "fh-logger": {
           "version": "0.5.0",
-          "from": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
+          "from": "fh-logger@0.5.0",
           "resolved": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
           "dependencies": {
             "bunyan": {
@@ -401,82 +525,103 @@
                   "version": "0.6.0",
                   "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+                  "optional": true,
                   "dependencies": {
                     "nan": {
                       "version": "2.3.5",
                       "from": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+                      "optional": true
                     }
                   }
+                },
+                "moment": {
+                  "version": "2.13.0",
+                  "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+                  "optional": true
                 },
                 "mv": {
                   "version": "2.1.1",
                   "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                  "optional": true,
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.1",
                       "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "optional": true,
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
                           "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "optional": true
                         }
                       }
                     },
                     "ncp": {
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                      "optional": true
                     },
                     "rimraf": {
                       "version": "2.4.5",
                       "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                      "optional": true,
                       "dependencies": {
                         "glob": {
                           "version": "6.0.4",
                           "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                          "optional": true,
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.5",
                               "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                              "optional": true,
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
                                   "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                  "optional": true
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
                               "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "optional": true
                             },
                             "minimatch": {
                               "version": "3.0.2",
                               "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                              "optional": true,
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.5",
                                   "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+                                  "optional": true,
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.4.1",
                                       "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+                                      "optional": true
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
                                       "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "optional": true
                                     }
                                   }
                                 }
@@ -497,7 +642,8 @@
                             "path-is-absolute": {
                               "version": "1.0.0",
                               "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "optional": true
                             }
                           }
                         }
@@ -508,12 +654,8 @@
                 "safe-json-stringify": {
                   "version": "1.0.3",
                   "from": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
-                },
-                "moment": {
-                  "version": "2.13.0",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
+                  "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+                  "optional": true
                 }
               }
             },
@@ -555,125 +697,510 @@
             }
           }
         },
+        "request": {
+          "version": "2.74.0",
+          "from": "request@>=2.74.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "aws4": {
+              "version": "1.4.1",
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
+            },
+            "bl": {
+              "version": "1.1.2",
+              "from": "bl@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "1.0.0-rc4",
+              "from": "form-data@>=1.0.0-rc4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "1.5.2",
+                  "from": "async@>=1.5.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "from": "har-validator@>=2.0.6 <2.1.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "from": "commander@>=2.9.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.13.1",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "hawk@>=3.1.3 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "http-signature@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.3.0",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "from": "json-schema@0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.8.3",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.14.0",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "optional": true
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "optional": true
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.3",
+                      "from": "tweetnacl@>=0.13.0 <0.14.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.11",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.23.0",
+                  "from": "mime-db@>=1.23.0 <1.24.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+            },
+            "qs": {
+              "version": "6.2.1",
+              "from": "qs@>=6.2.0 <6.3.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.3.1",
+              "from": "tough-cookie@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.3",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+            }
+          }
+        },
         "underscore": {
           "version": "1.8.3",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "from": "underscore@>=1.8.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
         }
       }
     },
     "fh-mbaas-express": {
-      "version": "5.6.4",
-      "from": "fh-mbaas-express@5.6.4",
-      "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.4.tgz",
+      "version": "5.6.6",
+      "from": "fh-mbaas-express@5.6.6",
+      "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.6.tgz",
       "dependencies": {
+        "async": {
+          "version": "0.2.9",
+          "from": "async@0.2.9",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+        },
         "body-parser": {
           "version": "1.15.2",
-          "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
+          "from": "body-parser@1.15.2",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
           "dependencies": {
             "bytes": {
               "version": "2.4.0",
-              "from": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+              "from": "bytes@2.4.0",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
             },
             "content-type": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+              "from": "content-type@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "depd": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+              "from": "depd@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
             },
             "http-errors": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+              "version": "1.5.1",
+              "from": "http-errors@>=1.5.0 <1.6.0",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "inherits@2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "setprototypeof": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+                  "version": "1.0.2",
+                  "from": "setprototypeof@1.0.2",
+                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
                 },
                 "statuses": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+                  "version": "1.3.1",
+                  "from": "statuses@>=1.3.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
                 }
               }
             },
             "iconv-lite": {
               "version": "0.4.13",
-              "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+              "from": "iconv-lite@0.4.13",
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "from": "on-finished@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                  "from": "ee-first@1.1.1",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "6.2.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+              "from": "qs@6.2.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
             },
             "raw-body": {
               "version": "2.1.7",
-              "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+              "from": "raw-body@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
               "dependencies": {
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                  "from": "unpipe@1.0.0",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "type-is": {
-              "version": "1.6.13",
-              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+              "version": "1.6.14",
+              "from": "type-is@>=1.6.13 <1.7.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                  "from": "media-typer@0.3.0",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.12",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "version": "2.1.13",
+                  "from": "mime-types@>=2.1.13 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.24.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                      "version": "1.25.0",
+                      "from": "mime-db@>=1.25.0 <1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                     }
                   }
                 }
@@ -683,244 +1210,244 @@
         },
         "cors": {
           "version": "2.1.0",
-          "from": "https://registry.npmjs.org/cors/-/cors-2.1.0.tgz",
+          "from": "cors@2.1.0",
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.1.0.tgz"
         },
         "express": {
           "version": "4.14.0",
-          "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+          "from": "express@4.14.0",
           "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.3.3",
-              "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "from": "accepts@>=1.3.3 <1.4.0",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "2.1.12",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "version": "2.1.13",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.24.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                      "version": "1.25.0",
+                      "from": "mime-db@>=1.25.0 <1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                     }
                   }
                 },
                 "negotiator": {
                   "version": "0.6.1",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                  "from": "negotiator@0.6.1",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                 }
               }
             },
             "array-flatten": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+              "from": "array-flatten@1.1.1",
               "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
             },
             "content-disposition": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+              "from": "content-disposition@0.5.1",
               "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
             },
             "content-type": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+              "from": "content-type@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
             },
             "cookie": {
               "version": "0.3.1",
-              "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+              "from": "cookie@0.3.1",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
             },
             "cookie-signature": {
               "version": "1.0.6",
-              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+              "from": "cookie-signature@1.0.6",
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "depd": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+              "from": "depd@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
             },
             "encodeurl": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+              "from": "encodeurl@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
             },
             "escape-html": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+              "from": "escape-html@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
             },
             "etag": {
               "version": "1.7.0",
-              "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+              "from": "etag@>=1.7.0 <1.8.0",
               "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
             },
             "finalhandler": {
               "version": "0.5.0",
-              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+              "from": "finalhandler@0.5.0",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
               "dependencies": {
                 "statuses": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+                  "version": "1.3.1",
+                  "from": "statuses@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
                 },
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                  "from": "unpipe@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "fresh": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+              "from": "fresh@0.3.0",
               "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
             },
             "merge-descriptors": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+              "from": "merge-descriptors@1.0.1",
               "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
             },
             "methods": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+              "from": "methods@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "from": "on-finished@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                  "from": "ee-first@1.1.1",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "parseurl": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "from": "parseurl@>=1.3.1 <1.4.0",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "path-to-regexp": {
               "version": "0.1.7",
-              "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+              "from": "path-to-regexp@0.1.7",
               "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
             },
             "proxy-addr": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+              "from": "proxy-addr@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
               "dependencies": {
                 "forwarded": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+                  "from": "forwarded@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                 },
                 "ipaddr.js": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
+                  "from": "ipaddr.js@1.1.1",
                   "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
                 }
               }
             },
             "qs": {
               "version": "6.2.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+              "from": "qs@6.2.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
             },
             "range-parser": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+              "from": "range-parser@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
             },
             "send": {
               "version": "0.14.1",
-              "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+              "from": "send@0.14.1",
               "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
               "dependencies": {
                 "destroy": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                  "from": "destroy@>=1.0.4 <1.1.0",
                   "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                 },
                 "http-errors": {
-                  "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+                  "version": "1.5.1",
+                  "from": "http-errors@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
                   "dependencies": {
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "inherits@2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "setprototypeof": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "setprototypeof@1.0.2",
+                      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "from": "mime@1.3.4",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "statuses": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+                  "version": "1.3.1",
+                  "from": "statuses@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
                 }
               }
             },
             "serve-static": {
               "version": "1.11.1",
-              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+              "from": "serve-static@>=1.11.1 <1.12.0",
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
             },
             "type-is": {
-              "version": "1.6.13",
-              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+              "version": "1.6.14",
+              "from": "type-is@>=1.6.13 <1.7.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                  "from": "media-typer@0.3.0",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.12",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "version": "2.1.13",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.24.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                      "version": "1.25.0",
+                      "from": "mime-db@>=1.25.0 <1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                     }
                   }
                 }
@@ -928,20 +1455,20 @@
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+              "from": "utils-merge@1.0.0",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             },
             "vary": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+              "from": "vary@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
             }
           }
         },
         "fh-amqp-js": {
-          "version": "0.7.0",
-          "from": "https://registry.npmjs.org/fh-amqp-js/-/fh-amqp-js-0.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/fh-amqp-js/-/fh-amqp-js-0.7.0.tgz",
+          "version": "0.7.1",
+          "from": "fh-amqp-js@0.7.1",
+          "resolved": "https://registry.npmjs.org/fh-amqp-js/-/fh-amqp-js-0.7.1.tgz",
           "dependencies": {
             "amqp": {
               "version": "0.2.0",
@@ -966,27 +1493,15 @@
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
             },
             "node-uuid": {
-              "version": "1.4.3",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+              "version": "1.4.7",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "rc": {
               "version": "0.1.1",
               "from": "https://registry.npmjs.org/rc/-/rc-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/rc/-/rc-0.1.1.tgz",
               "dependencies": {
-                "optimist": {
-                  "version": "0.3.7",
-                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                  "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                },
                 "deep-extend": {
                   "version": "0.2.11",
                   "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
@@ -996,14 +1511,224 @@
                   "version": "1.1.0",
                   "from": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    }
+                  }
                 }
               }
             }
           }
         },
+        "fh-mbaas-client": {
+          "version": "0.15.0",
+          "from": "fh-mbaas-client@0.15.0",
+          "resolved": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-0.15.0.tgz",
+          "dependencies": {
+            "fh-logger": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
+              "dependencies": {
+                "bunyan": {
+                  "version": "1.8.1",
+                  "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
+                  "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
+                  "dependencies": {
+                    "dtrace-provider": {
+                      "version": "0.6.0",
+                      "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+                      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+                      "optional": true,
+                      "dependencies": {
+                        "nan": {
+                          "version": "2.3.5",
+                          "from": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+                          "optional": true
+                        }
+                      }
+                    },
+                    "moment": {
+                      "version": "2.13.0",
+                      "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+                      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+                      "optional": true
+                    },
+                    "mv": {
+                      "version": "2.1.1",
+                      "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                      "optional": true,
+                      "dependencies": {
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "optional": true,
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "optional": true
+                            }
+                          }
+                        },
+                        "ncp": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                          "optional": true
+                        },
+                        "rimraf": {
+                          "version": "2.4.5",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                          "optional": true,
+                          "dependencies": {
+                            "glob": {
+                              "version": "6.0.4",
+                              "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                              "optional": true,
+                              "dependencies": {
+                                "inflight": {
+                                  "version": "1.0.5",
+                                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                                  "optional": true,
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.2",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "optional": true
+                                },
+                                "minimatch": {
+                                  "version": "3.0.2",
+                                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                                  "optional": true,
+                                  "dependencies": {
+                                    "brace-expansion": {
+                                      "version": "1.1.5",
+                                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+                                      "optional": true,
+                                      "dependencies": {
+                                        "balanced-match": {
+                                          "version": "0.4.1",
+                                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+                                          "optional": true
+                                        },
+                                        "concat-map": {
+                                          "version": "0.0.1",
+                                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                          "optional": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "once": {
+                                  "version": "1.3.3",
+                                  "from": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.2",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "path-is-absolute": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "safe-json-stringify": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+                      "optional": true
+                    }
+                  }
+                },
+                "continuation-local-storage": {
+                  "version": "3.1.7",
+                  "from": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.7.tgz",
+                  "dependencies": {
+                    "async-listener": {
+                      "version": "0.6.0",
+                      "from": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.0.tgz",
+                      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.0.tgz",
+                      "dependencies": {
+                        "shimmer": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "emitter-listener": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
+                      "dependencies": {
+                        "shimmer": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "from": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+                  "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                }
+              }
+            },
+            "underscore": {
+              "version": "1.8.3",
+              "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+            }
+          }
+        },
         "fh-reportingclient": {
           "version": "0.5.4",
-          "from": "https://registry.npmjs.org/fh-reportingclient/-/fh-reportingclient-0.5.4.tgz",
+          "from": "fh-reportingclient@0.5.4",
           "resolved": "https://registry.npmjs.org/fh-reportingclient/-/fh-reportingclient-0.5.4.tgz",
           "dependencies": {
             "async": {
@@ -1015,50 +1740,50 @@
         },
         "multer": {
           "version": "0.1.8",
-          "from": "https://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
+          "from": "multer@0.1.8",
           "resolved": "https://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
           "dependencies": {
             "busboy": {
               "version": "0.2.13",
-              "from": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
+              "from": "busboy@>=0.2.9 <0.3.0",
               "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
               "dependencies": {
                 "dicer": {
                   "version": "0.2.5",
-                  "from": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+                  "from": "dicer@0.2.5",
                   "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
                   "dependencies": {
                     "streamsearch": {
                       "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+                      "from": "streamsearch@0.1.2",
                       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
                     }
                   }
                 },
                 "readable-stream": {
                   "version": "1.1.14",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 }
@@ -1066,32 +1791,32 @@
             },
             "mkdirp": {
               "version": "0.3.5",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "from": "mkdirp@>=0.3.5 <0.4.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
             },
             "qs": {
               "version": "1.2.2",
-              "from": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+              "from": "qs@>=1.2.2 <1.3.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
             },
             "type-is": {
               "version": "1.5.7",
-              "from": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+              "from": "type-is@>=1.5.2 <1.6.0",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                  "from": "media-typer@0.3.0",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.0.14",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                  "from": "mime-types@>=2.0.9 <2.1.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.12.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                      "from": "mime-db@>=1.12.0 <1.13.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                     }
                   }
@@ -1100,21 +1825,421 @@
             }
           }
         },
+        "request": {
+          "version": "2.74.0",
+          "from": "request@2.74.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "aws4": {
+              "version": "1.5.0",
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+            },
+            "bl": {
+              "version": "1.1.2",
+              "from": "bl@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.0",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "1.0.1",
+              "from": "form-data@>=1.0.0-rc4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "2.1.4",
+                  "from": "async@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "4.17.4",
+                      "from": "lodash@>=4.14.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "har-validator": {
+              "version": "2.0.6",
+              "from": "har-validator@>=2.0.6 <2.1.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.9.0",
+                  "from": "commander@>=2.9.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-my-json-valid": {
+                  "version": "2.15.0",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                  "dependencies": {
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "dependencies": {
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.1",
+                      "from": "jsonpointer@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "hawk@>=3.1.3 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "dependencies": {
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "http-signature@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.3.1",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.10.1",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "optional": true
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "optional": true
+                    },
+                    "getpass": {
+                      "version": "0.1.6",
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "optional": true
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.13",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.25.0",
+                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.7",
+              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+            },
+            "qs": {
+              "version": "6.2.1",
+              "from": "qs@>=6.2.0 <6.3.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "from": "tough-cookie@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "from": "punycode@>=1.4.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.4.3",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+            }
+          }
+        },
         "type-is": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/type-is/-/type-is-1.1.0.tgz",
+          "from": "type-is@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.1.0.tgz",
           "dependencies": {
             "mime": {
               "version": "1.2.11",
-              "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+              "from": "mime@>=1.2.11 <1.3.0",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
             }
           }
         },
         "underscore": {
           "version": "1.5.1",
-          "from": "https://registry.npmjs.org/underscore/-/underscore-1.5.1.tgz",
+          "from": "underscore@1.5.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.1.tgz"
         }
       }
@@ -1126,12 +2251,12 @@
       "dependencies": {
         "node-rsa": {
           "version": "0.3.2",
-          "from": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.3.2.tgz",
+          "from": "node-rsa@0.3.2",
           "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.3.2.tgz",
           "dependencies": {
             "asn1": {
               "version": "0.2.3",
-              "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+              "from": "asn1@0.2.3",
               "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
             }
           }
@@ -1141,55 +2266,185 @@
     "fh-statsc": {
       "version": "0.3.0",
       "from": "fh-statsc@0.3.0",
-      "resolved": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.9",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+    },
+    "form-data": {
+      "version": "1.0.1",
+      "from": "form-data@>=1.0.0-rc4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "2.1.4",
+          "from": "async@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz"
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "from": "lodash@>=4.14.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        }
+      }
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "from": "generate-function@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+    },
+    "getpass": {
+      "version": "0.1.6",
+      "from": "getpass@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "from": "graceful-readlink@>=1.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "from": "har-validator@>=2.0.6 <2.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
+    "hashring": {
+      "version": "3.2.0",
+      "from": "hashring@>=3.2.0 <3.3.0",
+      "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz"
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "from": "hawk@>=3.1.3 <3.2.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "from": "hoek@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "from": "http-signature@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "from": "inherits@>=2.0.1 <2.1.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+    },
+    "is-my-json-valid": {
+      "version": "2.15.0",
+      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz"
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "from": "is-property@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "from": "isarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "from": "isstream@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+    },
+    "jackpot": {
+      "version": "0.0.6",
+      "from": "jackpot@>=0.0.6",
+      "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz"
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "from": "jodid25519@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+      "optional": true
+    },
+    "jsbn": {
+      "version": "0.1.0",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "from": "json-schema@0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "from": "jsonpointer@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+    },
+    "jsprim": {
+      "version": "1.3.1",
+      "from": "jsprim@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
+    },
+    "lodash": {
+      "version": "3.9.3",
+      "from": "lodash@3.9.3",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
     },
     "lodash-contrib": {
       "version": "393.0.1",
       "from": "lodash-contrib@>=393.0.1 <394.0.0",
-      "resolved": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz",
-      "dependencies": {
-        "lodash": {
-          "version": "3.9.3",
-          "from": "lodash@3.9.3",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz"
     },
     "memcached": {
       "version": "2.2.2",
       "from": "memcached@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
-      "dependencies": {
-        "hashring": {
-          "version": "3.2.0",
-          "from": "hashring@>=3.2.0 <3.3.0",
-          "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
-          "dependencies": {
-            "connection-parse": {
-              "version": "0.0.7",
-              "from": "connection-parse@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz"
-            },
-            "simple-lru-cache": {
-              "version": "0.0.2",
-              "from": "simple-lru-cache@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz"
-            }
-          }
-        },
-        "jackpot": {
-          "version": "0.0.6",
-          "from": "jackpot@>=0.0.6",
-          "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
-          "dependencies": {
-            "retry": {
-              "version": "0.6.0",
-              "from": "retry@0.6.0",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
-            }
-          }
-        }
-      }
+      "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz"
+    },
+    "mime-db": {
+      "version": "1.25.0",
+      "from": "mime-db@>=1.25.0 <1.26.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
+    },
+    "mime-types": {
+      "version": "2.1.13",
+      "from": "mime-types@>=2.1.7 <2.2.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
     },
     "moment": {
       "version": "2.14.1",
@@ -1201,15 +2456,55 @@
       "from": "mongodb-uri@0.9.7",
       "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz"
     },
+    "node-uuid": {
+      "version": "1.4.7",
+      "from": "node-uuid@>=1.4.7 <1.5.0",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "from": "oauth-sign@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+    },
     "optval": {
       "version": "1.0.1",
       "from": "optval@1.0.1",
       "resolved": "https://registry.npmjs.org/optval/-/optval-1.0.1.tgz"
     },
+    "pinkie": {
+      "version": "2.0.4",
+      "from": "pinkie@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+    },
     "pkginfo": {
       "version": "0.2.3",
       "from": "pkginfo@0.2.3",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "from": "punycode@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+    },
+    "qs": {
+      "version": "6.2.1",
+      "from": "qs@>=6.2.0 <6.3.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
+    },
+    "readable-stream": {
+      "version": "2.0.6",
+      "from": "readable-stream@>=2.0.5 <2.1.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
     },
     "redis": {
       "version": "0.8.2",
@@ -1219,390 +2514,32 @@
     "request": {
       "version": "2.74.0",
       "from": "request@2.74.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz"
+    },
+    "retry": {
+      "version": "0.6.0",
+      "from": "retry@0.6.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+    },
+    "simple-lru-cache": {
+      "version": "0.0.2",
+      "from": "simple-lru-cache@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz"
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "from": "sntp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+    },
+    "sshpk": {
+      "version": "1.10.1",
+      "from": "sshpk@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
       "dependencies": {
-        "aws-sign2": {
-          "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-        },
-        "aws4": {
-          "version": "1.5.0",
-          "from": "aws4@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
-        },
-        "bl": {
-          "version": "1.1.2",
-          "from": "bl@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "from": "readable-stream@>=2.0.5 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "from": "caseless@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "dependencies": {
-            "delayed-stream": {
-              "version": "1.0.0",
-              "from": "delayed-stream@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-            }
-          }
-        },
-        "extend": {
-          "version": "3.0.0",
-          "from": "extend@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-        },
-        "form-data": {
-          "version": "1.0.1",
-          "from": "form-data@>=1.0.0-rc4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-          "dependencies": {
-            "async": {
-              "version": "2.1.4",
-              "from": "async@>=2.0.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "lodash@>=4.14.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "from": "har-validator@>=2.0.6 <2.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "commander": {
-              "version": "2.9.0",
-              "from": "commander@>=2.9.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                }
-              }
-            },
-            "is-my-json-valid": {
-              "version": "2.15.0",
-              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-              "dependencies": {
-                "generate-function": {
-                  "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "dependencies": {
-                    "is-property": {
-                      "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                    }
-                  }
-                },
-                "jsonpointer": {
-                  "version": "4.0.0",
-                  "from": "jsonpointer@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
-                }
-              }
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "from": "pinkie-promise@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "dependencies": {
-                "pinkie": {
-                  "version": "2.0.4",
-                  "from": "pinkie@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                }
-              }
-            }
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3",
-              "from": "hoek@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-            },
-            "boom": {
-              "version": "2.10.1",
-              "from": "boom@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-            }
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "dependencies": {
-            "assert-plus": {
-              "version": "0.2.0",
-              "from": "assert-plus@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-            },
-            "jsprim": {
-              "version": "1.3.1",
-              "from": "jsprim@>=1.2.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-              "dependencies": {
-                "extsprintf": {
-                  "version": "1.0.2",
-                  "from": "extsprintf@1.0.2",
-                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                },
-                "json-schema": {
-                  "version": "0.2.3",
-                  "from": "json-schema@0.2.3",
-                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-                },
-                "verror": {
-                  "version": "1.3.6",
-                  "from": "verror@1.3.6",
-                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                }
-              }
-            },
-            "sshpk": {
-              "version": "1.10.1",
-              "from": "sshpk@>=1.7.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
-              "dependencies": {
-                "asn1": {
-                  "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                },
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                },
-                "dashdash": {
-                  "version": "1.14.1",
-                  "from": "dashdash@>=1.12.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-                },
-                "getpass": {
-                  "version": "0.1.6",
-                  "from": "getpass@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
-                },
-                "jsbn": {
-                  "version": "0.1.0",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                },
-                "tweetnacl": {
-                  "version": "0.14.4",
-                  "from": "tweetnacl@>=0.14.0 <0.15.0",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.4.tgz"
-                },
-                "jodid25519": {
-                  "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                },
-                "bcrypt-pbkdf": {
-                  "version": "1.0.0",
-                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "is-typedarray": {
+        "assert-plus": {
           "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-        },
-        "mime-types": {
-          "version": "2.1.13",
-          "from": "mime-types@>=2.1.7 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-          "dependencies": {
-            "mime-db": {
-              "version": "1.25.0",
-              "from": "mime-db@>=1.25.0 <1.26.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
-            }
-          }
-        },
-        "node-uuid": {
-          "version": "1.4.7",
-          "from": "node-uuid@>=1.4.7 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.1 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-        },
-        "qs": {
-          "version": "6.2.1",
-          "from": "qs@>=6.2.0 <6.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "from": "stringstream@>=0.0.4 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "from": "tough-cookie@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "from": "punycode@>=1.4.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "from": "tunnel-agent@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
@@ -1610,6 +2547,42 @@
       "version": "0.0.9",
       "from": "stack-trace@0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "from": "stringstream@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "from": "supports-color@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "from": "tough-cookie@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "optional": true
     },
     "underscore": {
       "version": "1.7.0",
@@ -1820,6 +2793,11 @@
                       "version": "2.0.0",
                       "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
@@ -1842,11 +2820,6 @@
               "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
                 "boom": {
                   "version": "2.10.1",
                   "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -1856,6 +2829,11 @@
                   "version": "2.0.5",
                   "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
@@ -1911,25 +2889,29 @@
                       "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz",
                       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                     },
-                    "jsbn": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.13.3",
-                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "optional": true
                     },
                     "jodid25519": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "optional": true
                     },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "optional": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.3",
+                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+                      "optional": true
                     }
                   }
                 }
@@ -1965,7 +2947,7 @@
             "node-uuid": {
               "version": "1.4.7",
               "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.1",
@@ -1995,6 +2977,16 @@
           }
         }
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    },
+    "verror": {
+      "version": "1.3.6",
+      "from": "verror@1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
     },
     "winston": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {
@@ -10,7 +10,7 @@
     "eyes": "0.1.8",
     "fh-db": "1.2.5",
     "fh-mbaas-client": "0.15.0",
-    "fh-mbaas-express": "5.6.4",
+    "fh-mbaas-express": "5.6.6",
     "fh-security": "0.2.0",
     "fh-statsc": "0.3.0",
     "lodash-contrib": "^393.0.1",


### PR DESCRIPTION
related to #31 added missing shrinkwrap

# Issue
Vulnerability in node-uuid - Insecure Entropy Source 
# Solution
Update fh-mbaas-express to include fh-amqp-js@0.7.1 that has the fix.
Update fh-mbaas-api with the new version of fh-mbaas-express.

# JIRA
https://issues.jboss.org/browse/RAINCATCH-431