### PR TITLE
WIP FH-3065 Add mongodb impl for the Updates model for sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode/
 lib-cov/
 .project
 .settings/

--- a/lib/sync-UpdatesModel.js
+++ b/lib/sync-UpdatesModel.js
@@ -1,0 +1,86 @@
+var syncUtil = require('./sync-util');
+var fhdb;
+
+var init = function () {
+  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'verbose', 'UpdatesModel Init');
+};
+
+var setFHDB = function(db) {
+  fhdb = db;
+};
+
+var create = function(dataset_id, data, cb) {
+  // Check if the Update has already been recorded, then create it if it doesn't
+  fhdb({
+    "act": "list",
+    "type": dataset_id + "-updates",
+    "eq": {
+      "cuid": data.cuid,
+      "type": data.type,
+      "action": data.action,
+      "hash": data.hash,
+      "uid": data.uid
+    }
+  }, function (err, found) {
+    if (err) return cb(err);
+    if (found && found.list && found.list.length > 0) {
+      syncUtil.doLog(dataset_id, 'info', 'Update is already recorded, ignore', data);
+      return cb(null, found.list[0]);
+    } else {
+      fhdb({
+        "act": "create",
+        "type": dataset_id + "-updates",
+        "fields": data
+      }, function (err, res) {
+        cb(err, res);
+      });
+    }
+  });
+};
+
+var list = function(dataset_id, eq, cb) {
+  fhdb({
+    "act": "list",
+    "type": dataset_id + "-updates",
+    "eq": eq
+  }, cb);
+};
+
+var remove = function(dataset_id, data, cb) {
+  // Check if the record already exists, then remove it if it does
+  fhdb({
+    "act": "list",
+    "type": dataset_id + "-updates",
+    "eq": {
+      "cuid": data.cuid,
+      "hash": data.hash
+    }
+  }, function (err, res) {
+    if (err) return cb(err, data);
+
+    if (res && res.list && res.list.length > 0) {
+      var rec = res.list[0];
+      var uid = rec.guid;
+      fhdb({
+        "act": "delete",
+        "type": dataset_id + "-updates",
+        "guid": uid
+      }, function (err) {
+        if (err) return cb(err, data);
+
+        return cb(null, data);
+      });
+    }
+    else {
+      return cb(null, data);
+    }
+  });
+};
+
+module.exports = {
+  create: create,
+  list: list,
+  remove: remove,
+  setFHDB: setFHDB,
+  init: init
+}

--- a/lib/sync-UpdatesModel_fhdb.js
+++ b/lib/sync-UpdatesModel_fhdb.js
@@ -1,10 +1,6 @@
 var syncUtil = require('./sync-util');
 var fhdb;
 
-var init = function () {
-  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'verbose', 'UpdatesModel Init');
-};
-
 var setFHDB = function(db) {
   fhdb = db;
 };
@@ -43,7 +39,17 @@ var list = function(dataset_id, eq, cb) {
     "act": "list",
     "type": dataset_id + "-updates",
     "eq": eq
-  }, cb);
+  }, function(err, records) {
+    if (err) return cb(err);
+    var res = [];
+    if (records.list && records.list.length) {
+      records.list.forEach(function(record){
+        record.fields._id = record.guid;
+        res.push(record.fields);
+      });
+    }
+    return cb(null, res);
+  });
 };
 
 var remove = function(dataset_id, data, cb) {
@@ -81,6 +87,5 @@ module.exports = {
   create: create,
   list: list,
   remove: remove,
-  setFHDB: setFHDB,
-  init: init
+  setFHDB: setFHDB
 }

--- a/lib/sync-UpdatesModel_mongo.js
+++ b/lib/sync-UpdatesModel_mongo.js
@@ -1,0 +1,41 @@
+var syncUtil = require('./sync-util');
+var MongoClient = require('mongodb').MongoClient;
+var fhdb;
+var mongo;
+
+var setFHDB = function(db) {
+  fhdb = db;
+};
+
+var setConnectionUrl = function(url) {
+  MongoClient.connect(url, function(err, db) {
+    if (err) throw err;
+    syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'sync-UpdatesModel MongoClient connected');
+
+    mongo = db;
+  });
+};
+
+var create = function(dataset_id, data, cb) {
+  return mongo.collection(dataset_id + "-updates").insertOne(data, cb);
+};
+
+var list = function(dataset_id, eq, cb) {
+  return mongo.collection(dataset_id + "-updates").find(eq).toArray(cb);
+};
+
+var remove = function(dataset_id, data, cb) {
+  var toDelete = {
+    cuid: data.cuid,
+    hash: data.hash
+  };
+  return mongo.collection(dataset_id + "-updates").deleteOne(toDelete, cb);
+};
+
+module.exports = {
+  create: create,
+  list: list,
+  remove: remove,
+  setFHDB: setFHDB,
+  setConnectionUrl: setConnectionUrl
+}

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -1,11 +1,11 @@
 var async = require('async');
 var util = require('util');
 var DataSetModel = require('./sync-DataSetModel');
-var UpdatesModel = require('./sync-UpdatesModel');
 var syncUtil = require('./sync-util');
 var config;
 var db = require('./db');
 var fhdb;
+var UpdatesModel;
 
 module.exports = function (cfg) {
   if (!cfg) {
@@ -73,7 +73,18 @@ var sync = function () {
       fhdb = db(config);
       DataSetModel.setFHDB(fhdb);
       DataSetModel.init();
-      UpdatesModel.setFHDB(fhdb);
+      fhdb({
+        "act": "connectionString"
+      }, function(err, url) {
+        if (url) {
+          UpdatesModel = require('./sync-UpdatesModel_mongo.js');
+          UpdatesModel.setFHDB(fhdb);
+          UpdatesModel.setConnectionUrl(url);
+        } else {
+          UpdatesModel = require('./sync-UpdatesModel_fhdb.js');
+          UpdatesModel.setFHDB(fhdb);
+        }
+      });
     }
   }
 
@@ -361,15 +372,14 @@ function returnUpdates(dataset_id, params, resIn, cb) {
   var eq = {
     cuid: cuid
   };
-  UpdatesModel.list(dataset_id, eq, function (err, res) {
+  UpdatesModel.list(dataset_id, eq, function (err, records) {
     if (err) return cb(err);
 
     var updates = {};
 
-    syncUtil.doLog(dataset_id, 'silly', 'returnUpdates - found ' + res.list.length + ' updates', params);
+    syncUtil.doLog(dataset_id, 'silly', 'returnUpdates - found ' + records.length + ' updates', params);
 
-    for (var di = 0, dl = res.list.length; di < dl; di += 1) {
-      var rec = res.list[di].fields;
+    records.forEach(function(rec) {
       if (!updates.hashes) {
         updates.hashes = {};
       }
@@ -381,7 +391,7 @@ function returnUpdates(dataset_id, params, resIn, cb) {
       updates[rec.type][rec.hash] = rec;
 
       syncUtil.doLog(dataset_id, 'verbose', 'returning update ' + util.inspect(rec), params);
-    }
+    });
 
     if (!resIn) {
       syncUtil.doLog(dataset_id, 'silly', 'returnUpdates - initialising res', params);
@@ -389,7 +399,7 @@ function returnUpdates(dataset_id, params, resIn, cb) {
     }
     resIn.updates = updates;
     syncUtil.doLog(dataset_id, 'silly', 'returnUpdates - final res = ' + util.inspect(resIn), params);
-    if (res.list.length > 0) {
+    if (records.length > 0) {
       syncUtil.doLog(dataset_id, 'verbose', 'returnUpdates :: ' + util.inspect(updates.hashes), params);
     }
 

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -1,6 +1,7 @@
 var async = require('async');
 var util = require('util');
 var DataSetModel = require('./sync-DataSetModel');
+var UpdatesModel = require('./sync-UpdatesModel');
 var syncUtil = require('./sync-util');
 var config;
 var db = require('./db');
@@ -72,6 +73,7 @@ var sync = function () {
       fhdb = db(config);
       DataSetModel.setFHDB(fhdb);
       DataSetModel.init();
+      UpdatesModel.setFHDB(fhdb);
     }
   }
 
@@ -251,31 +253,7 @@ function processPending(dataset_id, dataset, params, cb) {
           msg: util.inspect(msg)
         };
 
-        fhdb({
-          "act": "list",
-          "type": dataset_id + "-updates",
-          "eq": {
-            "cuid": cuid,
-            "type": type,
-            "action": action,
-            "hash": hash,
-            "uid": uid
-          }
-        }, function (err, found) {
-          if (err) return cb(err);
-          if (found && found.list && found.list.length > 0) {
-            syncUtil.doLog(dataset_id, 'info', 'Update is already recorded, ignore', update);
-            return cb(null, found.list[0]);
-          } else {
-            fhdb({
-              "act": "create",
-              "type": dataset_id + "-updates",
-              "fields": update
-            }, function (err, res) {
-              cb(err, res);
-            });
-          }
-        });
+        UpdatesModel.create(dataset_id, update, cb);
       }
 
       if ("create" === action) {
@@ -380,13 +358,10 @@ function returnUpdates(dataset_id, params, resIn, cb) {
   //syncUtil.doLog(dataset_id, 'verbose', 'START returnUpdates', params);
   syncUtil.doLog(dataset_id, 'silly', 'returnUpdates - existing res = ' + util.inspect(resIn), params);
   var cuid = syncUtil.getCuid(params);
-  fhdb({
-    "act": "list",
-    "type": dataset_id + "-updates",
-    "eq": {
-      "cuid": cuid
-    }
-  }, function (err, res) {
+  var eq = {
+    cuid: cuid
+  };
+  UpdatesModel.list(dataset_id, eq, function (err, res) {
     if (err) return cb(err);
 
     var updates = {};
@@ -438,33 +413,7 @@ function acknowledgeUpdates(dataset_id, params, cb) {
 
     async.forEachSeries(updates, function (update, itemCallback) {
         syncUtil.doLog(dataset_id, 'verbose', 'acknowledgeUpdates :: processing update ' + util.inspect(update), params);
-        fhdb({
-          "act": "list",
-          "type": dataset_id + "-updates",
-          "eq": {
-            "cuid": update.cuid,
-            "hash": update.hash
-          }
-        }, function (err, res) {
-          if (err) return itemCallback(err, update);
-
-          if (res && res.list && res.list.length > 0) {
-            var rec = res.list[0];
-            var uid = rec.guid;
-            fhdb({
-              "act": "delete",
-              "type": dataset_id + "-updates",
-              "guid": uid
-            }, function (err) {
-              if (err) return itemCallback(err, update);
-
-              return itemCallback(null, update);
-            });
-          }
-          else {
-            return itemCallback(null, update);
-          }
-        });
+        UpdatesModel.remove(dataset_id, update, itemCallback);
       },
       function (err) {
         if (err) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,27 +4,27 @@
   "dependencies": {
     "async": {
       "version": "0.2.9",
-      "from": "async@0.2.9",
+      "from": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
     },
     "colors": {
       "version": "0.6.2",
-      "from": "colors@0.6.2",
+      "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
     },
     "cycle": {
       "version": "1.0.3",
-      "from": "cycle@1.0.3",
+      "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
     },
     "eyes": {
       "version": "0.1.8",
-      "from": "eyes@0.1.8",
+      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
     },
     "fh-db": {
       "version": "1.2.5",
-      "from": "fh-db@1.2.5",
+      "from": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.5.tgz",
       "resolved": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.5.tgz",
       "dependencies": {
         "adm-zip": {
@@ -384,7 +384,7 @@
     },
     "fh-mbaas-client": {
       "version": "0.15.0",
-      "from": "fh-mbaas-client@0.15.0",
+      "from": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-0.15.0.tgz",
       "resolved": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-0.15.0.tgz",
       "dependencies": {
         "fh-logger": {
@@ -1121,7 +1121,7 @@
     },
     "fh-security": {
       "version": "0.2.0",
-      "from": "fh-security@0.2.0",
+      "from": "https://registry.npmjs.org/fh-security/-/fh-security-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/fh-security/-/fh-security-0.2.0.tgz",
       "dependencies": {
         "node-rsa": {
@@ -1140,51 +1140,51 @@
     },
     "fh-statsc": {
       "version": "0.3.0",
-      "from": "fh-statsc@0.3.0",
+      "from": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz"
     },
     "lodash-contrib": {
       "version": "393.0.1",
-      "from": "lodash-contrib@>=393.0.1 <394.0.0",
+      "from": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.9.3",
-          "from": "lodash@3.9.3",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
         }
       }
     },
     "memcached": {
       "version": "2.2.2",
-      "from": "memcached@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
       "dependencies": {
         "hashring": {
           "version": "3.2.0",
-          "from": "hashring@>=3.2.0 <3.3.0",
+          "from": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
           "dependencies": {
             "connection-parse": {
               "version": "0.0.7",
-              "from": "connection-parse@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz"
             },
             "simple-lru-cache": {
               "version": "0.0.2",
-              "from": "simple-lru-cache@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz"
             }
           }
         },
         "jackpot": {
           "version": "0.0.6",
-          "from": "jackpot@>=0.0.6",
+          "from": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
           "dependencies": {
             "retry": {
               "version": "0.6.0",
-              "from": "retry@0.6.0",
+              "from": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
             }
           }
@@ -1193,82 +1193,165 @@
     },
     "moment": {
       "version": "2.14.1",
-      "from": "moment@2.14.1",
+      "from": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz"
+    },
+    "mongodb": {
+      "version": "2.2.22",
+      "from": "mongodb@>=2.1.18 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.22.tgz",
+      "dependencies": {
+        "es6-promise": {
+          "version": "3.2.1",
+          "from": "es6-promise@3.2.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+        },
+        "mongodb-core": {
+          "version": "2.1.7",
+          "from": "mongodb-core@2.1.7",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.7.tgz",
+          "dependencies": {
+            "bson": {
+              "version": "1.0.4",
+              "from": "bson@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz"
+            },
+            "require_optional": {
+              "version": "1.0.0",
+              "from": "require_optional@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+              "dependencies": {
+                "semver": {
+                  "version": "5.3.0",
+                  "from": "semver@>=5.1.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                },
+                "resolve-from": {
+                  "version": "2.0.0",
+                  "from": "resolve-from@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.1.5",
+          "from": "readable-stream@2.1.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "dependencies": {
+            "buffer-shims": {
+              "version": "1.0.0",
+              "from": "buffer-shims@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+            }
+          }
+        }
+      }
     },
     "mongodb-uri": {
       "version": "0.9.7",
-      "from": "mongodb-uri@0.9.7",
+      "from": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
       "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz"
     },
     "optval": {
       "version": "1.0.1",
-      "from": "optval@1.0.1",
+      "from": "https://registry.npmjs.org/optval/-/optval-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/optval/-/optval-1.0.1.tgz"
     },
     "pkginfo": {
       "version": "0.2.3",
-      "from": "pkginfo@0.2.3",
+      "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
     },
     "redis": {
       "version": "0.8.2",
-      "from": "redis@0.8.2",
+      "from": "https://registry.npmjs.org/redis/-/redis-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.2.tgz"
     },
     "request": {
       "version": "2.74.0",
-      "from": "request@2.74.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
           "version": "1.5.0",
-          "from": "aws4@>=1.2.1 <2.0.0",
+          "from": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
         },
         "bl": {
           "version": "1.1.2",
-          "from": "bl@>=1.1.2 <1.2.0",
+          "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
-              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -1277,44 +1360,44 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "from": "caseless@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "delayed-stream@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "extend": {
           "version": "3.0.0",
-          "from": "extend@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.1",
-          "from": "form-data@>=1.0.0-rc4 <1.1.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "dependencies": {
             "async": {
               "version": "2.1.4",
-              "from": "async@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
               "dependencies": {
                 "lodash": {
                   "version": "4.17.4",
-                  "from": "lodash@>=4.14.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
                 }
               }
@@ -1323,104 +1406,104 @@
         },
         "har-validator": {
           "version": "2.0.6",
-          "from": "har-validator@>=2.0.6 <2.1.0",
+          "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
-              "from": "commander@>=2.9.0 <3.0.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.15.0",
-              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "4.0.1",
-                  "from": "jsonpointer@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                 }
               }
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
-                  "from": "pinkie@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
@@ -1429,111 +1512,111 @@
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
-              "from": "hoek@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "boom@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
-              "from": "assert-plus@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.3.1",
-              "from": "jsprim@>=1.2.2 <2.0.0",
+              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.0.2",
-                  "from": "extsprintf@1.0.2",
+                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.3",
-                  "from": "json-schema@0.2.3",
+                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
-                  "from": "verror@1.3.6",
+                  "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 }
               }
             },
             "sshpk": {
               "version": "1.10.2",
-              "from": "sshpk@>=1.7.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 },
                 "dashdash": {
                   "version": "1.14.1",
-                  "from": "dashdash@>=1.12.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                 },
                 "getpass": {
                   "version": "0.1.6",
-                  "from": "getpass@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                 },
                 "jsbn": {
                   "version": "0.1.0",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.14.5",
-                  "from": "tweetnacl@>=0.14.0 <0.15.0",
+                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 },
                 "bcrypt-pbkdf": {
                   "version": "1.0.0",
-                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
                 }
               }
@@ -1542,83 +1625,83 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "2.1.14",
-          "from": "mime-types@>=2.1.7 <2.2.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.26.0",
-              "from": "mime-db@>=1.26.0 <1.27.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "node-uuid@>=1.4.7 <1.5.0",
+          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
           "version": "6.2.1",
-          "from": "qs@>=6.2.0 <6.3.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "stringstream@>=0.0.4 <0.1.0",
+          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "from": "tough-cookie@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
-              "from": "punycode@>=1.4.1 <2.0.0",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.4.3",
-          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
     "stack-trace": {
       "version": "0.0.9",
-      "from": "stack-trace@0.0.9",
+      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
     },
     "underscore": {
       "version": "1.7.0",
-      "from": "underscore@1.7.0",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "unifiedpush-node-sender": {
       "version": "0.12.0",
-      "from": "unifiedpush-node-sender@0.12.0",
+      "from": "https://registry.npmjs.org/unifiedpush-node-sender/-/unifiedpush-node-sender-0.12.0.tgz",
       "resolved": "https://registry.npmjs.org/unifiedpush-node-sender/-/unifiedpush-node-sender-0.12.0.tgz",
       "dependencies": {
         "lodash": {
@@ -1680,7 +1763,7 @@
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
@@ -1998,19 +2081,19 @@
     },
     "winston": {
       "version": "0.8.0",
-      "from": "winston@0.8.0",
+      "from": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
       "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
       "dependencies": {
         "pkginfo": {
           "version": "0.3.1",
-          "from": "pkginfo@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
         }
       }
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@4.0.1",
+      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lodash-contrib": "^393.0.1",
     "memcached": "^2.0.0",
     "moment": "2.14.1",
+    "mongodb": "^2.1.18",
     "mongodb-uri": "0.9.7",
     "optval": "1.0.1",
     "pkginfo": "0.2.3",

--- a/test/test_fhdb.js
+++ b/test/test_fhdb.js
@@ -18,7 +18,10 @@ module.exports = {
     process.env['FH_MBAAS_TYPE'] = 'openshift3';
     var localdbStub = sinon.stub().callsArgAsync(1);
     var databaseConnectionStringStub = sinon.stub().callsArgWithAsync(1, null, {
-      url: 'test-url'
+      url: 'test-url' });
+
+    var dbStub = sinon.stub().returns(function(option, cb) {
+      cb(null, null);
     });
 
     $fh = proxyquire('../lib/api.js', {
@@ -31,6 +34,9 @@ module.exports = {
         'fh-db': {
           'local_db': localdbStub
         }
+      }),
+      './sync-srv': proxyquire('../lib/sync-srv.js', {
+        './db': dbStub
       })
     });
     $fh.db({

--- a/test/test_sync-srv.js
+++ b/test/test_sync-srv.js
@@ -1,0 +1,76 @@
+var util = require('util');
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+var dataHandler = require('./fixtures/syncHandler');
+var assert = require('assert');
+
+var dataset_id = "myShoppingList";
+var config = {
+  fhapi: {
+    appname : 'test_sync-srv'
+  },
+  fhditch: {
+    host: 'localhost',
+    port: 443,
+    protocol: 'https'
+  }
+};
+var mongoStub = {
+  create: sinon.stub().callsArgWith(2, null, {}),
+  list: sinon.stub().callsArgWith(2, null, {
+     forEach: sinon.stub()
+  }),
+  remove: sinon.stub().callsArgWith(2, null),
+  setFHDB: sinon.stub(),
+  setConnectionUrl: sinon.stub()
+};
+
+module.exports = {
+  setUp : function(finish){
+
+    var dbStub = sinon.stub().returns(function(option, cb) {
+      cb(null, "dummy:connectionstring");
+    });
+    sync = proxyquire("../lib/sync-srv.js", {
+      './sync-UpdatesModel_mongo.js': mongoStub,
+      './db': dbStub
+    })(config);
+
+    sync.init(dataset_id, {}, function() {
+      sync.handleList(dataset_id, dataHandler.doList);
+      sync.handleCreate(dataset_id, dataHandler.doCreate);
+      sync.handleRead(dataset_id, dataHandler.doRead);
+      sync.handleUpdate(dataset_id, dataHandler.doUpdate);
+      sync.handleDelete(dataset_id, dataHandler.doDelete);
+      sync.handleCollision(dataset_id, dataHandler.doCollision);
+      sync.listCollisions(dataset_id, dataHandler.listCollisions);
+      sync.removeCollision(dataset_id, dataHandler.removeCollision);
+      finish();
+    });
+  },
+
+  'test sync with acknowledgements' : function(finish) {
+    var params = {
+      "fn": "sync",
+      "dataset_id": dataset_id,
+      "query_params": {},
+      "pending": [],
+      "acknowledgements": [
+        { "cuid":"95F6C8E085F24D278280CE3480290A3C",
+          "type":"applied",
+          "action":"create",
+          "hash":"e062e09d2b83e3753c89dd56376f50262c197ee1",
+          "uid":"5889b2de859084ac853c88e3",
+          "msg":"''"
+         }
+        ]
+    };
+    sync.invoke('myShoppingList', params, function(err, res){
+      assert.ok(!err, 'Error: ' + err);
+      assert.ok(mongoStub.list.called);
+      assert.ok(mongoStub.remove.called);
+      finish();
+    });
+  },
+
+};


### PR DESCRIPTION
* abstracts the '<dataset>-updates' fhdb model updates to a separate model file.
* adds a second update model that connects with the mongo client rather than fhdb
  * this allows for doing a create and delete without having to do a list first (fhdb limitations)