### PR TITLE
support custom hashing rules for sync records

### DIFF
--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -89,7 +89,7 @@ var self = {
       for (var i in records) {
         var rec = {};
         var recData = records[i];
-        var hash = hashFn(recData);
+        var hash = hashFn(recData, i); // pass the record and its id
         hashes.push(hash);
         rec.data = recData;
         rec.hash = hash;

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -463,37 +463,7 @@ var self = {
           }
         }
       }
-    )
-
-    self.doListHandler(dataset.id, datasetClient.queryParams, function (err, records) {
-      if (err) {
-        datasetClient.syncRunning = false;
-        datasetClient.syncLoopEnd = new Date().getTime();
-        return cb && cb(err);
-      }
-
-      self.generateRecordHashes(dataset.id, records, function (err, hashes) {
-        if (err) {
-          datasetClient.syncRunning = false;
-          datasetClient.syncLoopEnd = new Date().getTime();
-          return cb && cb(err);
-        }
-
-        var globalHash = hashes.hash;
-
-        var previousHash = datasetClient.dataHash ? datasetClient.dataHash : '<undefined>';
-        syncUtil.doLog(dataset.id, 'verbose', 'doSyncList cb ' + ( cb !== undefined) + ' - Global Hash (prev :: cur) = ' + previousHash + ' ::  ' + globalHash);
-
-        datasetClient.dataHash = globalHash;
-        self.datasetClientRecords[datasetClient.id] = hashes.records;
-
-        datasetClient.syncRunning = false;
-        datasetClient.syncLoopEnd = new Date().getTime();
-        if (cb) {
-          cb(null, hashes);
-        }
-      });
-    }, datasetClient.metaData);
+    );
   },
 
   forceSyncList: function (dataset_id, datasetClient, cb) {

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -53,6 +53,23 @@ var self = {
 
 
   /**
+   * Returns the hash fn for hashing records for a given dataset
+   * @param  {String}   dataset_id
+   * @param  {Function} callback
+   * @return {undefined}
+   */
+  getHashFunction: function (dataset_id, callback) {
+    self.getDataset(dataset_id, function (err, dataset) {
+      if (err) {
+        return callback(err);
+      }
+
+      callback(null, dataset.hashHandler || self.globalHashHandler);
+    });
+  },
+
+
+  /**
    * Passes the hashing function that should be used for records as a success
    * parameter to the supplied callback
    * @param   {String} dataset_id

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -27,6 +27,7 @@ var self = {
   globalCollisionHandler: undefined,
   globalCollisionLister: undefined,
   globalCollisionRemover: undefined,
+  globalHashHandler: defaultDataHandler.doHash,
   globalRequestInterceptor: function (dataset_id, params, cb) {
     return cb()
   },
@@ -48,6 +49,42 @@ var self = {
 
   setFHDB: function (db) {
     defaultDataHandler.setFHDB(db);
+  },
+
+
+  /**
+   * Passes the hashing function that should be used for records as a success
+   * parameter to the supplied callback
+   * @param   {String} dataset_id
+   * @param   {Function} callback
+   * @return  {undefined}
+   */
+  generateRecordHashes: function (dataset_id, records, callback) {
+    self.getDataset(dataset_id, function (err, dataset) {
+      if (err) {
+        return callback(err);
+      }
+
+      var hashFn = dataset.hashHandler || self.globalHashHandler;
+
+      var hashes = [];
+      var recOut = {};
+      for (var i in records) {
+        var rec = {};
+        var recData = records[i];
+        var hash = hashFn(recData);
+        hashes.push(hash);
+        rec.data = recData;
+        rec.hash = hash;
+        recOut[i] = rec;
+      }
+      var globalHash = syncUtil.generateHash(hashes);
+
+      callback(null, {
+        hash: globalHash,
+        records: recOut
+      });
+    });
   },
 
   doListHandler: function (dataset_id, query_params, cb, meta_data) {
@@ -375,6 +412,42 @@ var self = {
     datasetClient.syncPending = false;
     datasetClient.syncLoopStart = new Date().getTime();
 
+    async.waterfall(
+      [
+        function (next) {
+          self.doListHandler(dataset.id, datasetClient.queryParams, next, datasetClient.metaData);
+        },
+        function (records, next) {
+          self.generateRecordHashes(dataset.id, records, next);
+        },
+        function (hashes, next) {
+          var globalHash = hashes.hash;
+
+          var previousHash = datasetClient.dataHash ? datasetClient.dataHash : '<undefined>';
+          syncUtil.doLog(dataset.id, 'verbose', 'doSyncList cb ' + ( cb !== undefined) + ' - Global Hash (prev :: cur) = ' + previousHash + ' ::  ' + globalHash);
+
+          datasetClient.dataHash = globalHash;
+          self.datasetClientRecords[datasetClient.id] = hashes.records;
+
+          datasetClient.syncRunning = false;
+          datasetClient.syncLoopEnd = new Date().getTime();
+
+          next(null, hashes);
+        }
+      ],
+      function (err, hashes) {
+        if (err) {
+          datasetClient.syncRunning = false;
+          datasetClient.syncLoopEnd = new Date().getTime();
+          return cb && cb(err);
+        } else {
+          if (cb) {
+            cb(null, hashes);
+          }
+        }
+      }
+    )
+
     self.doListHandler(dataset.id, datasetClient.queryParams, function (err, records) {
       if (err) {
         datasetClient.syncRunning = false;
@@ -382,36 +455,27 @@ var self = {
         return cb && cb(err);
       }
 
+      self.generateRecordHashes(dataset.id, records, function (err, hashes) {
+        if (err) {
+          datasetClient.syncRunning = false;
+          datasetClient.syncLoopEnd = new Date().getTime();
+          return cb && cb(err);
+        }
 
-      var hashes = [];
-      var recOut = {};
-      for (var i in records) {
-        var rec = {};
-        var recData = records[i];
-        var hash = syncUtil.generateHash(recData);
-        hashes.push(hash);
-        rec.data = recData;
-        rec.hash = hash;
-        recOut[i] = rec;
-      }
-      var globalHash = syncUtil.generateHash(hashes);
+        var globalHash = hashes.hash;
 
-      var previousHash = datasetClient.dataHash ? datasetClient.dataHash : '<undefined>';
-      syncUtil.doLog(dataset.id, 'verbose', 'doSyncList cb ' + ( cb !== undefined) + ' - Global Hash (prev :: cur) = ' + previousHash + ' ::  ' + globalHash);
+        var previousHash = datasetClient.dataHash ? datasetClient.dataHash : '<undefined>';
+        syncUtil.doLog(dataset.id, 'verbose', 'doSyncList cb ' + ( cb !== undefined) + ' - Global Hash (prev :: cur) = ' + previousHash + ' ::  ' + globalHash);
 
-      datasetClient.dataHash = globalHash;
-      self.datasetClientRecords[datasetClient.id] = recOut;
+        datasetClient.dataHash = globalHash;
+        self.datasetClientRecords[datasetClient.id] = hashes.records;
 
-      var res = {
-        hash: globalHash,
-        records: recOut
-      };
-
-      datasetClient.syncRunning = false;
-      datasetClient.syncLoopEnd = new Date().getTime();
-      if (cb) {
-        cb(null, res);
-      }
+        datasetClient.syncRunning = false;
+        datasetClient.syncLoopEnd = new Date().getTime();
+        if (cb) {
+          cb(null, hashes);
+        }
+      });
     }, datasetClient.metaData);
   },
 
@@ -420,25 +484,8 @@ var self = {
     self.doListHandler(dataset_id, datasetClient.queryParams, function (err, records) {
       if (err) return cb(err);
 
+      self.generateRecordHashes(dataset_id, records, cb);
 
-      var hashes = [];
-      var recOut = {};
-      for (var i in records) {
-        var rec = {};
-        var recData = records[i];
-        var hash = syncUtil.generateHash(recData);
-        hashes.push(hash);
-        rec.data = recData;
-        rec.hash = hash;
-        recOut[i] = rec;
-      }
-      var globalHash = syncUtil.generateHash(hashes);
-
-      var res = {
-        hash: globalHash,
-        records: recOut
-      };
-      return cb(null, res);
     }, datasetClient.metaData);
   },
 
@@ -597,6 +644,9 @@ module.exports = {
   setGlobalCollisionRemover: generateGlobalSetter('globalCollisionRemover', self),
   setGlobalRequestInterceptor: generateGlobalSetter('globalRequestInterceptor', self),
   setGlobalResponseInterceptor: generateGlobalSetter('globalResponseInterceptor', self),
+  setGlobalHashHandler: generateGlobalSetter('globalHashHandler', self),
+  generateRecordHashes: self.generateRecordHashes,
+  doHashHandler: self.doHashHandler,
   doListHandler: self.doListHandler,
   doCreateHandler: self.doCreateHandler,
   doReadHandler: self.doReadHandler,

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -663,6 +663,7 @@ module.exports = {
   setGlobalResponseInterceptor: generateGlobalSetter('globalResponseInterceptor', self),
   setGlobalHashHandler: generateGlobalSetter('globalHashHandler', self),
   generateRecordHashes: self.generateRecordHashes,
+  getHashFunction: self.getHashFunction,
   doHashHandler: self.doHashHandler,
   doListHandler: self.doListHandler,
   doCreateHandler: self.doCreateHandler,

--- a/lib/sync-datahandler.js
+++ b/lib/sync-datahandler.js
@@ -9,6 +9,7 @@ module.exports = {
     fhdb = db;
   },
 
+  // Default to the built in hashing algorithm
   doHash: syncUtil.generateHash,
 
   doList: function (dataset_id, params, cb, meta_data) {

--- a/lib/sync-datahandler.js
+++ b/lib/sync-datahandler.js
@@ -9,6 +9,8 @@ module.exports = {
     fhdb = db;
   },
 
+  doHash: syncUtil.generateHash,
+
   doList: function (dataset_id, params, cb, meta_data) {
     syncUtil.doLog(dataset_id, 'verbose', 'doList : ' + dataset_id + ' :: query_params=' + util.inspect(params) + ' :: meta_data=' + util.inspect(meta_data));
 

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -232,150 +232,155 @@ function processPending(dataset_id, dataset, params, cb) {
   var cuid = syncUtil.getCuid(params);
 
   syncUtil.doLog(dataset_id, 'verbose', 'processPending :: starting async.forEachSeries');
-  async.forEachSeries(pending, function (pendingObj, itemCallback) {
-      //var pendingObj = pending[i];
-      syncUtil.doLog(dataset_id, 'silly', 'processPending :: item = ' + util.inspect(pendingObj), params);
-      var action = pendingObj.action;
-      var uid = pendingObj.uid;
-      var pre = pendingObj.pre;
-      var post = pendingObj.post;
-      var hash = pendingObj.hash;
-      var timestamp = pendingObj.timestamp;
 
-      function addUpdate(type, action, hash, uid, msg, cb) {
+  async.waterfall([
+    function getHashFunctionForPending (next) {
+      DataSetModel.getHashFunction(dataset_id, next);
+    },
+    function (hashingFunction, next) {
+      async.forEachSeries(pending, function (pendingObj, itemCallback) {
+          //var pendingObj = pending[i];
+          syncUtil.doLog(dataset_id, 'silly', 'processPending :: item = ' + util.inspect(pendingObj), params);
+          var action = pendingObj.action;
+          var uid = pendingObj.uid;
+          var pre = pendingObj.pre;
+          var post = pendingObj.post;
+          var hash = pendingObj.hash;
+          var timestamp = pendingObj.timestamp;
 
-        var update = {
-          cuid: cuid,
-          type: type,
-          action: action,
-          hash: hash,
-          uid: uid,
-          msg: util.inspect(msg)
-        };
+          function addUpdate(type, action, hash, uid, msg, cb) {
 
-        fhdb({
-          "act": "list",
-          "type": dataset_id + "-updates",
-          "eq": {
-            "cuid": cuid,
-            "type": type,
-            "action": action,
-            "hash": hash,
-            "uid": uid
-          }
-        }, function (err, found) {
-          if (err) return cb(err);
-          if (found && found.list && found.list.length > 0) {
-            syncUtil.doLog(dataset_id, 'info', 'Update is already recorded, ignore', update);
-            return cb(null, found.list[0]);
-          } else {
+            var update = {
+              cuid: cuid,
+              type: type,
+              action: action,
+              hash: hash,
+              uid: uid,
+              msg: util.inspect(msg)
+            };
+
             fhdb({
-              "act": "create",
+              "act": "list",
               "type": dataset_id + "-updates",
-              "fields": update
-            }, function (err, res) {
-              cb(err, res);
+              "eq": {
+                "cuid": cuid,
+                "type": type,
+                "action": action,
+                "hash": hash,
+                "uid": uid
+              }
+            }, function (err, found) {
+              if (err) return cb(err);
+              if (found && found.list && found.list.length > 0) {
+                syncUtil.doLog(dataset_id, 'info', 'Update is already recorded, ignore', update);
+                return cb(null, found.list[0]);
+              } else {
+                fhdb({
+                  "act": "create",
+                  "type": dataset_id + "-updates",
+                  "fields": update
+                }, function (err, res) {
+                  cb(err, res);
+                });
+              }
             });
           }
-        });
-      }
 
-      if ("create" === action) {
-        syncUtil.doLog(dataset_id, 'verbose', 'CREATE Start', params);
-        DataSetModel.doCreateHandler(dataset_id, post, function (err, data) {
-          if (err) {
-            syncUtil.doLog(dataset_id, 'warn', 'CREATE Failed - uid=' + uid + ' : err = ' + err, params);
-            return addUpdate("failed", "create", hash, uid, err, itemCallback);
-          }
-          syncUtil.doLog(dataset_id, 'info', 'CREATE Success - uid=' + data.uid + ' : hash = ' + hash, params);
-          return addUpdate("applied", "create", hash, data.uid, '', itemCallback);
-        }, meta_data);
-      }
-      else if ("update" === action) {
-        syncUtil.doLog(dataset_id, 'verbose', 'UPDATE Start', params);
-        DataSetModel.doReadHandler(dataset_id, uid, function (err, data) {
-          if (err) {
-            syncUtil.doLog(dataset_id, 'warn', 'READ for UPDATE Failed - uid=' + uid + ' : err = ' + err, params);
-            return addUpdate("failed", "update", hash, uid, err, itemCallback);
-          }
-          syncUtil.doLog(dataset_id, 'verbose', ' READ for UPDATE Success', params);
-          syncUtil.doLog(dataset_id, 'silly', 'READ for UPDATE Data : \n' + util.inspect(data), params);
-
-          var preHash = syncUtil.generateHash(pre);
-          var dataHash = syncUtil.generateHash(data);
-
-          syncUtil.doLog(dataset_id, 'verbose', 'UPDATE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
-
-          if (preHash === dataHash) {
-            DataSetModel.doUpdateHandler(dataset_id, uid, post, function (err) {
+          if ("create" === action) {
+            syncUtil.doLog(dataset_id, 'verbose', 'CREATE Start', params);
+            DataSetModel.doCreateHandler(dataset_id, post, function (err, data) {
               if (err) {
-                syncUtil.doLog(dataset_id, 'warn', 'UPDATE Failed - uid=' + uid + ' : err = ' + err, params);
+                syncUtil.doLog(dataset_id, 'warn', 'CREATE Failed - uid=' + uid + ' : err = ' + err, params);
+                return addUpdate("failed", "create", hash, uid, err, itemCallback);
+              }
+              syncUtil.doLog(dataset_id, 'info', 'CREATE Success - uid=' + data.uid + ' : hash = ' + hash, params);
+              return addUpdate("applied", "create", hash, data.uid, '', itemCallback);
+            }, meta_data);
+          }
+          else if ("update" === action) {
+            syncUtil.doLog(dataset_id, 'verbose', 'UPDATE Start', params);
+            DataSetModel.doReadHandler(dataset_id, uid, function (err, data) {
+              if (err) {
+                syncUtil.doLog(dataset_id, 'warn', 'READ for UPDATE Failed - uid=' + uid + ' : err = ' + err, params);
                 return addUpdate("failed", "update", hash, uid, err, itemCallback);
               }
-              syncUtil.doLog(dataset_id, 'info', 'UPDATE Success - uid=' + uid + ' : hash = ' + hash, params);
-              return addUpdate("applied", "update", hash, uid, '', itemCallback);
+              syncUtil.doLog(dataset_id, 'verbose', ' READ for UPDATE Success', params);
+              syncUtil.doLog(dataset_id, 'silly', 'READ for UPDATE Data : \n' + util.inspect(data), params);
+
+              var preHash = hashingFunction(pre);
+              var dataHash = hashingFunction(data);
+
+              syncUtil.doLog(dataset_id, 'verbose', 'UPDATE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
+
+              if (preHash === dataHash) {
+                DataSetModel.doUpdateHandler(dataset_id, uid, post, function (err) {
+                  if (err) {
+                    syncUtil.doLog(dataset_id, 'warn', 'UPDATE Failed - uid=' + uid + ' : err = ' + err, params);
+                    return addUpdate("failed", "update", hash, uid, err, itemCallback);
+                  }
+                  syncUtil.doLog(dataset_id, 'info', 'UPDATE Success - uid=' + uid + ' : hash = ' + hash, params);
+                  return addUpdate("applied", "update", hash, uid, '', itemCallback);
+                }, meta_data);
+              } else {
+                var postHash = hashingFunction(post);
+                if (postHash === dataHash) {
+                  // Update has already been applied
+                  syncUtil.doLog(dataset_id, 'info', 'UPDATE Already Applied - uid=' + uid + ' : hash = ' + hash, params);
+                  return addUpdate("applied", "update", hash, uid, '', itemCallback);
+                }
+                else {
+                  syncUtil.doLog(dataset_id, 'warn', 'UPDATE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)), params);
+                  DataSetModel.doCollisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
+                  return addUpdate("collisions", "update", hash, uid, '', itemCallback);
+                }
+              }
             }, meta_data);
-          } else {
-            var postHash = syncUtil.generateHash(post);
-            if (postHash === dataHash) {
-              // Update has already been applied
-              syncUtil.doLog(dataset_id, 'info', 'UPDATE Already Applied - uid=' + uid + ' : hash = ' + hash, params);
-              return addUpdate("applied", "update", hash, uid, '', itemCallback);
-            }
-            else {
-              syncUtil.doLog(dataset_id, 'warn', 'UPDATE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)), params);
-              DataSetModel.doCollisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
-              return addUpdate("collisions", "update", hash, uid, '', itemCallback);
-            }
           }
-        }, meta_data);
-      }
-      else if ("delete" === action) {
-        syncUtil.doLog(dataset_id, 'verbose', 'DELETE Start', params);
-        DataSetModel.doReadHandler(dataset_id, uid, function (err, data) {
-          if (err) {
-            syncUtil.doLog(dataset_id, 'warn', 'READ for DELETE Failed - uid=' + uid + ' : err = ' + err, params);
-            return addUpdate("failed", "delete", hash, uid, err, itemCallback);
-          }
-          syncUtil.doLog(dataset_id, 'verbose', ' READ for DELETE Success', params);
-          syncUtil.doLog(dataset_id, 'silly', ' READ for DELETE Data : \n' + util.inspect(data), params);
+          else if ("delete" === action) {
+            syncUtil.doLog(dataset_id, 'verbose', 'DELETE Start', params);
+            DataSetModel.doReadHandler(dataset_id, uid, function (err, data) {
+              if (err) {
+                syncUtil.doLog(dataset_id, 'warn', 'READ for DELETE Failed - uid=' + uid + ' : err = ' + err, params);
+                return addUpdate("failed", "delete", hash, uid, err, itemCallback);
+              }
+              syncUtil.doLog(dataset_id, 'verbose', ' READ for DELETE Success', params);
+              syncUtil.doLog(dataset_id, 'silly', ' READ for DELETE Data : \n' + util.inspect(data), params);
 
-          var preHash = syncUtil.generateHash(pre);
-          var dataHash = syncUtil.generateHash(data);
+              var preHash = hashingFunction(pre);
+              var dataHash = hashingFunction(data);
 
-          syncUtil.doLog(dataset_id, 'verbose', 'DELETE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
+              syncUtil.doLog(dataset_id, 'verbose', 'DELETE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
 
-          if (!dataHash) {
-            //record has already been deleted
-            syncUtil.doLog(dataset_id, 'info', 'DELETE Already performed - uid=' + uid + ' : hash = ' + hash, params);
-            return addUpdate("applied", "delete", hash, uid, '', itemCallback);
+              if (!dataHash) {
+                //record has already been deleted
+                syncUtil.doLog(dataset_id, 'info', 'DELETE Already performed - uid=' + uid + ' : hash = ' + hash, params);
+                return addUpdate("applied", "delete", hash, uid, '', itemCallback);
+              }
+              else {
+                if (preHash === dataHash) {
+                  DataSetModel.doDeleteHandler(dataset_id, uid, function (err) {
+                    if (err) {
+                      syncUtil.doLog(dataset_id, 'warn', 'DELETE Failed - uid=' + uid + ' : err = ' + err, params);
+                      return addUpdate("failed", "delete", hash, uid, err, itemCallback);
+                    }
+                    syncUtil.doLog(dataset_id, 'info', 'DELETE Success - uid=' + uid + ' : hash = ' + hash, params);
+                    return addUpdate("applied", "delete", hash, uid, '', itemCallback);
+                  }, meta_data);
+                } else {
+                  syncUtil.doLog(dataset_id, 'warn', 'DELETE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)), params);
+                  DataSetModel.doCollisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
+                  return addUpdate("collisions", "delete", hash, uid, '', itemCallback);
+                }
+              }
+            }, meta_data);
           }
           else {
-            if (preHash === dataHash) {
-              DataSetModel.doDeleteHandler(dataset_id, uid, function (err) {
-                if (err) {
-                  syncUtil.doLog(dataset_id, 'warn', 'DELETE Failed - uid=' + uid + ' : err = ' + err, params);
-                  return addUpdate("failed", "delete", hash, uid, err, itemCallback);
-                }
-                syncUtil.doLog(dataset_id, 'info', 'DELETE Success - uid=' + uid + ' : hash = ' + hash, params);
-                return addUpdate("applied", "delete", hash, uid, '', itemCallback);
-              }, meta_data);
-            } else {
-              syncUtil.doLog(dataset_id, 'warn', 'DELETE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)), params);
-              DataSetModel.doCollisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
-              return addUpdate("collisions", "delete", hash, uid, '', itemCallback);
-            }
+            syncUtil.doLog(dataset_id, 'warn', 'unknown action : ' + action, params);
+            itemCallback();
           }
-        }, meta_data);
-      }
-      else {
-        syncUtil.doLog(dataset_id, 'warn', 'unknown action : ' + action, params);
-        itemCallback();
-      }
-    },
-    function () {
-      return cb();
-    });
+        }, next);
+    }
+  ], cb);
 }
 
 function returnUpdates(dataset_id, params, resIn, cb) {

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -307,8 +307,8 @@ function processPending(dataset_id, dataset, params, cb) {
               syncUtil.doLog(dataset_id, 'verbose', ' READ for UPDATE Success', params);
               syncUtil.doLog(dataset_id, 'silly', 'READ for UPDATE Data : \n' + util.inspect(data), params);
 
-              var preHash = hashingFunction(pre);
-              var dataHash = hashingFunction(data);
+              var preHash = hashingFunction(pre, uid);
+              var dataHash = hashingFunction(data, uid);
 
               syncUtil.doLog(dataset_id, 'verbose', 'UPDATE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
 
@@ -322,7 +322,7 @@ function processPending(dataset_id, dataset, params, cb) {
                   return addUpdate("applied", "update", hash, uid, '', itemCallback);
                 }, meta_data);
               } else {
-                var postHash = hashingFunction(post);
+                var postHash = hashingFunction(post, uid);
                 if (postHash === dataHash) {
                   // Update has already been applied
                   syncUtil.doLog(dataset_id, 'info', 'UPDATE Already Applied - uid=' + uid + ' : hash = ' + hash, params);
@@ -346,8 +346,8 @@ function processPending(dataset_id, dataset, params, cb) {
               syncUtil.doLog(dataset_id, 'verbose', ' READ for DELETE Success', params);
               syncUtil.doLog(dataset_id, 'silly', ' READ for DELETE Data : \n' + util.inspect(data), params);
 
-              var preHash = hashingFunction(pre);
-              var dataHash = hashingFunction(data);
+              var preHash = hashingFunction(pre, uid);
+              var dataHash = hashingFunction(data, uid);
 
               syncUtil.doLog(dataset_id, 'verbose', 'DELETE Hash Check ' + uid + ' (client :: dataStore) = ' + preHash + ' :: ' + dataHash, params);
 

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -49,6 +49,7 @@ var sync = function () {
    */
   function bindHandlerSetters (instance) {
     var handlerMap = {
+      handleHash: 'hashHandler',
       handleList: 'listHandler',
       handleCreate: 'createHandler',
       handleRead: 'readHandler',
@@ -93,7 +94,8 @@ var sync = function () {
     globalListCollisions: DataSetModel.setGlobalCollisionLister.bind(null),
     globalRemoveCollision: DataSetModel.setGlobalCollisionRemover.bind(null),
     globalInterceptRequest: DataSetModel.setGlobalRequestInterceptor.bind(null),
-    globalInterceptResponse: DataSetModel.setGlobalResponseInterceptor.bind(null)
+    globalInterceptResponse: DataSetModel.setGlobalResponseInterceptor.bind(null),
+    globalHandleHash: DataSetModel.setGlobalHashHandler.bind(null)
   };
 
   // Make sure to bind custom handler setters

--- a/lib/sync-util.js
+++ b/lib/sync-util.js
@@ -6,7 +6,7 @@ var assert = require('assert');
 var SYNC_LOGGER = 'SYNC';
 var loggers = {};
 
-var generateHash = function (plainText) {
+var generateHash = function (plainText/*, recordId */) {
   var hash;
   if (plainText) {
     if ('string' !== typeof plainText) {

--- a/test/test_sync_datasetmodel.js
+++ b/test/test_sync_datasetmodel.js
@@ -71,7 +71,10 @@ var tests = {
 
     var expectedHash = '1234567890';
 
-    function hasher (/* record */) {
+    function hasher (rec, uid) {
+      expect(rec).to.be.an('object');
+      expect(uid).to.be.a('string');
+
       // Obviously a terrible idea...
       return expectedHash;
     }
@@ -107,9 +110,9 @@ var tests = {
       }
     };
 
-    function hasher (record) {
+    function hasher (record, uid) {
       // Obviously a terrible idea, but proves the concept
-      return JSON.stringify(record);
+      return JSON.stringify(record) + uid;
     }
 
     mod.setGlobalHashHandler(hasher);
@@ -120,11 +123,11 @@ var tests = {
       expect(res.records).to.deep.equal({
         rec1: {
           data: records.rec1,
-          hash: hasher(records.rec1) // should match generated hash if our handler was used
+          hash: hasher(records.rec1, 'rec1') // should match generated hash if our handler was used
         },
         rec2: {
           data: records.rec2,
-          hash: hasher(records.rec2) // should match generated hash if our handler was used
+          hash: hasher(records.rec2, 'rec2') // should match generated hash if our handler was used
         }
       });
     });

--- a/test/test_sync_datasetmodel.js
+++ b/test/test_sync_datasetmodel.js
@@ -13,7 +13,8 @@ var map = {
   'setGlobalCollisionLister': 'globalCollisionLister',
   'setGlobalCollisionRemover': 'globalCollisionRemover',
   'setGlobalRequestInterceptor': 'globalRequestInterceptor',
-  'setGlobalResponseInterceptor': 'globalResponseInterceptor'
+  'setGlobalResponseInterceptor': 'globalResponseInterceptor',
+  'setGlobalHashHandler': 'globalHashHandler'
 };
 
 var tests = {
@@ -34,12 +35,105 @@ var tests = {
       expect(customInterceptor.called).to.be.true;
       done();
     });
+  },
+
+  'should use the default hash handler': function () {
+    var records = {
+      'rec1': {
+        name: 'fh.sync'
+      },
+      'rec2': {
+        name: 'fh.cloud'
+      }
+    };
+
+    mod.generateRecordHashes('dataset_name', records, function (err, res) {
+      expect(err).to.be.null;
+      expect(res.hash).to.be.a('string');
+
+      expect(res.records.rec1.data.name).to.equal(records.rec1.name);
+      expect(res.records.rec1.hash).to.be.a('string');
+
+      expect(res.records.rec2.data.name).to.equal(records.rec2.name);
+      expect(res.records.rec2.hash).to.be.a('string');
+    });
+  },
+
+  'should use dataset specific hash handler': function () {
+    var records = {
+      'rec1': {
+        name: 'fh.sync'
+      },
+      'rec2': {
+        name: 'fh.cloud'
+      }
+    };
+
+    var expectedHash = '1234567890';
+
+    function hasher (/* record */) {
+      // Obviously a terrible idea...
+      return expectedHash;
+    }
+
+    mod.getDataset('dataset_name', function (err, dataset) {
+      // mimic setting the handler via sync api
+      dataset.hashHandler = hasher;
+
+      mod.generateRecordHashes('dataset_name', records, function (err, res) {
+        expect(err).to.be.null;
+        expect(res.hash).to.be.a('string');
+        expect(res.records).to.deep.equal({
+          rec1: {
+            data: records.rec1,
+            hash: expectedHash
+          },
+          rec2: {
+            data: records.rec2,
+            hash: expectedHash
+          }
+        });
+      });
+    });
+  },
+
+  'should return a global hash, and individual hashes using "globalHashHandler"': function () {
+    var records = {
+      'rec1': {
+        name: 'fh.sync'
+      },
+      'rec2': {
+        name: 'fh.cloud'
+      }
+    };
+
+    function hasher (record) {
+      // Obviously a terrible idea, but proves the concept
+      return JSON.stringify(record);
+    }
+
+    mod.setGlobalHashHandler(hasher);
+
+    mod.generateRecordHashes('dataset_name', records, function (err, res) {
+      expect(err).to.be.null;
+      expect(res.hash).to.be.a('string');
+      expect(res.records).to.deep.equal({
+        rec1: {
+          data: records.rec1,
+          hash: hasher(records.rec1) // should match generated hash if our handler was used
+        },
+        rec2: {
+          data: records.rec2,
+          hash: hasher(records.rec2) // should match generated hash if our handler was used
+        }
+      });
+    });
   }
 };
 
 Object.keys(map).forEach(function (fnName) {
   var handlerTests = {}
-  
+
   handlerTests['should throw an AssertionError due invalid argument'] = function () {
     expect(function () {
       mod[fnName](null)
@@ -55,7 +149,7 @@ Object.keys(map).forEach(function (fnName) {
     }).to.not.throw();
   }
 
-  tests['#' + fnName] = handlerTests;  
+  tests['#' + fnName] = handlerTests;
 });
 
 module.exports = tests;

--- a/test/test_sync_handlers.js
+++ b/test/test_sync_handlers.js
@@ -43,7 +43,8 @@ module.exports = {
       setGlobalCollisionLister: sinon.spy(),
       setGlobalCollisionRemover: sinon.spy(),
       setGlobalRequestInterceptor: sinon.spy(),
-      setGlobalResponseInterceptor: sinon.spy()
+      setGlobalResponseInterceptor: sinon.spy(),
+      setGlobalHashHandler: sinon.spy()
     };
 
     // Creates a new sync instance


### PR DESCRIPTION
The idea behind this PR is that our default sync hashing is extremely robust and reliable, but the tradeoff is that it's expensive. This is due to the fact it recursively traverses an entire object, sorts the properties in each sub object/array, stringifies them, and then computes a hash using the sorted objects.

This expensive algorithm is not always necessary. For example, we might have a dataset that contains records like so:

```js
// Note Schema
{
  uid: String
  updateTs: Date,
  updateCount: Number
  title: String,
  content: String,
  meta: {
    // Could be many of these
    [key]: Object
  }
}
```

In this case instead of hashing the entire object we could simply hash the `uid+ updateTs.toString() + updateCount` or similar since each time a Note is updated/modified we would change these.

I tested locally the time it would take to complete the hashing for 500 `list` calls to the sync and found the following:

* Current Sync Hashing: 1259ms
* Custom Sync Hashing: 115ms

The test used node v4.4.3 and a ~90K piece of production JSON. I've seen the production JSON can go up to 250K but thought ~90K was a nice middle ground.

We have to support around 2000 users syncing 4 collections so this could make a real difference to throughput.