### PR TITLE
implement dataHandler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,8 @@ module.exports = function(grunt) {
     './test/sync/test_ack-processor.js',
     './test/sync/test_pending-processor.js',
     './test/sync/test_hashProvider.js',
-    './test/sync/test_api-sync.js'
+    './test/sync/test_api-sync.js',
+    './test/sync/test_dataHandlers.js'
   ];
   var unit_args = _.map(tests, makeTestArgs);
   var test_runner = '_mocha';

--- a/lib/sync/dataHandlers.js
+++ b/lib/sync/dataHandlers.js
@@ -1,13 +1,84 @@
-module.exports = function(){
+module.exports = function(options) {
+
+  if (!options || options.defaultHandlers === undefined) {
+    throw new Error('Default handlers were not passed in options.');
+  }
+
+  var names = {
+    LIST: 'listHandler',
+    CREATE: 'createHandler',
+    READ: 'readHandler',
+    UPDATE: 'updateHandler',
+    DELETE: 'deleteHandler',
+    COLLISION: 'collisionHandler'
+  }
+  var handlers = {};
+
   return {
+
+    /**
+     * Sets a custom list handler for the passed-in dataset
+     * @param datasetId
+     * @param handler
+     */
+    listHandler: function(datasetId, handler) {
+      setHandler(datasetId, names.LIST, handler);
+    },
+
+    /**
+     * Sets a custom create handler for the passed-in dataset
+     * @param datasetId
+     * @param handler
+     */
+    createHandler: function(datasetId, handler) {
+      setHandler(datasetId, names.CREATE, handler);
+    },
+
+    /**
+     * Sets a custom read handler for the passed-in dataset
+     * @param datasetId
+     * @param handler
+     */
+    readHandler: function(datasetId, handler) {
+      setHandler(datasetId, names.READ, handler);
+    },
+
+    /**
+     * Sets a custom update handler for the passed-in dataset
+     * @param datasetId
+     * @param handler
+     */
+    updateHandler: function(datasetId, handler) {
+      setHandler(datasetId, names.UPDATE, handler);
+    },
+
+    /**
+     * Sets a custom delete handler for the passed-in dataset
+     * @param datasetId
+     * @param handler
+     */
+    deleteHandler: function(datasetId, handler) {
+      setHandler(datasetId, names.DELETE, handler);
+    },
+
+    /**
+     * Sets a custom collision handler for the passed-in dataset
+     * @param datasetId
+     * @param handler
+     */
+    collisionHandler: function(datasetId, handler) {
+      setHandler(datasetId, names.COLLISION, handler);
+    },
+
     /**
      * @param datasetId
      * @param queryParams
      * @param metaData
      * @param callback
      */
-    doList: function(){
-      //TODO: implement this function
+    doList: function(datasetId, queryParams, metaData, callback) {
+      var handler = handlerFor(datasetId, names.LIST);
+      handler(datasetId, queryParams, metaData, callback);
     },
 
     /**
@@ -16,8 +87,9 @@ module.exports = function(){
      * @param metaData
      * @param callback
      */
-    doCreate: function() {
-
+    doCreate: function(datasetId, queryParams, metaData, callback) {
+      var handler = handlerFor(datasetId, names.CREATE);
+      handler(datasetId, queryParams, metaData, callback);
     },
 
     /**
@@ -26,8 +98,9 @@ module.exports = function(){
      * @param metaData
      * @param callback
      */
-    doRead: function() {
-
+    doRead: function(datasetId, uid, metaData, callback) {
+      var handler = handlerFor(datasetId, names.READ);
+      handler(datasetId, uid, metaData, callback);
     },
 
     /**
@@ -37,8 +110,9 @@ module.exports = function(){
      * @param metaData
      * @param callback
      */
-    doUpdate: function() {
-
+    doUpdate: function(datasetId, uid, record, metaData, callback) {
+      var handler = handlerFor(datasetId, names.UPDATE);
+      handler(datasetId, uid, record, metaData, callback);
     },
 
     /**
@@ -47,17 +121,47 @@ module.exports = function(){
      * @param metaData
      * @param callback
      */
-    doDelete: function() {
-
+    doDelete: function(datasetId, uid, metaData, callback) {
+      var handler = handlerFor(datasetId, names.DELETE);
+      handler(datasetId, uid, metaData, callback);
     },
 
     /**
      * @param datasetId
      * @param metaData
-     * @param collision fields
+     * @param collisionFields
      */
-    handleCollision: function() {
-
+    handleCollision: function(datasetId, metaData, collisionFields, callback){
+      var handler = handlerFor(datasetId, names.COLLISION);
+      handler(datasetId, metaData, collisionFields, callback);
     }
   };
+
+  function Handler(defaultHandlers) {
+    this.listHandler = defaultHandlers.listHandler;
+    this.createHandler = defaultHandlers.createHandler;
+    this.readHandler = defaultHandlers.readHandler;
+    this.updateHandler = defaultHandlers.updateHandler;
+    this.deleteHandler = defaultHandlers.deleteHandler;
+    this.collisionHandler = defaultHandlers.collisionHandler;
+  }
+
+  function setHandler(datasetId, handlerName, handler) {
+    var handlers = handlersFor(datasetId);
+    handlers[handlerName] = handler;
+  }
+
+  function handlerFor(datasetId, handlerName) {
+    return handlersFor(datasetId)[handlerName];
+  }
+
+  function handlersFor(datasetId) {
+    var handler = handlers[datasetId];
+    if (!handler) {
+      handler = new Handler(options.defaultHandlers);
+      handlers[datasetId] = handler;
+    }
+    return handler;
+  }
+
 };

--- a/test/sync/test_dataHandlers.js
+++ b/test/sync/test_dataHandlers.js
@@ -1,0 +1,161 @@
+var assert = require('assert');
+var sinon = require('sinon');
+var dataHandlersModule = require('../../lib/sync/dataHandlers.js');
+
+var id = 'datahandlers_test';
+var queryParams = {};
+var metaData = {};
+
+var defaultHandlers = {
+  listHandler: sinon.stub().yields(),
+  createHandler: sinon.stub().yields(),
+  readHandler: sinon.stub().yields(),
+  updateHandler: sinon.stub().yields(),
+  deleteHandler: sinon.stub().yields(),
+  collisionHandler: sinon.stub().yields(),
+}
+
+module.exports = {
+
+  'test no options passed to module should throw error': function(done) {
+    verifyMissingOptions(undefined, done);
+  },
+
+  'test no defaultHandlers passed to module should throw error': function(done) {
+    verifyMissingOptions({}, done);
+  },
+
+  'test set custom listHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.listHandler(id, function (datasetId, queryparams, metadata, cb) {
+      cb(null, 'dummy record');
+    });
+
+    dataHandlers.doList(id, queryParams, metaData, function(err, records) {
+      assert.ok(!err);
+      assert.equal(records, 'dummy record');
+      done();
+    });
+  },
+
+  'test set custom createHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.createHandler(id, function (datasetId, queryparams, metadata, cb) {
+      cb(null, 'dummy data');
+    });
+
+    dataHandlers.doCreate(id, queryParams, metaData, function(err, data) {
+      assert.ok(!err);
+      assert.equal(data, 'dummy data');
+      done();
+    });
+  },
+
+  'test set custom readHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.readHandler(id, function (datasetId, uid, metadata, cb) {
+      cb(null, 'dummy data');
+    });
+
+    dataHandlers.doRead(id, '123', metaData, function(err, data) {
+      assert.ok(!err);
+      assert.equal(data, 'dummy data');
+      done();
+    });
+  },
+
+  'test set custom updateHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.updateHandler(id, function (datasetId, uid, record, metadata, cb) {
+      cb(null);
+    });
+
+    dataHandlers.doUpdate(id, '123', 'record', metaData, function(err) {
+      assert.ok(!err);
+      done();
+    });
+  },
+
+  'test set custom deleteHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.deleteHandler(id, function (datasetId, uid, metadata, cb) {
+      cb(null);
+    });
+
+    dataHandlers.doDelete(id, '123', metaData, function(err) {
+      assert.ok(!err);
+      done();
+    });
+  },
+
+  'test set custom collisionHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.collisionHandler(id, function (datasetId, metadata, collisionFields, cb) {
+      cb(null);
+    });
+
+    dataHandlers.handleCollision(id, metaData, [], function(err) {
+      assert.ok(!err);
+      done();
+    });
+  },
+
+  'test set default listHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.doList(id, queryParams, metaData, function(err, records) {
+      assert.ok(defaultHandlers.listHandler.called);
+      done();
+    });
+  },
+
+  'test set default createHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.doCreate(id, queryParams, metaData, function(err, records) {
+      assert.ok(defaultHandlers.createHandler.called);
+      done();
+    });
+  },
+
+  'test set default readHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.doRead(id, '123', metaData, function(err, records) {
+      assert.ok(defaultHandlers.readHandler.called);
+      done();
+    });
+  },
+
+  'test set default updateHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.doUpdate(id, '123', 'pendingChange', metaData, function(err) {
+      assert.ok(defaultHandlers.updateHandler.called);
+      done();
+    });
+  },
+
+  'test set default deleteHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.doDelete(id, '123', metaData, function(err) {
+      assert.ok(defaultHandlers.deleteHandler.called);
+      done();
+    });
+  },
+
+  'test set default collisionHandler': function(done) {
+    var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
+    dataHandlers.handleCollision(id, metaData, [],  function(err) {
+      assert.ok(defaultHandlers.collisionHandler.called);
+      done();
+    });
+  }
+
+};
+
+function verifyMissingOptions(options, done) {
+    assert.throws(function() {
+      dataHandlersModule(options);
+    }, function(err) {
+      assert.equal(err.message, 'Default handlers were not passed in options.');
+      done();
+      return true;
+    });
+}


### PR DESCRIPTION
Motivation:
Implement the datahandlers so that each dataset can have it's own
datahandler for list/create/read/update/delete/collision.

JIRA:
https://issues.jboss.org/browse/FH-3170