### PR TITLE
[WIP] FH-3121 Integrate sync-acceptance-testing into Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+services: mongodb
 node_js:
   - "0.10"
   - "4.4.3"
@@ -10,3 +11,20 @@ before_install:
   - npm install -g grunt-cli
   - npm config set strict-ssl false
 install: npm install
+
+matrix:
+  # The acceptance tests only work with node 4 or higher.
+  exclude:
+  # Remove the original job for node 4.4.3, without the acceptance tests.
+  - node_js: "4.4.3"
+  include:
+  # Include an updated job, with the acceptance tests. This way we're not
+  # running the 4.4.3 build twice with one build including acceptance tests.
+  - node_js: "4.4.3"
+    script:
+      - npm link
+      - git clone https://github.com/feedhenry/sync-acceptance-testing.git
+      - cd sync-acceptance-testing
+      - npm install
+      - npm link fh-mbaas-api
+      - npm test


### PR DESCRIPTION
Currently the acceptance testing for the sync part of the
fh-mbaas-api is completely separate and would be required to be
executed separately to other tests.

This adds the acceptance tests to be executed in the Travis build.