### PR TITLE
Fix the redis client creation when doing a `sync.connect()`

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -57,7 +57,8 @@ function FHapi(cfg, logr) {
     web: require('./web')(cfg)
   };
 
-  var redisUrl = api.redisHost + ':' + api.redisPort;
+  var redisUrl = 'redis://' + api.redisHost + ':' + api.redisPort;
+
   api.db({
     "act" : "connectionString"
   }, function(err, connectionString) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,34 +4,34 @@
   "dependencies": {
     "async": {
       "version": "2.1.5",
-      "from": "async@2.1.5",
+      "from": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@>=4.14.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
         }
       }
     },
     "colors": {
       "version": "0.6.2",
-      "from": "colors@0.6.2",
+      "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
     },
     "cycle": {
       "version": "1.0.3",
-      "from": "cycle@1.0.3",
+      "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
     },
     "eyes": {
       "version": "0.1.8",
-      "from": "eyes@0.1.8",
+      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
     },
     "fh-component-metrics": {
       "version": "2.4.0",
-      "from": "fh-component-metrics@>=2.4.0 <3.0.0",
+      "from": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.4.0.tgz",
       "dependencies": {
         "async": {
@@ -55,7 +55,7 @@
     },
     "fh-db": {
       "version": "1.2.5",
-      "from": "fh-db@1.2.5",
+      "from": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.5.tgz",
       "resolved": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.5.tgz",
       "dependencies": {
         "adm-zip": {
@@ -347,7 +347,7 @@
     },
     "fh-mbaas-client": {
       "version": "0.15.0",
-      "from": "fh-mbaas-client@0.15.0",
+      "from": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-0.15.0.tgz",
       "resolved": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-0.15.0.tgz",
       "dependencies": {
         "fh-logger": {
@@ -527,7 +527,7 @@
     },
     "fh-mbaas-express": {
       "version": "5.6.9",
-      "from": "fh-mbaas-express@5.6.9",
+      "from": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.9.tgz",
       "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.9.tgz",
       "dependencies": {
         "async": {
@@ -1089,7 +1089,7 @@
     },
     "fh-security": {
       "version": "0.2.0",
-      "from": "fh-security@0.2.0",
+      "from": "https://registry.npmjs.org/fh-security/-/fh-security-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/fh-security/-/fh-security-0.2.0.tgz",
       "dependencies": {
         "node-rsa": {
@@ -1108,7 +1108,7 @@
     },
     "fh-statsc": {
       "version": "0.3.0",
-      "from": "fh-statsc@0.3.0",
+      "from": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz",
       "dependencies": {
         "async": {
@@ -1120,46 +1120,46 @@
     },
     "lodash-contrib": {
       "version": "393.0.1",
-      "from": "lodash-contrib@>=393.0.1 <394.0.0",
+      "from": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.9.3",
-          "from": "lodash@3.9.3",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
         }
       }
     },
     "memcached": {
       "version": "2.2.2",
-      "from": "memcached@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
       "dependencies": {
         "hashring": {
           "version": "3.2.0",
-          "from": "hashring@>=3.2.0 <3.3.0",
+          "from": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
           "dependencies": {
             "connection-parse": {
               "version": "0.0.7",
-              "from": "connection-parse@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz"
             },
             "simple-lru-cache": {
               "version": "0.0.2",
-              "from": "simple-lru-cache@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz"
             }
           }
         },
         "jackpot": {
           "version": "0.0.6",
-          "from": "jackpot@>=0.0.6",
+          "from": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
           "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
           "dependencies": {
             "retry": {
               "version": "0.6.0",
-              "from": "retry@0.6.0",
+              "from": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
             }
           }
@@ -1168,42 +1168,42 @@
     },
     "moment": {
       "version": "2.14.1",
-      "from": "moment@2.14.1",
+      "from": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz"
     },
     "mongodb": {
       "version": "2.1.18",
-      "from": "mongodb@2.1.18",
+      "from": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
       "dependencies": {
         "es6-promise": {
           "version": "3.0.2",
-          "from": "es6-promise@3.0.2",
+          "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
         },
         "mongodb-core": {
           "version": "1.3.18",
-          "from": "mongodb-core@1.3.18",
+          "from": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
           "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
           "dependencies": {
             "bson": {
               "version": "0.4.23",
-              "from": "bson@>=0.4.23 <0.5.0",
+              "from": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
               "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
             },
             "require_optional": {
               "version": "1.0.0",
-              "from": "require_optional@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
               "dependencies": {
                 "semver": {
                   "version": "5.3.0",
-                  "from": "semver@>=5.1.0 <6.0.0",
+                  "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                 },
                 "resolve-from": {
                   "version": "2.0.0",
-                  "from": "resolve-from@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
                 }
               }
@@ -1212,27 +1212,27 @@
         },
         "readable-stream": {
           "version": "1.0.31",
-          "from": "readable-stream@1.0.31",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
@@ -1241,82 +1241,99 @@
     },
     "mongodb-queue": {
       "version": "2.2.0",
-      "from": "mongodb-queue@2.2.0",
+      "from": "https://registry.npmjs.org/mongodb-queue/-/mongodb-queue-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/mongodb-queue/-/mongodb-queue-2.2.0.tgz"
     },
     "mongodb-uri": {
       "version": "0.9.7",
-      "from": "mongodb-uri@0.9.7",
+      "from": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
       "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz"
     },
     "optval": {
       "version": "1.0.1",
-      "from": "optval@1.0.1",
+      "from": "https://registry.npmjs.org/optval/-/optval-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/optval/-/optval-1.0.1.tgz"
     },
     "pkginfo": {
       "version": "0.2.3",
-      "from": "pkginfo@0.2.3",
+      "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
     },
     "redis": {
-      "version": "0.8.2",
-      "from": "redis@0.8.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.2.tgz"
+      "version": "2.6.5",
+      "from": "redis@latest",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
+      "dependencies": {
+        "double-ended-queue": {
+          "version": "2.1.0-0",
+          "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
+        },
+        "redis-commands": {
+          "version": "1.3.1",
+          "from": "redis-commands@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
+        },
+        "redis-parser": {
+          "version": "2.4.0",
+          "from": "redis-parser@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.4.0.tgz"
+        }
+      }
     },
     "request": {
       "version": "2.74.0",
-      "from": "request@2.74.0",
+      "from": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
           "version": "1.6.0",
-          "from": "aws4@>=1.2.1 <2.0.0",
+          "from": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
         },
         "bl": {
           "version": "1.1.2",
-          "from": "bl@>=1.1.2 <1.2.0",
+          "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
-              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -1325,136 +1342,136 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "from": "caseless@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "delayed-stream@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "extend": {
           "version": "3.0.0",
-          "from": "extend@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.1",
-          "from": "form-data@>=1.0.0-rc4 <1.1.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz"
         },
         "har-validator": {
           "version": "2.0.6",
-          "from": "har-validator@>=2.0.6 <2.1.0",
+          "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
-              "from": "commander@>=2.9.0 <3.0.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "graceful-readlink@>=1.0.0",
+                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.15.0",
-              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "4.0.1",
-                  "from": "jsonpointer@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                 }
               }
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
-                  "from": "pinkie@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
@@ -1463,111 +1480,111 @@
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
-              "from": "hoek@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "boom@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
-              "from": "assert-plus@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.3.1",
-              "from": "jsprim@>=1.2.2 <2.0.0",
+              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
               "dependencies": {
                 "extsprintf": {
                   "version": "1.0.2",
-                  "from": "extsprintf@1.0.2",
+                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.3",
-                  "from": "json-schema@0.2.3",
+                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
-                  "from": "verror@1.3.6",
+                  "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 }
               }
             },
             "sshpk": {
               "version": "1.10.2",
-              "from": "sshpk@>=1.7.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 },
                 "dashdash": {
                   "version": "1.14.1",
-                  "from": "dashdash@>=1.12.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                 },
                 "getpass": {
                   "version": "0.1.6",
-                  "from": "getpass@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                 },
                 "jsbn": {
                   "version": "0.1.1",
-                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.14.5",
-                  "from": "tweetnacl@>=0.14.0 <0.15.0",
+                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 },
                 "bcrypt-pbkdf": {
                   "version": "1.0.1",
-                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
                 }
               }
@@ -1576,83 +1593,83 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "2.1.14",
-          "from": "mime-types@>=2.1.7 <2.2.0",
+          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.26.0",
-              "from": "mime-db@>=1.26.0 <1.27.0",
+              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "node-uuid@>=1.4.7 <1.5.0",
+          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
           "version": "6.2.2",
-          "from": "qs@>=6.2.0 <6.3.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.2.2.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.2.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "stringstream@>=0.0.4 <0.1.0",
+          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "from": "tough-cookie@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
-              "from": "punycode@>=1.4.1 <2.0.0",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.4.3",
-          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
     "stack-trace": {
       "version": "0.0.9",
-      "from": "stack-trace@0.0.9",
+      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
     },
     "underscore": {
       "version": "1.7.0",
-      "from": "underscore@1.7.0",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "unifiedpush-node-sender": {
       "version": "0.12.0",
-      "from": "unifiedpush-node-sender@0.12.0",
+      "from": "https://registry.npmjs.org/unifiedpush-node-sender/-/unifiedpush-node-sender-0.12.0.tgz",
       "resolved": "https://registry.npmjs.org/unifiedpush-node-sender/-/unifiedpush-node-sender-0.12.0.tgz",
       "dependencies": {
         "lodash": {
@@ -2032,24 +2049,24 @@
     },
     "winston": {
       "version": "0.8.0",
-      "from": "winston@0.8.0",
+      "from": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
       "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "pkginfo": {
           "version": "0.3.1",
-          "from": "pkginfo@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
         }
       }
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@4.0.1",
+      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "mongodb-uri": "0.9.7",
     "optval": "1.0.1",
     "pkginfo": "0.2.3",
-    "redis": "0.8.2",
+    "redis": "^2.6.5",
     "request": "2.74.0",
     "stack-trace": "0.0.9",
     "underscore": "1.7.0",


### PR DESCRIPTION
This change does 2 things to fix the below error on startup
```
Internal error: [Error: Redis connection to 127.0.0.1:[object Object]
failed - connect ECONNREFUSED 127.0.0.1]
```

First, the redis client is updated to the latest (2.6.5) from 0.8.2
(~5yrs old). The latest version is backwards compatible, despite the 2
major version bumps.
Second, the redis connection string is changed to a supported format
i.e. starts with `redis://`. This is the actual fix.