### PR TITLE
Feature/addition of response handler

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "editor.tabSize": 2
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-    "editor.tabSize": 2
-}

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -51,7 +51,6 @@ var self = {
   },
 
   doListHandler: function (dataset_id, query_params, cb, meta_data) {
-   
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.listHandler) {

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -30,7 +30,9 @@ var self = {
   globalRequestInterceptor: function (dataset_id, params, cb) {
     return cb()
   },
-
+  globalResponseInterceptor: function (dataset_id, params, cb) {
+    return cb();
+  },
   defaults: {
     "syncFrequency": 10,
     "clientSyncTimeout": 15,
@@ -49,6 +51,7 @@ var self = {
   },
 
   doListHandler: function (dataset_id, query_params, cb, meta_data) {
+   
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
       if (dataset.listHandler) {
@@ -152,6 +155,18 @@ var self = {
       }
       else {
         self.globalRequestInterceptor(dataset_id, params, cb);
+      }
+    });
+  },
+
+  doResponseInterceptor: function (dataset_id, params, cb) {
+    self.getDataset(dataset_id, function (err, dataset) {
+      if (err) return cb(err);
+      if (dataset.responseInterceptor) {
+        dataset.responseInterceptor(dataset_id, params, cb);
+      }
+      else {
+        self.globalResponseInterceptor(dataset_id, params, cb);
       }
     });
   },
@@ -582,6 +597,7 @@ module.exports = {
   setGlobalCollisionLister: generateGlobalSetter('globalCollisionLister', self),
   setGlobalCollisionRemover: generateGlobalSetter('globalCollisionRemover', self),
   setGlobalRequestInterceptor: generateGlobalSetter('globalRequestInterceptor', self),
+  setGlobalResponseInterceptor: generateGlobalSetter('globalResponseInterceptor', self),
   doListHandler: self.doListHandler,
   doCreateHandler: self.doCreateHandler,
   doReadHandler: self.doReadHandler,
@@ -591,6 +607,7 @@ module.exports = {
   doCollisionLister: self.doCollisionLister,
   doCollisionRemover: self.doCollisionRemover,
   doRequestInterceptor: self.doRequestInterceptor,
+  doResponseInterceptor: self.doResponseInterceptor,
   stopDatasetSync: self.stopDatasetSync,
   stopAllDatasetSync: self.stopAllDatasetSync,
   getDataset: self.getDataset,

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -426,7 +426,6 @@ function returnUpdates(dataset_id, params, resIn, cb) {
         return cb(null, resIn);
       }
     });
-    
   });
 }
 

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -57,7 +57,8 @@ var sync = function () {
       handleCollision: 'collisionHandler',
       listCollisions: 'collisionLister',
       removeCollision: 'collisionRemover',
-      interceptRequest: 'requestInterceptor'
+      interceptRequest: 'requestInterceptor',
+      interceptResponse: 'responseInterceptor'
     };
 
     Object.keys(handlerMap).forEach(function (key) {
@@ -91,7 +92,8 @@ var sync = function () {
     globalHandleCollision: DataSetModel.setGlobalCollisionHandler.bind(null),
     globalListCollisions: DataSetModel.setGlobalCollisionLister.bind(null),
     globalRemoveCollision: DataSetModel.setGlobalCollisionRemover.bind(null),
-    globalInterceptRequest: DataSetModel.setGlobalRequestInterceptor.bind(null)
+    globalInterceptRequest: DataSetModel.setGlobalRequestInterceptor.bind(null),
+    globalInterceptResponse: DataSetModel.setGlobalResponseInterceptor.bind(null)
   };
 
   // Make sure to bind custom handler setters
@@ -415,7 +417,16 @@ function returnUpdates(dataset_id, params, resIn, cb) {
     if (res.list.length > 0) {
       syncUtil.doLog(dataset_id, 'verbose', 'returnUpdates :: ' + util.inspect(updates.hashes), params);
     }
-    return cb(null, resIn);
+
+    DataSetModel.doResponseInterceptor(dataset_id, params, function (err) {
+      if (err) {
+        return cb(err, null);
+      }
+      else {
+        return cb(null, resIn);
+      }
+    });
+    
   });
 }
 

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -418,7 +418,7 @@ function returnUpdates(dataset_id, params, resIn, cb) {
       syncUtil.doLog(dataset_id, 'verbose', 'returnUpdates :: ' + util.inspect(updates.hashes), params);
     }
 
-    DataSetModel.doResponseInterceptor(dataset_id, params, function (err) {
+    DataSetModel.doResponseInterceptor(dataset_id, params.query_params, function (err) {
       if (err) {
         return cb(err, null);
       }

--- a/test/fixtures/syncHandler.js
+++ b/test/fixtures/syncHandler.js
@@ -36,4 +36,9 @@ exports.doCollision = function(dataset_id, hash, uid, pre, post) {
 
 exports.removeCollision = function(dataset_id, hash, cb) {
   return cb(null, {});
+};
+
+exports.doResponseInterceptor = function(dataset_id, params, cb) {
+  console.log("doResponseInterceptor : ", dataset_id, " :: ", params);
+  return cb(null, {});
 }

--- a/test/test_sync.js
+++ b/test/test_sync.js
@@ -31,6 +31,7 @@ module.exports = {
       $fh.sync.handleCollision(dataset_id, dataHandler.doCollision);
       $fh.sync.listCollisions(dataset_id, dataHandler.listCollisions);
       $fh.sync.removeCollision(dataset_id, dataHandler.removeCollision);
+      $fh.sync.interceptResponse(dataset_id, dataHandler.doResponseInterceptor);
       finish();
     });
   },

--- a/test/test_sync_datasetmodel.js
+++ b/test/test_sync_datasetmodel.js
@@ -12,7 +12,8 @@ var map = {
   'setGlobalCollisionHandler': 'globalCollisionHandler',
   'setGlobalCollisionLister': 'globalCollisionLister',
   'setGlobalCollisionRemover': 'globalCollisionRemover',
-  'setGlobalRequestInterceptor': 'globalRequestInterceptor'
+  'setGlobalRequestInterceptor': 'globalRequestInterceptor',
+  'setGlobalResponseInterceptor': 'globalResponseInterceptor'
 };
 
 var tests = {

--- a/test/test_sync_handlers.js
+++ b/test/test_sync_handlers.js
@@ -42,7 +42,8 @@ module.exports = {
       setGlobalCollisionHandler: sinon.spy(),
       setGlobalCollisionLister: sinon.spy(),
       setGlobalCollisionRemover: sinon.spy(),
-      setGlobalRequestInterceptor: sinon.spy()
+      setGlobalRequestInterceptor: sinon.spy(),
+      setGlobalResponseInterceptor: sinon.spy()
     };
 
     // Creates a new sync instance


### PR DESCRIPTION
Implementing response interceptor to allow custom handlers to be called once the sync cycle completes.
I've tested this by creating some records in a dataset while offline.  When I went back online I could see the create handler firing on the cloud for each new record created and then the response interceptor firing a single time once all db operations are completed.  This is the expected functionality.