### PR TITLE
FH-3023 Add asyncGenerateHash function

### DIFF
--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -317,12 +317,13 @@ var self = {
 
       self.asyncGetClientHash(query_params, meta_data, function(err, clientHash) {
         var datasetClient = dataset.clients[clientHash];
+        var currentTime = new Date().getTime();
         if (!datasetClient) {
           datasetClient = {
             id: clientHash,
             datasetId: dataset_id,
-            created: new Date().getTime(),
-            lastAccessed: new Date().getTime(),
+            created: currentTime,
+            lastAccessed: currentTime,
             queryParams: query_params,
             metaData: meta_data,
             syncRunning: false,
@@ -635,6 +636,7 @@ module.exports = {
   removeDatasetClient: self.removeDatasetClient,
   syncDatasetClient: self.syncDatasetClient,
   getClientHash: self.getClientHash,
+  asyncGetClientHash: self.asyncGetClientHash,
   toJSON: self.toJSON,
   setFHDB: self.setFHDB,
   init: init

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -259,22 +259,28 @@ var self = {
 
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return err;
-      var clientHash = self.getClientHash(query_params, meta_data);
-      var datasetClient = dataset.clients[clientHash];
-      if (!datasetClient) {
-        self.createDatasetClient(dataset_id, query_params, meta_data, function (err, dsc) {
-          if (err) return cb(err);
-          recordAccessInfo(dsc, params);
-          return cb(null, dsc);
-        });
-      }
-      else {
-        recordAccessInfo(datasetClient, params);
-        return cb(null, datasetClient);
-      }
+      //var clientHash = self.getClientHash(query_params, meta_data);
+      //console.log('clientHash - Sync Result : ' + clientHash);
+
+      self.asyncGetClientHash(query_params, meta_data, function(err, clientHash) {
+        console.log('clientHash - Async Result : ' + clientHash);
+        var datasetClient = dataset.clients[clientHash];
+        if (!datasetClient) {
+          self.createDatasetClient(dataset_id, query_params, meta_data, function (err, dsc) {
+            if (err) return cb(err);
+            recordAccessInfo(dsc, params);
+            return cb(null, dsc);
+          });
+        }
+        else {
+          recordAccessInfo(datasetClient, params);
+          return cb(null, datasetClient);
+        }
+      });
     });
 
     function recordAccessInfo(datasetClient, params) {
+      console.log('recordAccessInfo', params);
       datasetClient.lastAccessed = new Date().getTime();
       datasetClient.syncActive = true;
 
@@ -310,26 +316,31 @@ var self = {
   createDatasetClient: function (dataset_id, query_params, meta_data, cb) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return err;
-      var clientHash = dataset_id + "_" + self.getClientHash(query_params, meta_data);
-      var datasetClient = dataset.clients[clientHash];
-      if (!datasetClient) {
-        datasetClient = {
-          id: clientHash,
-          datasetId: dataset_id,
-          created: new Date().getTime(),
-          lastAccessed: new Date().getTime(),
-          queryParams: query_params,
-          metaData: meta_data,
-          syncRunning: false,
-          syncPending: true,
-          syncActive: true,
-          pendingCallbacks: [],
-          instances: {}
-        };
-        dataset.clients[clientHash] = datasetClient;
-      }
-      syncUtil.doLog(dataset_id, 'verbose', 'createDatasetClient :: ' + util.inspect(datasetClient));
-      return cb(null, datasetClient);
+      //var clientHash = dataset_id + "_" + self.getClientHash(query_params, meta_data);
+      //console.log('getDataset callback - Sync : ' + clientHash);
+
+      self.asyncGetClientHash(query_params, meta_data, function(err, clientHash) {
+        console.log('getDataset callback - Async : ' + dataset_id + '_' + clientHash);
+        var datasetClient = dataset.clients[clientHash];
+        if (!datasetClient) {
+          datasetClient = {
+            id: clientHash,
+            datasetId: dataset_id,
+            created: new Date().getTime(),
+            lastAccessed: new Date().getTime(),
+            queryParams: query_params,
+            metaData: meta_data,
+            syncRunning: false,
+            syncPending: true,
+            syncActive: true,
+            pendingCallbacks: [],
+            instances: {}
+          };
+          dataset.clients[clientHash] = datasetClient;
+        }
+        syncUtil.doLog(dataset_id, 'verbose', 'createDatasetClient :: ' + util.inspect(datasetClient));
+        return cb(null, datasetClient);
+      });
     });
   },
 
@@ -347,6 +358,14 @@ var self = {
       cb(err, res);
     });
     syncUtil.doLog(datasetClient.datasetId, 'silly', 'Now there are ' + datasetClient.pendingCallbacks.length + ' calbacks for datasetclient id =' + datasetClient.id, datasetClient);
+  },
+
+  asyncGetClientHash: function(queryParams, metaData, cb) {
+    return syncUtil.asyncGenerateHash(queryParams, function(err, queryParamsHash) {
+      return syncUtil.asyncGenerateHash(metaData, function(err, metaDataHash) {
+        return cb(null, queryParamsHash + '-' + metaDataHash);
+      });
+    });
   },
 
   getClientHash: function (query_params, meta_data) {
@@ -371,7 +390,8 @@ var self = {
 
       var hashes = [];
       var recOut = {};
-      for (var i in records) {
+      /*for (var i in records) {
+        console.log('sync i ' + i);
         var rec = {};
         var recData = records[i];
         var hash = syncUtil.generateHash(recData);
@@ -380,24 +400,53 @@ var self = {
         rec.hash = hash;
         recOut[i] = rec;
       }
-      var globalHash = syncUtil.generateHash(hashes);
 
-      var previousHash = datasetClient.dataHash ? datasetClient.dataHash : '<undefined>';
-      syncUtil.doLog(dataset.id, 'verbose', 'doSyncList cb ' + ( cb !== undefined) + ' - Global Hash (prev :: cur) = ' + previousHash + ' ::  ' + globalHash);
+      console.log('doListHandler recOut - sync : ' + syncUtil.generateHash(recOut));
+      console.log('doListHandler hashes - sync : ' + syncUtil.generateHash(hashes));*/
 
-      datasetClient.dataHash = globalHash;
-      self.datasetClientRecords[datasetClient.id] = recOut;
+      // Start: Aiden Keating - Super amazing work v2
 
-      var res = {
-        hash: globalHash,
-        records: recOut
-      };
+      async.forEachSeries(Object.keys(records), function(recordId, itemCallback){
+        var record = records[recordId];
+        syncUtil.asyncGenerateHash(record, function(err, recordHash) {
+          var rec = {
+            data: record,
+            hash: recordHash
+          };
+          hashes.push(recordHash);
+          recOut[recordId] = rec;
+          itemCallback();
+        });
+      }, function(err) {
+        if (err) return cb(err);
+        // console.log('doListHandler recOut - async : ' + syncUtil.generateHash(recOut));
+        // console.log('doListHandler hashes - async : ' + syncUtil.generateHash(hashes));
 
-      datasetClient.syncRunning = false;
-      datasetClient.syncLoopEnd = new Date().getTime();
-      if (cb) {
-        cb(null, res);
-      }
+        syncUtil.asyncGenerateHash(hashes, function(err, globalHash) {
+          console.log('doListHandler callback - Async : ' + globalHash);
+          var previousHash = datasetClient.dataHash ? datasetClient.dataHash : '<undefined>';
+          syncUtil.doLog(dataset.id, 'verbose', 'doSyncList cb ' + ( cb !== undefined) + ' - Global Hash (prev :: cur) = ' + previousHash + ' ::  ' + globalHash);
+
+          datasetClient.dataHash = globalHash;
+          self.datasetClientRecords[datasetClient.id] = recOut;
+
+          var res = {
+            hash: globalHash,
+            records: recOut
+          };
+
+          datasetClient.syncRunning = false;
+          datasetClient.syncLoopEnd = new Date().getTime();
+          if (cb) {
+            cb(null, res);
+          }
+        });
+      })
+
+      // End:  Aiden Keating - Super amazing work v2
+
+      //var globalHash = syncUtil.generateHash(hashes);
+      //console.log('doListHandler callback - Sync : ' + globalHash);
     }, datasetClient.metaData);
   },
 
@@ -407,7 +456,7 @@ var self = {
       if (err) return cb(err);
 
 
-      var hashes = [];
+      /*var hashes = [];
       var recOut = {};
       for (var i in records) {
         var rec = {};
@@ -418,13 +467,48 @@ var self = {
         rec.hash = hash;
         recOut[i] = rec;
       }
-      var globalHash = syncUtil.generateHash(hashes);
 
-      var res = {
-        hash: globalHash,
-        records: recOut
-      };
-      return cb(null, res);
+      if (hashes.length > 0) {
+        console.log('forceSyncList - sync hashes : ' + syncUtil.generateHash(hashes));
+        console.log('forceSyncList - sync recOut : ' + syncUtil.generateHash(recOut));
+      }*/
+
+      // Start: Aiden Keating Hyper Dragon Work v4.8
+
+      var recOut = {};
+      var hashes = [];
+
+      async.forEachSeries(Object.keys(records), function(recordId, itemCallback) {
+        var record = records[recordId];
+        syncUtil.asyncGenerateHash(record, function(err, recordHash) {
+          var rec = {
+            data: record,
+            hash: recordHash
+          };
+          hashes.push(recordHash);
+          recOut[recordId] = rec;
+          itemCallback();
+        });
+      }, function(err) {
+        if (err) return cb(err);
+
+        return syncUtil.asyncGenerateHash(hashes, function(err, globalHash) {
+          var res = {
+            hash: globalHash,
+            records: recOut
+          };
+          console.log('Async result: ' + JSON.stringify(res));
+          return cb(null, res);
+        });
+      })
+      // End: Aiden Keating Hyper Dragon Work 4.8
+
+      //var globalHash = syncUtil.generateHash(hashes);
+      //var res = {
+      //  hash: globalHash,
+      //  records: recOut
+      //};
+      //console.log('Sync result: ' + JSON.stringify(res));
     }, datasetClient.metaData);
   },
 

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -638,4 +638,4 @@ module.exports = {
   toJSON: self.toJSON,
   setFHDB: self.setFHDB,
   init: init
-}
+};

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -259,11 +259,8 @@ var self = {
 
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return err;
-      //var clientHash = self.getClientHash(query_params, meta_data);
-      //console.log('clientHash - Sync Result : ' + clientHash);
 
       self.asyncGetClientHash(query_params, meta_data, function(err, clientHash) {
-        console.log('clientHash - Async Result : ' + clientHash);
         var datasetClient = dataset.clients[clientHash];
         if (!datasetClient) {
           self.createDatasetClient(dataset_id, query_params, meta_data, function (err, dsc) {
@@ -280,7 +277,6 @@ var self = {
     });
 
     function recordAccessInfo(datasetClient, params) {
-      console.log('recordAccessInfo', params);
       datasetClient.lastAccessed = new Date().getTime();
       datasetClient.syncActive = true;
 
@@ -315,12 +311,11 @@ var self = {
 
   createDatasetClient: function (dataset_id, query_params, meta_data, cb) {
     self.getDataset(dataset_id, function (err, dataset) {
-      if (err) return err;
-      //var clientHash = dataset_id + "_" + self.getClientHash(query_params, meta_data);
-      //console.log('getDataset callback - Sync : ' + clientHash);
+      if (err) {
+        return err;
+      }
 
       self.asyncGetClientHash(query_params, meta_data, function(err, clientHash) {
-        console.log('getDataset callback - Async : ' + dataset_id + '_' + clientHash);
         var datasetClient = dataset.clients[clientHash];
         if (!datasetClient) {
           datasetClient = {
@@ -390,21 +385,6 @@ var self = {
 
       var hashes = [];
       var recOut = {};
-      /*for (var i in records) {
-        console.log('sync i ' + i);
-        var rec = {};
-        var recData = records[i];
-        var hash = syncUtil.generateHash(recData);
-        hashes.push(hash);
-        rec.data = recData;
-        rec.hash = hash;
-        recOut[i] = rec;
-      }
-
-      console.log('doListHandler recOut - sync : ' + syncUtil.generateHash(recOut));
-      console.log('doListHandler hashes - sync : ' + syncUtil.generateHash(hashes));*/
-
-      // Start: Aiden Keating - Super amazing work v2
 
       async.forEachSeries(Object.keys(records), function(recordId, itemCallback){
         var record = records[recordId];
@@ -419,11 +399,8 @@ var self = {
         });
       }, function(err) {
         if (err) return cb(err);
-        // console.log('doListHandler recOut - async : ' + syncUtil.generateHash(recOut));
-        // console.log('doListHandler hashes - async : ' + syncUtil.generateHash(hashes));
 
         syncUtil.asyncGenerateHash(hashes, function(err, globalHash) {
-          console.log('doListHandler callback - Async : ' + globalHash);
           var previousHash = datasetClient.dataHash ? datasetClient.dataHash : '<undefined>';
           syncUtil.doLog(dataset.id, 'verbose', 'doSyncList cb ' + ( cb !== undefined) + ' - Global Hash (prev :: cur) = ' + previousHash + ' ::  ' + globalHash);
 
@@ -441,39 +418,17 @@ var self = {
             cb(null, res);
           }
         });
-      })
+      });
 
-      // End:  Aiden Keating - Super amazing work v2
-
-      //var globalHash = syncUtil.generateHash(hashes);
-      //console.log('doListHandler callback - Sync : ' + globalHash);
     }, datasetClient.metaData);
   },
 
   forceSyncList: function (dataset_id, datasetClient, cb) {
 
     self.doListHandler(dataset_id, datasetClient.queryParams, function (err, records) {
-      if (err) return cb(err);
-
-
-      /*var hashes = [];
-      var recOut = {};
-      for (var i in records) {
-        var rec = {};
-        var recData = records[i];
-        var hash = syncUtil.generateHash(recData);
-        hashes.push(hash);
-        rec.data = recData;
-        rec.hash = hash;
-        recOut[i] = rec;
+      if (err) {
+        return cb(err);
       }
-
-      if (hashes.length > 0) {
-        console.log('forceSyncList - sync hashes : ' + syncUtil.generateHash(hashes));
-        console.log('forceSyncList - sync recOut : ' + syncUtil.generateHash(recOut));
-      }*/
-
-      // Start: Aiden Keating Hyper Dragon Work v4.8
 
       var recOut = {};
       var hashes = [];
@@ -490,25 +445,19 @@ var self = {
           itemCallback();
         });
       }, function(err) {
-        if (err) return cb(err);
+        if (err) {
+          return cb(err);
+        }
 
         return syncUtil.asyncGenerateHash(hashes, function(err, globalHash) {
           var res = {
             hash: globalHash,
             records: recOut
           };
-          console.log('Async result: ' + JSON.stringify(res));
           return cb(null, res);
         });
       })
-      // End: Aiden Keating Hyper Dragon Work 4.8
 
-      //var globalHash = syncUtil.generateHash(hashes);
-      //var res = {
-      //  hash: globalHash,
-      //  records: recOut
-      //};
-      //console.log('Sync result: ' + JSON.stringify(res));
     }, datasetClient.metaData);
   },
 

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -297,16 +297,8 @@ function processPending(dataset_id, dataset, params, cb) {
           syncUtil.doLog(dataset_id, 'verbose', ' READ for UPDATE Success', params);
           syncUtil.doLog(dataset_id, 'silly', 'READ for UPDATE Data : \n' + util.inspect(data), params);
 
-          //var preHash = syncUtil.generateHash(pre);
-          //var dataHash = syncUtil.generateHash(data);
-
-          //console.log('update action - sync : ' + preHash);
-          //console.log('update action - sync : ' + dataHash);
-
           syncUtil.asyncGenerateHash(pre, function(err, preHash) {
             syncUtil.asyncGenerateHash(data, function(err, dataHash) {
-              console.log('update action - async : ' + preHash);
-              console.log('update action - async : ' + dataHash);
 
               syncUtil.doLog(dataset_id, 'verbose', 'UPDATE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
 
@@ -320,9 +312,6 @@ function processPending(dataset_id, dataset, params, cb) {
                   return addUpdate("applied", "update", hash, uid, '', itemCallback);
                 }, meta_data);
               } else {
-                //var postHash = syncUtil.generateHash(post);
-                //console.log('update action postHash - sync : ' + postHash);
-
                 syncUtil.asyncGenerateHash(post, function(err, postHash) {
                   if (postHash === dataHash) {
                     // Update has already been applied
@@ -350,16 +339,8 @@ function processPending(dataset_id, dataset, params, cb) {
           syncUtil.doLog(dataset_id, 'verbose', ' READ for DELETE Success', params);
           syncUtil.doLog(dataset_id, 'silly', ' READ for DELETE Data : \n' + util.inspect(data), params);
 
-          //var preHash = syncUtil.generateHash(pre);
-          //var dataHash = syncUtil.generateHash(data);
-
-          //console.log('delete action - sync : ' + preHash);
-          //console.log('delete action - sync : ' + dataHash);
-
           syncUtil.asyncGenerateHash(pre, function(err, preHash) {
             syncUtil.asyncGenerateHash(data, function(err, dataHash) {
-              console.log('delete action - async : ' + preHash);
-              console.log('delete action - async : ' + dataHash);
               syncUtil.doLog(dataset_id, 'verbose', 'DELETE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
 
               if (!dataHash) {

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -297,33 +297,47 @@ function processPending(dataset_id, dataset, params, cb) {
           syncUtil.doLog(dataset_id, 'verbose', ' READ for UPDATE Success', params);
           syncUtil.doLog(dataset_id, 'silly', 'READ for UPDATE Data : \n' + util.inspect(data), params);
 
-          var preHash = syncUtil.generateHash(pre);
-          var dataHash = syncUtil.generateHash(data);
+          //var preHash = syncUtil.generateHash(pre);
+          //var dataHash = syncUtil.generateHash(data);
 
-          syncUtil.doLog(dataset_id, 'verbose', 'UPDATE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
+          //console.log('update action - sync : ' + preHash);
+          //console.log('update action - sync : ' + dataHash);
 
-          if (preHash === dataHash) {
-            DataSetModel.doUpdateHandler(dataset_id, uid, post, function (err) {
-              if (err) {
-                syncUtil.doLog(dataset_id, 'warn', 'UPDATE Failed - uid=' + uid + ' : err = ' + err, params);
-                return addUpdate("failed", "update", hash, uid, err, itemCallback);
+          syncUtil.asyncGenerateHash(pre, function(err, preHash) {
+            syncUtil.asyncGenerateHash(data, function(err, dataHash) {
+              console.log('update action - async : ' + preHash);
+              console.log('update action - async : ' + dataHash);
+
+              syncUtil.doLog(dataset_id, 'verbose', 'UPDATE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
+
+              if (preHash === dataHash) {
+                DataSetModel.doUpdateHandler(dataset_id, uid, post, function (err) {
+                  if (err) {
+                    syncUtil.doLog(dataset_id, 'warn', 'UPDATE Failed - uid=' + uid + ' : err = ' + err, params);
+                    return addUpdate("failed", "update", hash, uid, err, itemCallback);
+                  }
+                  syncUtil.doLog(dataset_id, 'info', 'UPDATE Success - uid=' + uid + ' : hash = ' + hash, params);
+                  return addUpdate("applied", "update", hash, uid, '', itemCallback);
+                }, meta_data);
+              } else {
+                //var postHash = syncUtil.generateHash(post);
+                //console.log('update action postHash - sync : ' + postHash);
+
+                syncUtil.asyncGenerateHash(post, function(err, postHash) {
+                  if (postHash === dataHash) {
+                    // Update has already been applied
+                    syncUtil.doLog(dataset_id, 'info', 'UPDATE Already Applied - uid=' + uid + ' : hash = ' + hash, params);
+                    return addUpdate("applied", "update", hash, uid, '', itemCallback);
+                  }
+                  else {
+                    syncUtil.doLog(dataset_id, 'warn', 'UPDATE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)), params);
+                    DataSetModel.doCollisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
+                    return addUpdate("collisions", "update", hash, uid, '', itemCallback);
+                  }
+                });
               }
-              syncUtil.doLog(dataset_id, 'info', 'UPDATE Success - uid=' + uid + ' : hash = ' + hash, params);
-              return addUpdate("applied", "update", hash, uid, '', itemCallback);
-            }, meta_data);
-          } else {
-            var postHash = syncUtil.generateHash(post);
-            if (postHash === dataHash) {
-              // Update has already been applied
-              syncUtil.doLog(dataset_id, 'info', 'UPDATE Already Applied - uid=' + uid + ' : hash = ' + hash, params);
-              return addUpdate("applied", "update", hash, uid, '', itemCallback);
-            }
-            else {
-              syncUtil.doLog(dataset_id, 'warn', 'UPDATE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)), params);
-              DataSetModel.doCollisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
-              return addUpdate("collisions", "update", hash, uid, '', itemCallback);
-            }
-          }
+            });
+          });
         }, meta_data);
       }
       else if ("delete" === action) {
@@ -336,32 +350,41 @@ function processPending(dataset_id, dataset, params, cb) {
           syncUtil.doLog(dataset_id, 'verbose', ' READ for DELETE Success', params);
           syncUtil.doLog(dataset_id, 'silly', ' READ for DELETE Data : \n' + util.inspect(data), params);
 
-          var preHash = syncUtil.generateHash(pre);
-          var dataHash = syncUtil.generateHash(data);
+          //var preHash = syncUtil.generateHash(pre);
+          //var dataHash = syncUtil.generateHash(data);
 
-          syncUtil.doLog(dataset_id, 'verbose', 'DELETE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
+          //console.log('delete action - sync : ' + preHash);
+          //console.log('delete action - sync : ' + dataHash);
 
-          if (!dataHash) {
-            //record has already been deleted
-            syncUtil.doLog(dataset_id, 'info', 'DELETE Already performed - uid=' + uid + ' : hash = ' + hash, params);
-            return addUpdate("applied", "delete", hash, uid, '', itemCallback);
-          }
-          else {
-            if (preHash === dataHash) {
-              DataSetModel.doDeleteHandler(dataset_id, uid, function (err) {
-                if (err) {
-                  syncUtil.doLog(dataset_id, 'warn', 'DELETE Failed - uid=' + uid + ' : err = ' + err, params);
-                  return addUpdate("failed", "delete", hash, uid, err, itemCallback);
-                }
-                syncUtil.doLog(dataset_id, 'info', 'DELETE Success - uid=' + uid + ' : hash = ' + hash, params);
+          syncUtil.asyncGenerateHash(pre, function(err, preHash) {
+            syncUtil.asyncGenerateHash(data, function(err, dataHash) {
+              console.log('delete action - async : ' + preHash);
+              console.log('delete action - async : ' + dataHash);
+              syncUtil.doLog(dataset_id, 'verbose', 'DELETE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
+
+              if (!dataHash) {
+                //record has already been deleted
+                syncUtil.doLog(dataset_id, 'info', 'DELETE Already performed - uid=' + uid + ' : hash = ' + hash, params);
                 return addUpdate("applied", "delete", hash, uid, '', itemCallback);
-              }, meta_data);
-            } else {
-              syncUtil.doLog(dataset_id, 'warn', 'DELETE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)), params);
-              DataSetModel.doCollisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
-              return addUpdate("collisions", "delete", hash, uid, '', itemCallback);
-            }
-          }
+              }
+              else {
+                if (preHash === dataHash) {
+                  DataSetModel.doDeleteHandler(dataset_id, uid, function (err) {
+                    if (err) {
+                      syncUtil.doLog(dataset_id, 'warn', 'DELETE Failed - uid=' + uid + ' : err = ' + err, params);
+                      return addUpdate("failed", "delete", hash, uid, err, itemCallback);
+                    }
+                    syncUtil.doLog(dataset_id, 'info', 'DELETE Success - uid=' + uid + ' : hash = ' + hash, params);
+                    return addUpdate("applied", "delete", hash, uid, '', itemCallback);
+                  }, meta_data);
+                } else {
+                  syncUtil.doLog(dataset_id, 'warn', 'DELETE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)), params);
+                  DataSetModel.doCollisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
+                  return addUpdate("collisions", "delete", hash, uid, '', itemCallback);
+                }
+              }
+            });
+          });
         }, meta_data);
       }
       else {

--- a/lib/sync-util.js
+++ b/lib/sync-util.js
@@ -12,8 +12,7 @@ var asyncGenerateHash = function(plainText, cb) {
     return asyncSortedStringify(plainText, function(err, hash) {
       var shasum = crypto.createHash('sha1');
       shasum.update(hash);
-      hash = shasum.digest('hex');
-      return cb(null, hash);
+      return cb(null, shasum.digest('hex'));
     });
   } else {
     return cb(null, undefined);

--- a/lib/sync-util.js
+++ b/lib/sync-util.js
@@ -9,9 +9,7 @@ var loggers = {};
 
 var asyncGenerateHash = function(plainText, cb) {
   if(plainText) {
-    console.log('generateHash - async mode');
     return asyncSortedStringify(plainText, function(err, hash) {
-      console.log('generateHash response - ' + hash);
       var shasum = crypto.createHash('sha1');
       shasum.update(hash);
       hash = shasum.digest('hex');
@@ -53,12 +51,8 @@ var sortObject = function (object) {
 }
 
 var asyncSortedStringify = function (obj, cb) {
-  console.log('asyncSortedStringify');
-  console.log(typeof obj);
-  console.log(obj);
   if(obj) {
     return asyncJson.stringify(sortObject(obj), function stringifyComplete(err, jsonString) {
-      //console.log('asyncStringify')
       return cb(err, jsonString);
     });
   } else {

--- a/lib/sync-util.js
+++ b/lib/sync-util.js
@@ -1,10 +1,26 @@
 var crypto = require('crypto');
 var winston = require('winston');
+var asyncJson = require('async-json');
 var moment = require('moment');
 var assert = require('assert');
 
 var SYNC_LOGGER = 'SYNC';
 var loggers = {};
+
+var asyncGenerateHash = function(plainText, cb) {
+  if(plainText) {
+    console.log('generateHash - async mode');
+    return asyncSortedStringify(plainText, function(err, hash) {
+      console.log('generateHash response - ' + hash);
+      var shasum = crypto.createHash('sha1');
+      shasum.update(hash);
+      hash = shasum.digest('hex');
+      return cb(null, hash);
+    });
+  } else {
+    return cb(null, undefined);
+  }
+}
 
 var generateHash = function (plainText) {
   var hash;
@@ -36,6 +52,19 @@ var sortObject = function (object) {
   return result;
 }
 
+var asyncSortedStringify = function (obj, cb) {
+  console.log('asyncSortedStringify');
+  console.log(typeof obj);
+  console.log(obj);
+  if(obj) {
+    return asyncJson.stringify(sortObject(obj), function stringifyComplete(err, jsonString) {
+      //console.log('asyncStringify')
+      return cb(err, jsonString);
+    });
+  } else {
+    return cb(null, '');
+  }
+}
 
 var sortedStringify = function (obj) {
   var str = '';
@@ -91,6 +120,7 @@ exports.ensureHandlerIsFunction = function (target, fn) {
 };
 
 module.exports.generateHash = generateHash;
+module.exports.asyncGenerateHash = asyncGenerateHash;
 module.exports.sortObject = sortObject;
 module.exports.sortedStringify = sortedStringify;
 module.exports.setLogger = setLogger;

--- a/lib/sync-util.js
+++ b/lib/sync-util.js
@@ -18,7 +18,7 @@ var asyncGenerateHash = function(plainText, cb) {
   } else {
     return cb(null, undefined);
   }
-}
+};
 
 var generateHash = function (plainText) {
   var hash;
@@ -31,7 +31,7 @@ var generateHash = function (plainText) {
     hash = shasum.digest('hex');
   }
   return hash;
-}
+};
 
 var sortObject = function (object) {
   if (typeof object !== "object" || object === null) {
@@ -48,7 +48,7 @@ var sortObject = function (object) {
   });
 
   return result;
-}
+};
 
 var asyncSortedStringify = function (obj, cb) {
   if(obj) {
@@ -58,7 +58,7 @@ var asyncSortedStringify = function (obj, cb) {
   } else {
     return cb(null, '');
   }
-}
+};
 
 var sortedStringify = function (obj) {
   var str = '';
@@ -72,7 +72,7 @@ var sortedStringify = function (obj) {
   }
 
   return str;
-}
+};
 
 var setLogger = function (dataset_id, options) {
   var level = options.logLevel;
@@ -83,7 +83,15 @@ var setLogger = function (dataset_id, options) {
   });
 
   loggers[dataset_id] = logger;
-}
+};
+
+var getCuid = function (params) {
+  var cuid = '';
+  if (params && params.__fh && params.__fh.cuid) {
+    cuid = params.__fh.cuid;
+  }
+  return cuid;
+};
 
 var doLog = function (dataset_id, level, msg, params) {
 
@@ -95,15 +103,7 @@ var doLog = function (dataset_id, level, msg, params) {
 
     logger.log(level, logMsg);
   }
-}
-
-var getCuid = function (params) {
-  var cuid = '';
-  if (params && params.__fh && params.__fh.cuid) {
-    cuid = params.__fh.cuid;
-  }
-  return cuid;
-}
+};
 
 exports.ensureHandlerIsFunction = function (target, fn) {
   assert.equal(

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "async@0.2.9",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
     },
+    "async-json": {
+      "version": "0.0.2",
+      "from": "async-json@0.0.2",
+      "resolved": "https://registry.npmjs.org/async-json/-/async-json-0.0.2.tgz"
+    },
     "colors": {
       "version": "0.6.2",
       "from": "colors@0.6.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/api.js",
   "dependencies": {
     "async": "0.2.9",
+    "async-json": "0.0.2",
     "colors": "0.6.2",
     "cycle": "1.0.3",
     "eyes": "0.1.8",

--- a/test/test_sync_datasetmodel.js
+++ b/test/test_sync_datasetmodel.js
@@ -33,6 +33,26 @@ var tests = {
       expect(customInterceptor.called).to.be.true;
       done();
     });
+  },
+
+  '#ensureAsyncGetClientHashIsCorrect': {
+    'should have identical async and sync `get client hash` functions': function(done) {
+      
+      var testQueryParams = {
+        testKey: "testQueryParams"
+      };
+
+      var testMetaData = {
+        testKey: "testMetaData"
+      };
+
+      mod.asyncGetClientHash(testQueryParams, testMetaData, function(err, asyncClientHash) {
+        var syncClientHash = mod.getClientHash(testQueryParams, testMetaData);
+        
+        expect(asyncClientHash).to.equal(syncClientHash);
+        done();
+      });
+    }
   }
 };
 

--- a/test/test_sync_utils.js
+++ b/test/test_sync_utils.js
@@ -24,5 +24,21 @@ module.exports = {
         mod.ensureHandlerIsFunction('listHandler', sinon.spy());
       }).to.not.throw();
     }
+  },
+
+  '#ensureAsyncGenerateHashIsCorrect': {
+    'should generate identical hash to sync version': function (done) {
+      // Simple object to produce hash from
+      var testObject = {
+        testKey: 'testValue'
+      };
+
+      mod.asyncGenerateHash(testObject, function(err, asyncHash) {
+        var syncHash = mod.generateHash(testObject);
+
+        expect(asyncHash).to.equal(syncHash);
+        done();
+      });
+    }
   }
 };


### PR DESCRIPTION
Currently a large majority of the `JSON.stringify` commands are
made from `generateHash`. In performance analysis of the sync
framework this was found to be an issue.

This adds an `asyncGenerateHash` function and an `asyncGetClientHash`
function to the MBaaS API to allow for these calls to be made
asynchronously.

This also implements these calls internally in the API.