### PR TITLE
RHMAP-12825 - Env variables instead of hard-coded https protocol and port

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -45,7 +45,7 @@ function FHapi(cfg, logr) {
     service: require('./act')(cfg),
     sec: sec.security,
     auth: require('./auth')(cfg),
-    host: require('./host'),
+    host: require('./host')(cfg),
     permission_map: require('fh-db').permission_map,
     hash: function (opts, callback) {
       var p = {
@@ -87,11 +87,13 @@ function FHapi(cfg, logr) {
 }
 
 /**
- * Initilisation returns the $fh object to clients
+ * Initialisation returns the $fh object to clients
  */
 module.exports = (function () {
-  // First setup the required config params from  env variables
+  // First setup the required config params from env variables
   var millicore = process.env.FH_MILLICORE || 'NO-MILLICORE-DEFINED';
+  var millicore_protocol = process.env.FH_MILLICORE_PROTOCOL || 'https';
+  var millicore_port = process.env.FH_MILLICORE_PORT || 443;
   var domain = process.env.FH_DOMAIN || 'NO-DOMAIN-DEFINED';
   var instance = process.env.FH_INSTANCE || 'NO-INSTANCE-DEFINED';
   var appname = process.env.FH_APPNAME || 'NO-APPNAME-DEFINED';
@@ -143,8 +145,9 @@ module.exports = (function () {
   var cfg = {
     fhapi: {
       appname: appname,
+      protocol: millicore_protocol,
       millicore: millicore,
-      port: 443,
+      port: millicore_port,
       domain: domain,
       instance: instance,
       widget: widget,

--- a/lib/call.js
+++ b/lib/call.js
@@ -1,6 +1,7 @@
 var config,
   _ = require('underscore'),
   https = require('https'),
+  http = require('http'),
   futils = require('./fhutils'),
   fhutils;
 module.exports = function (cfg) {
@@ -12,7 +13,6 @@ module.exports = function (cfg) {
 //
 // $fh.call() : Call back to millicore from our Node.js code.
 // NOT a public function but may be one day.
-// TODO - note that it uses hardcoded https here.
 var call = function call(path, params, callback) {
   var headers = {
       "accept": "application/json"
@@ -35,12 +35,13 @@ var call = function call(path, params, callback) {
   addParams["widget"] = props.widgId;
 
   var fhResp = {};
-  var req = https.request(options, function (res) {
+  var protocolLibrary = props.protocol === 'http' ? http : https;
+  var req = protocolLibrary.request(options, function (res) {
     fhResp.status = res.statusCode;
     // TODO - *both* of these are recommended ways of setting timeout on http requests..
     // needs further investigation (and proper test case!!)
 
-    // bob build didnt like below..above suggests it was never verified?? ... changed to this to add timeout
+    // bob build didn't like below..above suggests it was never verified?? ... changed to this to add timeout
     //req.socket && req.socket.setTimeout(config.socketTimeout);
     //req.connection.setTimeout && req.connection.setTimeout(config.socketTimeout);
     req.on('socket', function (socket){

--- a/lib/host.js
+++ b/lib/host.js
@@ -1,20 +1,29 @@
-var _ = require('lodash-contrib');
-var request = require('request');
+var _ = require('lodash-contrib'),
+  request = require('request'),
+  futils = require('./fhutils'),
+  assert = require('assert');
 
-module.exports = function host(cb) {
-  var url = 'https://' + process.env.FH_MILLICORE + '/box/srv/1.1/ide/apps/app/hosts';
-  var data = {
-    "guid": process.env.FH_INSTANCE,
-    "env": process.env.FH_ENV
-  }
+module.exports = function(cfg) {
+  assert.ok(cfg, 'cfg is undefined');
 
-  request.post({
-    url: url,
-    json: true,
-    body: data
-  }, function (err, res, body) {
-    if (err) return cb(err);
+  var fhutils = new futils(cfg);
+  var millicoreProps = fhutils.getMillicoreProps();
 
-    return cb(err, _.getPath(body, "hosts.url"));
-  });
+  return function host(cb) {
+    var url = millicoreProps.protocol + '://' + millicoreProps.millicore + '/box/srv/1.1/ide/apps/app/hosts';
+    var data = {
+      "guid": process.env.FH_INSTANCE,
+      "env": process.env.FH_ENV
+    }
+
+    request.post({
+      url: url,
+      json: true,
+      body: data
+    }, function (err, res, body) {
+      if (err) return cb(err);
+
+      return cb(err, _.getPath(body, "hosts.url"));
+    });
+  };
 }

--- a/lib/push.js
+++ b/lib/push.js
@@ -25,7 +25,7 @@ module.exports = function (cfg) {
     fhutils.addAppApiKeyHeader(headers, opts.appapikey);
 
     return {
-      url: 'https://' + opts.millicore + ':' + opts.port + '/box/api/unifiedpush/mbaas/',
+      url: opts.protocol + '://' + opts.millicore + ':' + opts.port + '/box/api/unifiedpush/mbaas/',
       applicationId: "fake", // we have to use fake ID, it will be added by supercore
       masterSecret: "fake", // we have to use fake secret, it will be added by supercore
       headers: headers

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=6.1.5
+sonar.projectVersion=6.1.6
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/fixtures/env.js
+++ b/test/fixtures/env.js
@@ -7,6 +7,8 @@ module.exports = (function(){
   process.env.FH_APP_API_KEY = "someappapikey";
 
   process.env.FH_MILLICORE = 'localhost';
+  process.env.FH_MILLICORE_PROTOCOL = 'https';
+  process.env.FH_MILLICORE_PORT = 443;
   process.env.FH_DOMAIN = 'NO-DOMAIN-DEFINED';
   process.env.FH_INSTANCE = 'c0TPJzF6ztq0WjezxwPEC5W8';
   process.env.FH_APPNAME = '123';

--- a/test/test_fhpush.js
+++ b/test/test_fhpush.js
@@ -26,6 +26,7 @@ describe('$fh.push', function () {
         widget: 'a',
         instance: 'b',
         millicore: 'fake-domain.feedhenry.com',
+        protocol: 'https',
         port: 4567
       }
     };


### PR DESCRIPTION
**Motivation**

fh-mbaas-api cannot be fully used for clusters that doesn't support https protocol (e.g. ENG1).

**Modifications**

The biggest change is in hosts.js because the cfg object needed to be passed along. Otherwise I just replaced the hard coded https related stuff so that http can be used as well.