### PR TITLE
add implementation for default dataHandler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,7 +41,8 @@ module.exports = function(grunt) {
     './test/sync/test_hashProvider.js',
     './test/sync/test_api-sync.js',
     './test/sync/test_dataHandlers.js',
-    './test/sync/test_api-syncRecords.js'
+    './test/sync/test_api-syncRecords.js',
+    './test/sync/test_default-dataHandlers.js',
   ];
   var unit_args = _.map(tests, makeTestArgs);
   var test_runner = '_mocha';

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -20,13 +20,7 @@ module.exports = function (db) {
         if (err) {
           return cb(err);
         }
-        var data = {};
-        array.forEach(function extractUidAndData(value) {
-          var uid = value._id;
-          delete value._id;
-          data[uid] = value;
-        });
-        cb(null, data);
+        cb(null, toObject(array));
       });
     },
 
@@ -71,14 +65,24 @@ module.exports = function (db) {
                      'doCollision : ' + dataset_id +
                      ' :: collisionFields=' + util.inspect(collisionFields) +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(collisionCollection(dataset_id)).insertOne(collisionFields, cb);
+      mongo.collection(collisionCollection(dataset_id)).insertOne(collisionFields, function(err, res) {
+        if (err) {
+          return cb(err);
+        }
+        cb(null, makeResponse(res.ops[0]));
+      });
     },
 
     listCollisions: function (dataset_id, meta_data, cb) {
       syncUtil.doLog(dataset_id, 'verbose',
                      'listCollisions : ' + dataset_id +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(collisionCollection(dataset_id)).find().toArray(cb);
+      mongo.collection(collisionCollection(dataset_id)).find().toArray(function (err, array) {
+        if (err) {
+          return cb(err);
+        }
+        cb(null, toObject(array));
+      });
     },
 
     removeCollision: function (dataset_id, uid, meta_data, cb) {
@@ -92,6 +96,17 @@ module.exports = function (db) {
   };
 
 };
+
+function toObject(array) {
+  var data = {};
+  array.forEach(function extractUidAndData(value) {
+    var uid = value._id;
+    delete value._id;
+    data[uid] = value;
+  });
+  return data;
+}
+
 
 function makeResponse(res) {
   var data = {

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -23,7 +23,12 @@ module.exports = function (db) {
       syncUtil.doLog(dataset_id, 'verbose',
                      'doCreate : ' + dataset_id + ' :: ' + util.inspect(data) +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(dataset_id).insertOne(data, cb);
+      mongo.collection(dataset_id).insertOne(data, function(err, res) {
+        if (err) {
+          return cb(err);
+        }
+        cb(null, makeResponse(res.ops[0]));
+      });
     },
 
     doRead: function (dataset_id, uid, meta_data, cb) {
@@ -76,6 +81,16 @@ module.exports = function (db) {
   };
 
 };
+
+function makeResponse(res) {
+  var uid = res._id;
+  var data = {
+    uid: res._id,
+    data: res
+  };
+  delete res._id;
+  return data;
+}
 
 function collisionCollection(dataset_id) {
   return dataset_id + '_collision';

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -1,7 +1,6 @@
 var syncUtil = require('../sync-util');
 var util = require('util');
 
-var COLL_POSTFIX = '_collision';
 var mongo;
 
 module.exports = function (db) {
@@ -56,14 +55,14 @@ module.exports = function (db) {
                      'doCollision : ' + dataset_id +
                      ' :: collisionFields=' + util.inspect(collisionFields) +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(dataset_id + COLL_POSTFIX).insertOne(collisionFields, cb);
+      mongo.collection(collisionCollection(dataset_id)).insertOne(collisionFields, cb);
     },
 
     listCollisions: function (dataset_id, meta_data, cb) {
       syncUtil.doLog(dataset_id, 'verbose',
                      'listCollisions : ' + dataset_id +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(dataset_id + COLL_POSTFIX).find().toArray(cb);
+      mongo.collection(collisionCollection(dataset_id)).find().toArray(cb);
     },
 
     removeCollision: function (dataset_id, uid, meta_data, cb) {
@@ -71,9 +70,13 @@ module.exports = function (db) {
                      'removeCollision : ' + dataset_id +
                      ' :: uid=' + uid +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(dataset_id + COLL_POSTFIX).remove({"_id" : uid}, cb);
+      mongo.collection(collisionCollection(dataset_id)).remove({"_id" : uid}, cb);
     }
 
   };
 
 };
+
+function collisionCollection(dataset_id) {
+  return dataset_id + '_collision';
+}

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -1,0 +1,80 @@
+var syncUtil = require('../sync-util');
+var util = require('util');
+var _ = require('underscore');
+
+var COLL_POSTFIX = '_collision';
+var mongo;
+
+module.exports = function (db) {
+
+  if (!db) {
+    throw new Error('MongoDB instance must be passed to module.');
+  }
+  mongo = db
+
+  return {
+    doList: function (dataset_id, params, meta_data, cb) {
+      syncUtil.doLog(dataset_id, 'verbose',
+                     'doList : ' + dataset_id +
+                     ' :: query_params=' + util.inspect(params) +
+                     ' :: meta_data=' + util.inspect(meta_data));
+      mongo.collection(dataset_id).find(params).toArray(cb);
+    },
+
+    doCreate: function (dataset_id, data, meta_data, cb) {
+      syncUtil.doLog(dataset_id, 'verbose',
+                     'doCreate : ' + dataset_id + ' :: ' + util.inspect(data) +
+                     ' :: meta=' + util.inspect(meta_data));
+      mongo.collection(dataset_id).insertOne(data, cb);
+    },
+
+    doRead: function (dataset_id, uid, meta_data, cb) {
+      syncUtil.doLog(dataset_id, 'verbose',
+                     'doRead : ' + dataset_id +
+                      ' :: ' + uid +
+                      ' :: meta=' + util.inspect(meta_data));
+      mongo.collection(dataset_id).findOne({"_id" : uid}, cb);
+    },
+
+    doUpdate: function (dataset_id, uid, data, meta_data, cb) {
+      syncUtil.doLog(dataset_id, 'verbose',
+                     'doUpdate : ' + dataset_id +
+                     ' :: ' + uid + ' :: ' + util.inspect(data) +
+                     ' :: meta=' + util.inspect(meta_data));
+      mongo.collection(dataset_id).update({"_id" : uid}, data, cb);
+    },
+
+    doDelete: function (dataset_id, uid, meta_data, cb) {
+      syncUtil.doLog(dataset_id, 'verbose',
+                     'doDelete : ' + dataset_id +
+                     ' :: ' + uid +
+                     ' :: meta=' + util.inspect(meta_data));
+      mongo.collection(dataset_id).remove({"_id" : uid}, cb);
+    },
+
+    handleCollision: function (dataset_id, meta_data, collisionFields, cb) {
+      syncUtil.doLog(dataset_id, 'verbose',
+                     'doCollision : ' + dataset_id +
+                     ' :: collisionFields=' + util.inspect(collisionFields) +
+                     ' :: meta=' + util.inspect(meta_data));
+      mongo.collection(dataset_id + COLL_POSTFIX).insertOne(collisionFields, cb);
+    },
+
+    listCollisions: function (dataset_id, meta_data, cb) {
+      syncUtil.doLog(dataset_id, 'verbose',
+                     'listCollisions : ' + dataset_id +
+                     ' :: meta=' + util.inspect(meta_data));
+      mongo.collection(dataset_id + COLL_POSTFIX).find().toArray(cb);
+    },
+
+    removeCollision: function (dataset_id, uid, meta_data, cb) {
+      syncUtil.doLog(dataset_id, 'verbose',
+                     'removeCollision : ' + dataset_id +
+                     ' :: uid=' + uid +
+                     ' :: meta=' + util.inspect(meta_data));
+      mongo.collection(dataset_id + COLL_POSTFIX).remove({"_id" : uid}, cb);
+    }
+
+  };
+
+};

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -16,7 +16,18 @@ module.exports = function (db) {
                      'doList : ' + dataset_id +
                      ' :: query_params=' + util.inspect(params) +
                      ' :: meta_data=' + util.inspect(meta_data));
-      mongo.collection(dataset_id).find(params).toArray(cb);
+      mongo.collection(dataset_id).find(params).toArray(function (err, array) {
+        if (err) {
+          return cb(err);
+        }
+        var data = {};
+        array.forEach(function extractUidAndData(value) {
+          var uid = value._id;
+          delete value._id;
+          data[uid] = value;
+        });
+        cb(null, data);
+      });
     },
 
     doCreate: function (dataset_id, data, meta_data, cb) {
@@ -83,7 +94,6 @@ module.exports = function (db) {
 };
 
 function makeResponse(res) {
-  var uid = res._id;
   var data = {
     uid: res._id,
     data: res

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -40,7 +40,7 @@ module.exports = function (db) {
                      'doUpdate : ' + dataset_id +
                      ' :: ' + uid + ' :: ' + util.inspect(data) +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(dataset_id).update({"_id" : uid}, data, cb);
+      mongo.collection(dataset_id).updateOne({"_id" : uid}, data, cb);
     },
 
     doDelete: function (dataset_id, uid, meta_data, cb) {

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -1,6 +1,5 @@
 var syncUtil = require('../sync-util');
 var util = require('util');
-var _ = require('underscore');
 
 var COLL_POSTFIX = '_collision';
 var mongo;

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -7,6 +7,7 @@ var metricsModule = require('./sync-metrics');
 var MongodbQueue = require('./mongodbQueue');
 var Worker = require('./worker');
 var dataHandlersModule = require('./dataHandlers');
+var defaultDataHandlersModule = require('./default-dataHandlers');
 var storageModule = require('./storage');
 var hashProviderModule = require('./hashProvider');
 var ackProcessor = require('./ack-processor');
@@ -185,7 +186,9 @@ function start(cb) {
     return cb('MongoDB Client & Redis Client are not connected. Ensure connect() is called before calling start');
   }
 
-  dataHandlers = dataHandlersModule();
+  dataHandlers = dataHandlersModule(options = {
+    defaultHandlers: defaultDataHandlersModule(db)
+  });
   syncStorage = storageModule();
   hashProvider = hashProviderModule();
   syncLock = syncLockModule();

--- a/test/sync/test_default-dataHandlers.js
+++ b/test/sync/test_default-dataHandlers.js
@@ -1,0 +1,178 @@
+var assert = require('assert');
+var sinon = require('sinon');
+var defaultDataHandlersModule = require('../../lib/sync/default-dataHandlers.js');
+
+var id = 'datahandler_test';
+var queryParams = {};
+var metaData = {};
+
+// stubs when there is no real MongoDB
+var collectionStub = {
+  insertOne: sinon.stub().callsArgWith(1, null, {
+    result: { ok: 1, n: 1},
+    connection: null,
+    insertedCount: 1,
+    insertedId: '58b3d9efde2810043a0ac99d'}),
+  find: sinon.stub().returns({
+    toArray: sinon.stub().callsArgWith(0, null, [{
+      "_id": '58b3d9efde2810043a0ac99d'}]),
+  }),
+  findOne: sinon.stub().callsArgWith(1, null, {
+    "_id": '58b3d9efde2810043a0ac99d'
+  }),
+  update: sinon.stub().callsArgWith(2, null),
+  remove: sinon.stub().callsArgWith(1, null, {
+    result: { ok: 1, n: 1}
+  }),
+  drop: sinon.stub()
+};
+var dbStub = {
+  collection: sinon.stub().withArgs(id).returns(collectionStub)
+};
+
+var url = 'mongodb://localhost:27017/dataHandlersTest';
+var MongoClient = require('mongodb').MongoClient;
+
+module.exports = {
+
+  'test defaultDataHandlers module constructor': function(done) {
+    assert.throws(function() {
+      defaultDataHandlersModule();
+    }, function(err) {
+      assert.equal(err.message, 'MongoDB instance must be passed to module.');
+      done();
+      return true;
+    });
+  },
+
+  'test doCreate': function(done) {
+    MongoClient.connect(url, function(err, db) {
+      db = err ? dbStub : db;
+      var dataHandlers = defaultDataHandlersModule(db);
+      dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
+        assert.ok(!err);
+        assert.equal(res.result.ok, 1);
+        assert.equal(res.insertedCount, 1);
+        assert.ok(res.insertedId);
+        db.collection(id).drop();
+        done();
+      });
+    });
+  },
+
+  'test doList': function(done) {
+    const that = this;
+    MongoClient.connect(url, function(err, db) {
+      db = err ? dbStub : db;
+      var dataHandlers = defaultDataHandlersModule(db);
+      dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
+        var uid = res.insertedId;
+        dataHandlers.doList(id, queryParams, metaData, function(err, res) {
+          assert.ok(!err);
+          assert.ok(res[0]);
+          db.collection(id).drop();
+          done();
+        });
+      });
+    });
+  },
+
+  'test doRead': function(done) {
+    const that = this;
+    MongoClient.connect(url, function(err, db) {
+      db = err ? dbStub : db;
+      var dataHandlers = defaultDataHandlersModule(db);
+      dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
+        var uid = res.insertedId;
+        dataHandlers.doRead(id, uid, metaData, function(err, res) {
+          assert.ok(!err);
+          assert.ok(res._id);
+          db.collection(id).drop();
+          done();
+        });
+      });
+    });
+  },
+
+  'test doUpdate': function(done) {
+    const that = this;
+    MongoClient.connect(url, function(err, db) {
+      db = err ? dbStub : db;
+      var dataHandlers = defaultDataHandlersModule(db);
+      dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
+        var uid = res.insertedId;
+        dataHandlers.doUpdate(id, uid, {name: "Doe"}, metaData, function(err) {
+          assert.ok(!err);
+          db.collection(id).drop();
+          done();
+        });
+      });
+    });
+  },
+
+  'test doDelete': function(done) {
+    const that = this;
+    MongoClient.connect(url, function(err, db) {
+      db = err ? dbStub : db;
+      var dataHandlers = defaultDataHandlersModule(db);
+      dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
+        var uid = res.insertedId;
+        dataHandlers.doDelete(id, uid, metaData, function(err, res) {
+          assert.ok(!err);
+          db.collection(id).drop();
+          done();
+        });
+      });
+    });
+  },
+
+  'test handleCollision': function(done) {
+    const that = this;
+    MongoClient.connect(url, function(err, db) {
+      db = err ? dbStub : db;
+      var dataHandlers = defaultDataHandlersModule(db);
+      dataHandlers.handleCollision(id, metaData, {'name': 'Doe'}, function(err, res) {
+        assert.ok(!err);
+        assert.equal(res.result.ok, 1);
+        assert.equal(res.insertedCount, 1);
+        assert.ok(res.insertedId);
+        db.collection(id + '_collision').drop();
+        done();
+      });
+    });
+  },
+
+  'test listCollisions': function(done) {
+    const that = this;
+    MongoClient.connect(url, function(err, db) {
+      db = err ? dbStub : db;
+      var dataHandlers = defaultDataHandlersModule(db);
+      dataHandlers.handleCollision(id, metaData, {'name': 'Doe'}, function(err, res) {
+        assert.ok(!err);
+        dataHandlers.listCollisions(id, metaData, function(err, res) {
+          db.collection(id + '_collision').drop();
+          done();
+        });
+      });
+    });
+  },
+
+  'test removeCollision': function(done) {
+    const that = this;
+    MongoClient.connect(url, function(err, db) {
+      db = err ? dbStub : db;
+      var dataHandlers = defaultDataHandlersModule(db);
+      dataHandlers.handleCollision(id, metaData, {'name': 'Doe'}, function(err, res) {
+        assert.ok(!err);
+        var uid = res.insertedId;
+        dataHandlers.removeCollision(id, uid, metaData, function(err, res) {
+          assert.equal(res.result.ok, 1);
+          assert.equal(res.result.n, 1);
+          db.collection(id + '_collision').drop();
+          done();
+        });
+      });
+    });
+  }
+
+};

--- a/test/sync/test_default-dataHandlers.js
+++ b/test/sync/test_default-dataHandlers.js
@@ -20,7 +20,7 @@ var collectionStub = {
   findOne: sinon.stub().callsArgWith(1, null, {
     "_id": '58b3d9efde2810043a0ac99d'
   }),
-  update: sinon.stub().callsArgWith(2, null),
+  updateOne: sinon.stub().callsArgWith(2, null),
   remove: sinon.stub().callsArgWith(1, null, {
     result: { ok: 1, n: 1}
   }),

--- a/test/sync/test_default-dataHandlers.js
+++ b/test/sync/test_default-dataHandlers.js
@@ -8,19 +8,19 @@ var metaData = {};
 
 // stubs when there is no real MongoDB
 var collectionStub = {
-  insertOne: sinon.stub().callsArgWith(1, null, {
+  insertOne: sinon.stub().yields(null, {
     result: { ok: 1, n: 1},
     connection: null,
     insertedCount: 1,
     insertedId: '58b3d9efde2810043a0ac99d'}),
   find: sinon.stub().returns({
-    toArray: sinon.stub().callsArgWith(0, null, [{
+    toArray: sinon.stub().yields(null, [{
       "_id": '58b3d9efde2810043a0ac99d'}]),
   }),
-  findOne: sinon.stub().callsArgWith(1, null, {
+  findOne: sinon.stub().yields(null, {
     "_id": '58b3d9efde2810043a0ac99d'
   }),
-  updateOne: sinon.stub().callsArgWith(2, null),
+  updateOne: sinon.stub().yields(null),
   remove: sinon.stub().callsArgWith(1, null, {
     result: { ok: 1, n: 1}
   }),

--- a/test/sync/test_default-dataHandlers.js
+++ b/test/sync/test_default-dataHandlers.js
@@ -5,21 +5,22 @@ var defaultDataHandlersModule = require('../../lib/sync/default-dataHandlers.js'
 var id = 'datahandler_test';
 var queryParams = {};
 var metaData = {};
+var stubUid = '58b3d9efde2810043a0ac99d';
 
 // stubs when there is no real MongoDB
 var collectionStub = {
   insertOne: sinon.stub().yields(null, {
     result: { ok: 1, n: 1},
-    ops: [ {'_id': '58b3d9efde2810043a0ac99d', 'name': 'Fletch'}],
+    ops: [{'_id': stubUid, 'name': 'Fletch'}],
     connection: null,
     insertedCount: 1,
-    insertedId: '58b3d9efde2810043a0ac99d'}),
+    insertedId: stubUid}),
   find: sinon.stub().returns({
-    toArray: sinon.stub().yields(null, [{
-      "_id": '58b3d9efde2810043a0ac99d'}]),
+    toArray: sinon.stub().yields(null, [
+      {"_id": stubUid, 'name': 'Fletch'}]),
   }),
   findOne: sinon.stub().yields(null, {
-    "_id": '58b3d9efde2810043a0ac99d'
+    "_id": stubUid
   }),
   updateOne: sinon.stub().yields(null),
   remove: sinon.stub().callsArgWith(1, null, {
@@ -42,6 +43,7 @@ module.exports = {
     }, function(err) {
       assert.equal(err.message, 'MongoDB instance must be passed to module.');
       done();
+      collectionStub.insertOne.reset();
       return true;
     });
   },
@@ -66,11 +68,14 @@ module.exports = {
     MongoClient.connect(url, function(err, db) {
       db = err ? dbStub : db;
       var dataHandlers = defaultDataHandlersModule(db);
-      dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
-        var uid = res.insertedId;
+      var data = {'name': 'Fletch'};
+      dataHandlers.doCreate(id, data, metaData, function(err, res) {
+        var uid = res.uid || stubUid;
         dataHandlers.doList(id, queryParams, metaData, function(err, res) {
           assert.ok(!err);
-          assert.ok(res[0]);
+          assert.ok(res);
+          assert.ok(res[uid]);
+          assert.equal(res[uid].name, 'Fletch');
           db.collection(id).drop();
           done();
         });
@@ -84,7 +89,7 @@ module.exports = {
       db = err ? dbStub : db;
       var dataHandlers = defaultDataHandlersModule(db);
       dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
-        var uid = res.uid;
+        var uid = res.uid || stubUid;
         dataHandlers.doRead(id, uid, metaData, function(err, res) {
           assert.ok(!err);
           assert.ok(res._id);
@@ -101,7 +106,7 @@ module.exports = {
       db = err ? dbStub : db;
       var dataHandlers = defaultDataHandlersModule(db);
       dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
-        var uid = res.uid;
+        var uid = res.uid || stubUid;
         dataHandlers.doUpdate(id, uid, {name: "Doe"}, metaData, function(err) {
           assert.ok(!err);
           db.collection(id).drop();
@@ -117,7 +122,7 @@ module.exports = {
       db = err ? dbStub : db;
       var dataHandlers = defaultDataHandlersModule(db);
       dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
-        var uid = res.uid;
+        var uid = res.uid || stubUid;
         dataHandlers.doDelete(id, uid, metaData, function(err, res) {
           assert.ok(!err);
           db.collection(id).drop();

--- a/test/sync/test_default-dataHandlers.js
+++ b/test/sync/test_default-dataHandlers.js
@@ -10,6 +10,7 @@ var metaData = {};
 var collectionStub = {
   insertOne: sinon.stub().yields(null, {
     result: { ok: 1, n: 1},
+    ops: [ {'_id': '58b3d9efde2810043a0ac99d', 'name': 'Fletch'}],
     connection: null,
     insertedCount: 1,
     insertedId: '58b3d9efde2810043a0ac99d'}),
@@ -49,11 +50,11 @@ module.exports = {
     MongoClient.connect(url, function(err, db) {
       db = err ? dbStub : db;
       var dataHandlers = defaultDataHandlersModule(db);
-      dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
+      var data = {'name': 'Fletch'};
+      dataHandlers.doCreate(id, data, metaData, function(err, res) {
         assert.ok(!err);
-        assert.equal(res.result.ok, 1);
-        assert.equal(res.insertedCount, 1);
-        assert.ok(res.insertedId);
+        assert.ok(res.uid);
+        assert.equal(res.data.name, 'Fletch');
         db.collection(id).drop();
         done();
       });
@@ -83,7 +84,7 @@ module.exports = {
       db = err ? dbStub : db;
       var dataHandlers = defaultDataHandlersModule(db);
       dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
-        var uid = res.insertedId;
+        var uid = res.uid;
         dataHandlers.doRead(id, uid, metaData, function(err, res) {
           assert.ok(!err);
           assert.ok(res._id);
@@ -100,7 +101,7 @@ module.exports = {
       db = err ? dbStub : db;
       var dataHandlers = defaultDataHandlersModule(db);
       dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
-        var uid = res.insertedId;
+        var uid = res.uid;
         dataHandlers.doUpdate(id, uid, {name: "Doe"}, metaData, function(err) {
           assert.ok(!err);
           db.collection(id).drop();
@@ -116,7 +117,7 @@ module.exports = {
       db = err ? dbStub : db;
       var dataHandlers = defaultDataHandlersModule(db);
       dataHandlers.doCreate(id, queryParams, metaData, function(err, res) {
-        var uid = res.insertedId;
+        var uid = res.uid;
         dataHandlers.doDelete(id, uid, metaData, function(err, res) {
           assert.ok(!err);
           db.collection(id).drop();


### PR DESCRIPTION
Motivation:
We need to have a default implementation of the dataHandler for cases
where a user does not provide an override.

Modifications:
Added the default dataHandler implementation and updated the
dataHandlersModule to take the defaults as its options so that the
defaults will always be used unless overridden.

JIRA:
https://issues.jboss.org/browse/FH-3177