### PR TITLE
FH-3171 Add hash provider for sync

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,8 @@ module.exports = function(grunt) {
     './test/sync/test_sync-processor.js',
     './test/sync/test_sync-scheduler.js',
     './test/sync/test_ack-processor.js',
-    './test/sync/test_pending-processor.js'
+    './test/sync/test_pending-processor.js',
+    './test/sync/test_hashProvider.js'
   ];
   var unit_args = _.map(tests, makeTestArgs);
   var test_runner = '_mocha';

--- a/lib/sync/hashProvider.js
+++ b/lib/sync/hashProvider.js
@@ -1,18 +1,89 @@
-module.exports = function() {
-  return {
-    /**
-     * @param datasetId
-     * @param record
-     */
-    recordHash: function() {
-      //TODO: implement this
-    },
-    /**
-     * @param datasetId
-     * @param hashesArrayOfAllRecords
-     */
-    globalHash: function() {
-      //TODO: implement this
-    }
-  };
+var syncUtil = require('./util');
+
+/**
+ * Store for the overridden hashing functions for each dataset.
+ */
+var overrides = {
+  record: {},
+  global: {}
+}
+
+/**
+ * Set the default hashing algorithm.
+ */
+var defaultHashFn = syncUtil.generateHash;
+
+/**
+ * Invoke the datasets record hash function on a record
+ * @param {String} datasetId the id of the dataset
+ * @param {Object} record record in the dataset to hash
+ * @returns {String} the resulting record hash
+ */
+function recordHash(datasetId, record) {
+  return getRecordHashFn(datasetId)(record);
+}
+
+/**
+ * Invoke the datasets global hash function on an array of hashes
+ * @param {String} datasetId the id of the dataset
+ * @param {String[]} hashes array of record hashes in the dataset
+ * @returns {String} the resulting global hash
+ */
+function globalHash(datasetId, hashes) {
+  return getGlobalHashFn(datasetId)(hashes);
+}
+
+/**
+ * Set the current record hash function for the dataset.
+ * @param {String} datasetId the id of the dataset
+ * @param {Function} hashFn the function to override
+ */
+function setRecordHashFn(datasetId, hashFn) {
+  overrides.record[datasetId] = hashFn;
+}
+
+/**
+ * Set the current global hash function for the dataset.
+ * @param {String} datasetId the id of the dataset
+ * @param {Function} hashFn the function to override
+ */
+function setGlobalHashFn(datasetId, hashFn) {
+  overrides.global[datasetId] = hashFn;
+}
+
+/**
+ * Get the current record hash function for the dataset
+ * @param {String} datasetId the id of the dataset
+ * @returns {String} the resulting hash
+ * @returns {Function} the record hashing function for the specified dataset
+ */
+function getRecordHashFn(datasetId) {
+  return overrides.record[datasetId] || defaultHashFn;
+}
+
+/**
+ * Get the current global hash function for the dataset
+ * @param {String} datasetId the id of the dataset
+ * @returns {Function} the global hashing function for the specified dataset
+ */
+function getGlobalHashFn(datasetId) {
+  return overrides.global[datasetId] || defaultHashFn;
+}
+
+/**
+ * Get the default hashing function for sync
+ * @returns {Function} the default hashing function
+ */
+function getDefaultHashFn() {
+  return defaultHashFn;
+}
+
+module.exports = {
+  recordHash: recordHash,
+  globalHash: globalHash,
+  getRecordHashFn: getRecordHashFn,
+  setRecordHashFn: setRecordHashFn,
+  getGlobalHashFn: getGlobalHashFn,
+  setGlobalHashFn: setGlobalHashFn,
+  getDefaultHashFn: getDefaultHashFn
 };

--- a/test/sync/test_hashProvider.js
+++ b/test/sync/test_hashProvider.js
@@ -1,0 +1,56 @@
+var assert = require('assert');
+var hashProvider = require('../../lib/sync/hashProvider');
+
+var defaultHashFn = hashProvider.getDefaultHashFn();
+
+var testRecord = { test: 'test' };
+var testRecordDefaultHash = '2cf4bac104e148d1541885ddd9cec7ab530f4ccf';
+var testHashes = ['test', 'sync', 'hash'];
+
+var notOverriddenDataset = 'not_overridden';
+var overriddenDataset = 'overridden';
+
+function recordHashOverride(record) {
+  return record;
+}
+
+function globalHashOverride(hashes) {
+  return hashes.join('');
+}
+
+module.exports = {
+  'test default record hash provider': function() {
+    var hashFn = hashProvider.getRecordHashFn(overriddenDataset);
+    assert.equal(hashFn, defaultHashFn);
+
+    var hash = hashProvider.recordHash(notOverriddenDataset, testRecord);
+    assert.equal(hash, testRecordDefaultHash);
+  },
+
+  'test default global hash provider': function() {
+    var hashFn = hashProvider.getRecordHashFn(overriddenDataset);
+    assert.equal(hashFn, defaultHashFn);
+
+    var hash = hashProvider.globalHash(notOverriddenDataset, testRecord);
+    assert.equal(hash, testRecordDefaultHash);
+  },
+
+  'test overridden record hash provider': function() {
+    hashProvider.setRecordHashFn(overriddenDataset, recordHashOverride);
+    var hashFn = hashProvider.getRecordHashFn(overriddenDataset);
+    assert.equal(hashFn, recordHashOverride);
+
+    var hash = hashProvider.recordHash(overriddenDataset, testRecord);
+    assert.equal(hash, testRecord);
+  },
+
+  'test overridden global hash provider': function() {
+    hashProvider.setGlobalHashFn(overriddenDataset, globalHashOverride);
+    var hashFn = hashProvider.getGlobalHashFn(overriddenDataset);
+    assert.equal(hashFn, globalHashOverride);
+
+    var hash = hashProvider.globalHash(overriddenDataset, testHashes);
+    var expectedHash = globalHashOverride(testHashes);
+    assert.equal(hash, expectedHash);
+  }
+};


### PR DESCRIPTION
Adds a module that allows for the hashing algorithm used for each
dataset to be overridden. For each dataset there is a `recordHash`
and a `globalHash` function. 

The `recordHash` function deals with
the hashing of single records in a dataset. This can be overridden
by calling `setRecordHash` and passing in the ID of the dataset.

The `globalHash` function deals with hashing for an entire dataset,
it accepts an array of record hashes and uses these to calculate
a hash for the entire dataset. This can be overridden in a similar
way to the record hash.