### PR TITLE
remove references to the datasetClientRecords

### DIFF
--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -40,7 +40,6 @@ var self = {
   },
 
   datasets: {},
-  datasetClientRecords: {},
   deletedDatasets: {},
   createDatasetOnDemand: true,
 
@@ -307,20 +306,6 @@ var self = {
     }
   },
 
-  getDatasetClientRecords: function (datasetClient, cb) {
-    var datasetClientId = datasetClient.id;
-    if (typeof self.datasetClientRecords[datasetClientId] !== "undefined") {
-      return cb(null, self.datasetClientRecords[datasetClientId]);
-    } else {
-      var datasetId = datasetClient.datasetId;
-      syncUtil.doLog(datasetId, 'silly', 'no data records found for datasetClient ' + datasetClientId + '. Do backend list.');
-      self.syncDatasetClient(datasetClient, function (err) {
-        if (err) return cb(err);
-        return cb(null, self.datasetClientRecords[datasetClientId]);
-      });
-    }
-  },
-
   createDatasetClient: function (dataset_id, query_params, meta_data, cb) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return err;
@@ -400,7 +385,6 @@ var self = {
       syncUtil.doLog(dataset.id, 'verbose', 'doSyncList cb ' + ( cb !== undefined) + ' - Global Hash (prev :: cur) = ' + previousHash + ' ::  ' + globalHash);
 
       datasetClient.dataHash = globalHash;
-      self.datasetClientRecords[datasetClient.id] = recOut;
 
       var res = {
         hash: globalHash,
@@ -489,7 +473,6 @@ var self = {
                 if (lastAccessed + syncClientTimeout < now) {
                   syncUtil.doLog(dataset_id, 'info', 'Deactivating sync for client ' + datasetClient.id + '. No client instances have accessed in ' + syncClientTimeout + 'ms');
                   datasetClient.syncActive = false;
-                  delete self.datasetClientRecords[datasetClient.id];
                 }
                 else {
                   var syncFrequency = dataset.config.syncFrequency * 1000;
@@ -527,40 +510,19 @@ var self = {
   toJSON: function (dataset_id, returnData, cb) {
     var res = {};
 
-    var addData = function (dataset) {
-      for (var i in dataset.clients) {
-        if (dataset.clients.hasOwnProperty(i)) {
-          var dsc = dataset.clients[i];
-          dsc.dataRecords = self.datasetClientRecords[dsc.id];
-        }
-      }
-    }
-
     if (!dataset_id) {
       // return entire sync object
       res = JSON.parse(JSON.stringify(self.datasets));
-      if (returnData) {
-        for (var i in res) {
-          if (res.hasOwnProperty(i)) {
-            var dataset = res[i];
-            addData(dataset);
-          }
-        }
-      }
       return cb(null, res);
     }
     else {
-      self.getDataset(dataset_id, function (err) {
+      self.getDataset(dataset_id, function (err, dataset) {
         if (err) return cb(err);
 
-        if (returnData) {
-          addData(res);
-        }
+        res = JSON.parse(JSON.stringify(dataset));
         return cb(null, res);
       });
     }
-
-
   },
 
   datasetMonitor: function () {
@@ -613,7 +575,6 @@ module.exports = {
   createDataset: self.createDataset,
   removeDataset: self.removeDataset,
   getDatasetClient: self.getDatasetClient,
-  getDatasetClientRecords: self.getDatasetClientRecords,
   createDatasetClient: self.createDatasetClient,
   removeDatasetClient: self.removeDatasetClient,
   syncDatasetClient: self.syncDatasetClient,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=6.1.5
+sonar.projectVersion=6.1.6
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
## Motive

The `datasetClientRecords` is not used anywhere. We should remove it to improve the memory usage of the sync framework.

## Changes

Remove the references to the `datasetClientRecords` variable and methods.

## JIRA

https://issues.jboss.org/browse/FH-3124

ping @david-martin @aidenkeating 