### PR TITLE
Wire up sync for testing, with an initial set of tests for invoke()

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,15 +25,12 @@ module.exports = function(grunt) {
     './test/test_fhstat.js',
     './test/test_cache.js',
     './test/test_redis.js',
-    './test/test_sync.js',
-    './test/test_sync_handlers.js',
-    './test/test_sync_datasetmodel.js',
-    './test/test_sync_utils.js',
     './test/test_fhauth.js',
     './test/test_init.js',
     './test/test_log.js',
     './test/test_fhpush.js',
-    './test/sync/test_mongodbQueue.js'
+    './test/sync/test_mongodbQueue.js',
+    './test/sync/test_index.js'
   ];
   var unit_args = _.map(tests, makeTestArgs);
   var test_runner = '_mocha';

--- a/lib/api.js
+++ b/lib/api.js
@@ -40,7 +40,7 @@ function FHapi(cfg, logr) {
     redisHost: cfg.redis.host || 'localhost',
     session: require('./session')(cfg),
     stats: require('./stats')(cfg),
-    sync: require('./sync'),
+    sync: require('./sync').api,
     act: require('./act')(cfg),
     service: require('./act')(cfg),
     sec: sec.security,
@@ -56,6 +56,24 @@ function FHapi(cfg, logr) {
     },
     web: require('./web')(cfg)
   };
+
+  var redisUrl = api.redisHost + ':' + api.redisPort;
+  api.db({
+    "act" : "connectionString"
+  }, function(err, connectionString) {
+    if (err) {
+      console.warn('Warning! Could not get a mongodb connection string. Sync will not work. (', err, ')');
+      return;
+    } else if (!connectionString) {
+      console.warn('Warning! Could not get a mongodb connection string. Sync will not work. If running in a Dynofarm/FeedHenry MBaaS, ensure the database is upgraded');
+      return;
+    }
+    api.sync.connect(connectionString, redisUrl, function(err) {
+      if (err) {
+        console.error('Error starting the sync server (', err, ')');
+      }
+    });
+  });
 
   api.mbaasExpress = function (opts) {
     opts = opts || {};

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -1,5 +1,6 @@
 var syncUtil = require('./util');
 var async = require('async');
+var util = require('util');
 var MongoClient = require('mongodb').MongoClient;
 var MongodbQueue = require('./mongodbQueue');
 var AckWorker = require('./ack-worker');
@@ -9,6 +10,8 @@ var SyncScheduler = require('./sync-scheduler');
 
 var ackQueue, pendingQueue, syncQueue, ackWorker, pendingWorker, syncWorker;
 
+var redisClient, mongoDbClient;
+
 function toJSON(dataset_id, returnData, cb) {
   syncUtil.doLog(dataset_id, 'info', 'toJSON');
 
@@ -17,26 +20,34 @@ function toJSON(dataset_id, returnData, cb) {
   return cb(null, {});
 }
 
+// Functions that are allowed to be invoked
+var invokeFunctions = ['sync', 'syncRecords', 'listCollisions', 'removeCollision', 'setLogLevel'];
+
+// Invoke the Sync Server.
 function invoke(dataset_id, params, callback) {
   syncUtil.doLog(dataset_id, 'info', 'invoke');
 
+  if (arguments.length < 3) throw new Error('invoke requires 3 arguments');
+
   // Verify that fn param has been passed
   if (!params || !params.fn) {
-    syncUtil.doLog(dataset_id, 'warn', 'no fn parameter provided :: ' + util.inspect(params), params);
-    return callback("no_fn", null);
+    var err = 'no fn parameter provided in params "' + util.inspect(params) + '"';
+    syncUtil.doLog(dataset_id, 'warn', err, params);
+    return callback(err, null);
   }
 
   var fn = params.fn;
 
   // Verify that fn param is valid
-  var fnHandler = invokeFunctions[fn];
-  if (!fnHandler) {
-    return callback("unknown_fn : " + fn, null);
+  if (invokeFunctions.indexOf(fn) < 0) {
+    return callback('invalid fn parameter provided in params "' + fn + '"', null);
   }
+  var fnHandler = module.exports[fn];
 
   return fnHandler(dataset_id, params, callback);
 }
 
+// Initialise cloud data sync service for specified dataset.
 function init(dataset_id, options, cb) {
   syncUtil.doLog(dataset_id, 'info', 'init');
   
@@ -45,6 +56,7 @@ function init(dataset_id, options, cb) {
   cb(null, {});
 }
 
+// Stop cloud data sync for the specified dataset_id.
 function stop(dataset_id, cb) {
   syncUtil.doLog(dataset_id, 'info', 'stop');
   
@@ -53,6 +65,7 @@ function stop(dataset_id, cb) {
   cb(null, {});
 }
 
+// Stop cloud data sync service for ALL datasets.
 function stopAll(cb) {
   syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'stopAll');
   
@@ -69,6 +82,8 @@ function listCollisions(dataset_id, params, cb) {
   return cb(null, {});
 }
 
+// Defines a handler function for deleting a collision from the collisions list.
+// Should be called after the dataset is initialised.
 function removeCollision(dataset_id, params, cb) {
   syncUtil.doLog(dataset_id, 'info', 'removeCollision');
 
@@ -89,7 +104,7 @@ function setLogLevel(dataset_id, params, cb) {
   }
 }
 
-function sync(dataset_id, params, callback) {
+function sync(dataset_id, params, cb) {
   syncUtil.doLog(dataset_id, 'info', 'sync');
 
   // TODO
@@ -97,8 +112,8 @@ function sync(dataset_id, params, callback) {
   return cb(null, {});
 }
 
-/* Synchronise the individual records for a dataset */
-function syncRecords(dataset_id, params, callback) {
+// Synchronise the individual records for a dataset
+function syncRecords(dataset_id, params, cb) {
   syncUtil.doLog(dataset_id, 'info', 'syncRecords');
 
   // TODO
@@ -106,21 +121,28 @@ function syncRecords(dataset_id, params, callback) {
   return cb(null, {});
 }
 
+function connect(mongoDBConnectionUrl, redisUrl, cb) {
+  async.parallel([
+    function connectToMongoDB(callback) {
+      MongoClient.connect(mongoDBConnectionUrl, callback);
+    },
+    function connectToRedis(callback) {
+      var client = redis.createClient(redisUrl);
+      return callback(null, client);
+    }
+  ], function(err, results) {
+    if (err) return cb(err);
+    mongoDbClient = results[0];
+    redisClient = results[1];
+    return cb();
+  });
+}
+
 function start(cb) {
   async.waterfall([
-    function getMongoDBConnectionString(callback) {
-      // if we can't get a connection string, it probably means we don't have an upgraded database.
-      // In that case, the callback will have an error
-      $fh.db({
-        "act" : "connectionString"
-      }, callback);
-    },
-    function connectToMongoDB(connectionString, callback) {
-      MongoClient.connect(url, callback);
-    },
-    function createQueues(mongoDbClient, callback) {
-      ackQueue = new MongodbQueue('sync-ack-queue', {mongodb: MongoClient});
-      pendingQueue = new MongodbQueue('sync-pending-queue', {mongodb: MongoClient});
+    function createQueues(callback) {
+      ackQueue = new MongodbQueue('sync-ack-queue', {mongodb: mongoDbClient});
+      pendingQueue = new MongodbQueue('sync-pending-queue', {mongodb: mongoDbClient});
       syncQueue = new MongodbQueue('sync-queue', {mongodb: mongoDbClient});
 
       async.parallel([
@@ -136,49 +158,45 @@ function start(cb) {
       return callback();
     },
     function startSyncScheduler(callback) {
-      syncScheduler = new SyncScheduler();
+      syncScheduler = new SyncScheduler(redisClient);
+      return callback();
     }
   ], cb);
 }
 
-// Functions which can be invoked through sync.invoke
-var invokeFunctions = {
-  "sync": sync,
-  "syncRecords": syncRecords,
-  "listCollisions": listCollisions,
-  "removeCollision": removeCollision,
-  "setLogLevel": setLogLevel
-};
-
 module.exports = {
-  init: init,
-  invoke: invoke,
-  stop: stop,
-  stopAll: stopAll,
-  toJSON: toJSON,
-  setLogLevel: setLogLevel,
-  globalHandleList: function() {},
-  globalHandleCreate: function() {},
-  globalHandleRead: function() {},
-  globalHandleUpdate: function() {},
-  globalHandleDelete: function() {},
-  globalHandleCollision: function() {},
-  globalListCollisions: function() {},
-  globalRemoveCollision: function() {},
-  globalInterceptRequest: function() {},
-  globalInterceptResponse: function() {},
-  handleList: function() {},
-  handleCreate: function() {},
-  handleRead: function() {},
-  handleUpdate: function() {},
-  handleDelete: function() {},
-  handleCollision: function() {},
-  listCollisions: function() {},
-  removeCollision: function() {},
-  interceptRequest: function() {},
-  interceptResponse: function() {}
+  sync: sync,
+  syncRecords: syncRecords,
+  listCollisions: listCollisions,
+  removeCollision: removeCollision,
+  api: {
+    init: init,
+    invoke: invoke,
+    stop: stop,
+    stopAll: stopAll,
+    connect: connect,
+    start: start,
+    toJSON: toJSON,
+    setLogLevel: setLogLevel,
+    globalHandleList: function() {},
+    globalHandleCreate: function() {},
+    globalHandleRead: function() {},
+    globalHandleUpdate: function() {},
+    globalHandleDelete: function() {},
+    globalHandleCollision: function() {},
+    globalListCollisions: function() {},
+    globalRemoveCollision: function() {},
+    globalInterceptRequest: function() {},
+    globalInterceptResponse: function() {},
+    handleList: function() {},
+    handleCreate: function() {},
+    handleRead: function() {},
+    handleUpdate: function() {},
+    handleDelete: function() {},
+    handleCollision: function() {},
+    listCollisions: function() {},
+    removeCollision: function() {},
+    interceptRequest: function() {},
+    interceptResponse: function() {}
+  }
 };
-
-
-
-

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,4 @@
-var proxyquire =  require('proxyquire').noCallThru(),
-exec = require('child_process').exec,
+var exec = require('child_process').exec,
 redis;
 
 exports.before = function(finish){

--- a/test/sync/test_index.js
+++ b/test/sync/test_index.js
@@ -1,0 +1,62 @@
+var assert = require('assert');
+var sync = require('../../lib/sync/index.js')
+var sinon = require('sinon');
+
+module.exports = {
+  'test invoke arg validation' : function() {
+    assert.throws(function() {
+      sync.api.invoke();
+    }, function(err) {
+      assert.equal(err.message, 'invoke requires 3 arguments');
+      return true;
+    });
+
+    assert.throws(function() {
+      sync.api.invoke('test_dataset_id');
+    }, function(err) {
+      assert.equal(err.message, 'invoke requires 3 arguments');
+      return true;
+    });
+
+    assert.throws(function() {
+      sync.api.invoke('test_dataset_id', {});
+    }, function(err) {
+      assert.equal(err.message, 'invoke requires 3 arguments');
+      return true;
+    });
+  },
+
+  'test invoke with missing fn': function(finish) {
+    sync.api.invoke('test_dataset_id', {}, function(err) {
+      assert.equal(err, 'no fn parameter provided in params "{}"');
+      return finish();
+    });
+  },
+
+  'test invoke with invalid fn': function(finish) {
+    var params = {
+      fn: 'some_invalid_fn'
+    };
+
+    sync.api.invoke('test_dataset_id', params, function(err) {
+      assert.equal(err, 'invalid fn parameter provided in params "some_invalid_fn"');
+      return finish();
+    });
+  },
+
+  'test invoke with valid fn': function(finish) {
+    // stub the syncRecords function so we can make sure its called
+    var syncRecords = sinon.stub(sync, "syncRecords");
+    syncRecords.callsArgWithAsync(2, null, {});
+    var params = {
+      fn: 'syncRecords'
+    };
+    sync.api.invoke('test_dataset_id', params, function(err, data) {
+      assert.ok(!err, err);
+      sinon.assert.calledOnce(syncRecords);
+      sinon.assert.calledWith(syncRecords, 'test_dataset_id', params);
+      syncRecords.restore();
+      return finish();
+    });
+  }
+};

--- a/test/test_fhdb.js
+++ b/test/test_fhdb.js
@@ -20,6 +20,12 @@ module.exports = {
     var databaseConnectionStringStub = sinon.stub().callsArgWithAsync(1, null, {
       url: 'test-url'
     });
+    var syncMock = {
+      api: {
+        connect: sinon.stub().callsArgAsync(2),
+        stopAll: sinon.stub().callsArgAsync(0)
+      }
+    };
 
     $fh = proxyquire('../lib/api.js', {
       './db': proxyquire('../lib/db.js', {
@@ -31,7 +37,8 @@ module.exports = {
         'fh-db': {
           'local_db': localdbStub
         }
-      })
+      }),
+      './sync': syncMock
     });
     $fh.db({
       "act" : "create",
@@ -47,7 +54,11 @@ module.exports = {
     }, function(err, res){
       assert.ok(!err, err);
       sinon.assert.calledOnce(localdbStub);
-      sinon.assert.calledOnce(databaseConnectionStringStub);
+
+      // this is called 2 times:
+      // - for sync connection
+      // - when calling fh.db
+      sinon.assert.calledTwice(databaseConnectionStringStub);
       finish();
     });
   },
@@ -60,6 +71,12 @@ module.exports = {
     var databaseConnectionStringStub = sinon.stub().callsArgWithAsync(1, null, {
       url: 'test-url'
     });
+    var syncMock = {
+      api: {
+        connect: sinon.stub().callsArgAsync(2),
+        stopAll: sinon.stub().callsArgAsync(0)
+      }
+    };
 
     $fh = proxyquire('../lib/api.js', {
       './db': proxyquire('../lib/db.js', {
@@ -71,7 +88,8 @@ module.exports = {
         'fh-db': {
           'local_db': localdbStub
         }
-      })
+      }),
+      './sync': syncMock
     });
     $fh.db({
       "act" : "connectionString"


### PR DESCRIPTION
start must be called to setup sync mongoclient, queues and workers.
start will always be called by fh-mbaas-api on initialisation.
start is not required to be called for testing