### PR TITLE
FH-3174 Implement the lock interface

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,7 +43,8 @@ module.exports = function(grunt) {
     './test/sync/test_dataHandlers.js',
     './test/sync/test_api-syncRecords.js',
     './test/sync/test_default-dataHandlers.js',
-    './test/sync/test_interceptors.js'
+    './test/sync/test_interceptors.js',
+    './test/sync/test_lock.js'
   ];
   var unit_args = _.map(tests, makeTestArgs);
   var test_runner = '_mocha';

--- a/lib/sync/lock.js
+++ b/lib/sync/lock.js
@@ -1,23 +1,31 @@
-// TODO Use mongodb for locking via https://github.com/chilts/mongodb-lock
-// TODO when using https://github.com/chilts/mongodb-lock, ensure old locks are removed
+var mongoLock = require('mongodb-lock');
 
+var locks = {};
 
+function findOrCreate(mongoClient, collectionName, lockName, timeout) {
+  if(locks[lockName]) {
+    return locks[lockName];
+  }
+  // Lock doesn't exist, create it.
+  var lock = mongoLock(mongoClient, collectionName, lockName, { timeout: timeout });
+  locks[lockName] = lock;
+  return lock;
+}
 
-module.exports = function() {
+module.exports = function(mongoClient, collectionName) {
+  collectionName = collectionName || 'sync_locks';
   return {
-    /**
-     * Acquire the lock with the given name.
-     * @param {String} lockName the name of the lock
-     * @param {Number} ttl Time to live on the lock
-     * @param {Function} callback
-     */
-    acquire: function() {
-      return {
-        //release the lock
-        release: function() {
+    acquire: function acquire(lockName, timeout, cb) {
+      var lock = findOrCreate(mongoClient, collectionName, lockName, timeout);
+      return lock.acquire(cb);
+    },
 
-        }
-      };
+    release: function release(lockName, lockCode, cb) {
+      var lock = locks[lockName];
+      if (lock) {
+        return lock.release(lockCode, cb)
+      }
+      return cb(new Error('Cannot release lock that does not exist'));
     }
-  };
+  }
 };

--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -82,10 +82,10 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
   });
 };
 
-function tryNext(target, lock) {
+function tryNext(target, lockCode) {
   setTimeout(function(){
-    if (lock) {
-      lock.release(function(err){
+    if (lockCode) {
+      syncLock.release(target.syncSchedulerLockName, lockCode, function(err){
         if (err) {
           //if failed, log the error. The lock will be release evetually when `timeBeforeCrashAssumed` is reached.
           syncUtil.doLog(syncUtil.SYNC_LOGGER, 'warn', 'Failed to release lock due to error (' + util.inspect(err) + ')');
@@ -104,18 +104,18 @@ function tryNext(target, lock) {
 SyncScheduler.prototype.start = function() {
   var self = this;
   //we only want one of the workers can become a scheduler
-  syncLock.acquire(self.syncSchedulerLockName, self.timeBeforeCrashAssumed, function(err, lock){
+  syncLock.acquire(self.syncSchedulerLockName, self.timeBeforeCrashAssumed, function(err, lockCode){
     if (err) {
       syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'Failed to accquire lock for key ' + self.syncSchedulerLockName + ' error = ' + util.inspect(err));
       tryNext(self);
-    } else if (lock) {
+    } else if (lockCode) {
       syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'Got lock for ' + self.syncSchedulerLockName);
       self.checkDatasetsForSyncing(function(err) {
         if (err) {
           // Any error may be intermittent, so log it and continue as normal
           syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Error checking datasets for syncing ' + util.inspect(err));
         }
-        tryNext(self, lock);
+        tryNext(self, lockCode);
       });
     } else {
       //no lock, try again

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1239,6 +1239,11 @@
         }
       }
     },
+    "mongodb-lock": {
+      "version": "0.3.0",
+      "from": "git://github.com/aidenkeating/mongodb-lock.git#mongodb-2.x-client-support",
+      "resolved": "git://github.com/aidenkeating/mongodb-lock.git#b651361295dad56fb90837dd4ae334b7302c5b63"
+    },
     "mongodb-queue": {
       "version": "2.2.0",
       "from": "https://registry.npmjs.org/mongodb-queue/-/mongodb-queue-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "memcached": "^2.0.0",
     "moment": "2.14.1",
     "mongodb": "2.1.18",
+    "mongodb-lock": "git://github.com/aidenkeating/mongodb-lock.git#mongodb-2.x-client-support",
     "mongodb-queue": "2.2.0",
     "mongodb-uri": "0.9.7",
     "optval": "1.0.1",

--- a/test/sync/test_lock.js
+++ b/test/sync/test_lock.js
@@ -1,0 +1,59 @@
+var assert = require('assert');
+var sinon = require('sinon');
+var proxyquire = require('proxyquire');
+
+var lockName = 'testOne';
+var codeName = 'lockCode';
+
+/**
+ * mongodb-lock.Lock relies on MongoDB, we don't need to test this as it's
+ * already being tested in its own repo. So just mock out expected responses.
+ */
+var mockMongoLock = function() {
+  return {
+    release: sinon.stub().yields(null, true),
+    acquire: sinon.stub().yields(null, codeName)
+  }
+}
+
+/**
+ * Needed for the initialisation of mongodb-lock.Lock object.
+ */
+var mockMongo = {
+  collection: sinon.stub()
+}
+
+var lockModule = proxyquire('../../lib/sync/lock', {
+  'mongodb-lock': mockMongoLock
+});
+
+/**
+ * There's not much to test here as it's just a wrapper around mongodb-lock.
+ * Ensure that the lock is created in acquire and ensure release passes back 
+ * the right value to the user (true or false).
+ */
+module.exports = {
+  'test acquire': function(done) {
+    var syncLockImpl = lockModule(mockMongo, 'sync_testing');
+
+    syncLockImpl.acquire(lockName, 1000, function(err, code) {
+      assert.ok(!err);
+      assert.ok(code === codeName);
+      return done();
+    });
+  },
+
+  'test valid release': function(done) {
+    var syncLockImpl = lockModule(mockMongo, 'sync_testing');
+
+    syncLockImpl.acquire(lockName, 1000, function(err, code) {
+      assert.ok(!err);
+      assert.ok(code);
+      syncLockImpl.release(lockName, code, function(err, res) {
+        assert.ok(!err);
+        assert.ok(res);
+        return done();
+      });
+    });
+  },
+}

--- a/test/sync/test_sync-scheduler.js
+++ b/test/sync/test_sync-scheduler.js
@@ -3,7 +3,8 @@ var sinon = require('sinon');
 var syncSchedulerModule = require('../../lib/sync/sync-scheduler');
 
 var lockProvider = {
-  acquire: sinon.stub()
+  acquire: sinon.stub(),
+  release: sinon.stub()
 };
 var lock = {
   release: sinon.stub()
@@ -53,7 +54,7 @@ module.exports = {
     };
 
     lockProvider.acquire.yieldsAsync(null, lock);
-    lock.release.yieldsAsync();
+    lockProvider.release.yieldsAsync();
 
     //the first dataset client is due to sync, and the second dataset client should be deactivated
     var datasetClients = [{
@@ -112,7 +113,7 @@ module.exports = {
     };
 
     lockProvider.acquire.yieldsAsync(null, lock);
-    lock.release.yieldsAsync();
+    lockProvider.release.yieldsAsync();
     var datasetClients = [];
     syncStorage.listDatasetClients.yieldsAsync(null, datasetClients);
     syncQueue.addMany.yieldsAsync();


### PR DESCRIPTION
This implements a wrapper around a modified version of mongodb-lock
which supports 2.x of the mongodb client.

The wrapper stores all locks created and will create a lock if it
doesn't exist during an acquisition request.