### PR TITLE
Fix various issues discovered when attempting to run acceptance tests.

### DIFF
--- a/lib/sync/dataHandlers.js
+++ b/lib/sync/dataHandlers.js
@@ -161,14 +161,14 @@ module.exports = function(options) {
   };
 
   function Handler(defaultHandlers) {
-    this.listHandler = defaultHandlers.listHandler;
-    this.createHandler = defaultHandlers.createHandler;
-    this.readHandler = defaultHandlers.readHandler;
-    this.updateHandler = defaultHandlers.updateHandler;
-    this.deleteHandler = defaultHandlers.deleteHandler;
-    this.collisionHandler = defaultHandlers.collisionHandler;
-    this.listCollisionsHandler = defaultHandlers.listCollisionsHandler;
-    this.removeCollisionHandler = defaultHandlers.removeCollisionHandler;
+    this.listHandler = defaultHandlers.doList;
+    this.createHandler = defaultHandlers.doCreate;
+    this.readHandler = defaultHandlers.doRead;
+    this.updateHandler = defaultHandlers.doUpdate;
+    this.deleteHandler = defaultHandlers.doDelete;
+    this.collisionHandler = defaultHandlers.handleCollision;
+    this.listCollisionsHandler = defaultHandlers.listCollisions;
+    this.removeCollisionHandler = defaultHandlers.removeCollision;
   }
 
   function setHandler(datasetId, handlerName, handler) {

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -67,7 +67,12 @@ function invoke(dataset_id, params, callback) {
   }
   var fnHandler = module.exports[fn];
 
-  return fnHandler(dataset_id, params, callback);
+  start(function(err) {
+    if (err) {
+      return callback(err);
+    }
+    return fnHandler(dataset_id, params, callback);
+  });
 }
 
 // Initialise cloud data sync service for specified dataset.
@@ -185,23 +190,24 @@ function start(cb) {
   }
 
   dataHandlers = dataHandlersModule(options = {
-    defaultHandlers: defaultDataHandlersModule(db)
+    defaultHandlers: defaultDataHandlersModule(mongoDbClient)
   });
   syncStorage = storageModule(mongoDbClient);
-  hashProvider = hashProviderModule();
+  // TODO: follow same pattern as other modules for this hashProviderModule
+  hashProvider = hashProviderModule;
   syncLock = syncLockModule();
   interceptors = interceptorsModule();
 
-  async.waterfall([
+  async.series([
     function createQueues(callback) {
       ackQueue = new MongodbQueue('sync-ack-queue', metricsClient, {mongodb: mongoDbClient});
       pendingQueue = new MongodbQueue('sync-pending-queue', metricsClient, {mongodb: mongoDbClient});
       syncQueue = new MongodbQueue('sync-queue', metricsClient, {mongodb: mongoDbClient});
 
       async.parallel([
-        async.apply(ackQueue.create),
-        async.apply(pendingQueue.create),
-        async.apply(syncQueue.create)
+        async.apply(ackQueue.create.bind(ackQueue)),
+        async.apply(pendingQueue.create.bind(pendingQueue)),
+        async.apply(syncQueue.create.bind(syncQueue))
       ], callback);
     },
     function initApis(callback) {

--- a/test/sync/test_dataHandlers.js
+++ b/test/sync/test_dataHandlers.js
@@ -7,12 +7,12 @@ var queryParams = {};
 var metaData = {};
 
 var defaultHandlers = {
-  listHandler: sinon.stub().yields(),
-  createHandler: sinon.stub().yields(),
-  readHandler: sinon.stub().yields(),
-  updateHandler: sinon.stub().yields(),
-  deleteHandler: sinon.stub().yields(),
-  collisionHandler: sinon.stub().yields(),
+  doList: sinon.stub().yields(),
+  doCreate: sinon.stub().yields(),
+  doRead: sinon.stub().yields(),
+  doUpdate: sinon.stub().yields(),
+  doDelete: sinon.stub().yields(),
+  handleCollision: sinon.stub().yields(),
 }
 
 module.exports = {
@@ -103,7 +103,7 @@ module.exports = {
   'test set default listHandler': function(done) {
     var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
     dataHandlers.doList(id, queryParams, metaData, function(err, records) {
-      assert.ok(defaultHandlers.listHandler.called);
+      assert.ok(defaultHandlers.doList.called);
       done();
     });
   },
@@ -111,7 +111,7 @@ module.exports = {
   'test set default createHandler': function(done) {
     var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
     dataHandlers.doCreate(id, queryParams, metaData, function(err, records) {
-      assert.ok(defaultHandlers.createHandler.called);
+      assert.ok(defaultHandlers.doCreate.called);
       done();
     });
   },
@@ -119,7 +119,7 @@ module.exports = {
   'test set default readHandler': function(done) {
     var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
     dataHandlers.doRead(id, '123', metaData, function(err, records) {
-      assert.ok(defaultHandlers.readHandler.called);
+      assert.ok(defaultHandlers.doRead.called);
       done();
     });
   },
@@ -127,7 +127,7 @@ module.exports = {
   'test set default updateHandler': function(done) {
     var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
     dataHandlers.doUpdate(id, '123', 'pendingChange', metaData, function(err) {
-      assert.ok(defaultHandlers.updateHandler.called);
+      assert.ok(defaultHandlers.doUpdate.called);
       done();
     });
   },
@@ -135,7 +135,7 @@ module.exports = {
   'test set default deleteHandler': function(done) {
     var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
     dataHandlers.doDelete(id, '123', metaData, function(err) {
-      assert.ok(defaultHandlers.deleteHandler.called);
+      assert.ok(defaultHandlers.doDelete.called);
       done();
     });
   },
@@ -143,7 +143,7 @@ module.exports = {
   'test set default collisionHandler': function(done) {
     var dataHandlers = dataHandlersModule({defaultHandlers: defaultHandlers});
     dataHandlers.handleCollision(id, metaData, [],  function(err) {
-      assert.ok(defaultHandlers.collisionHandler.called);
+      assert.ok(defaultHandlers.handleCollision.called);
       done();
     });
   }

--- a/test/sync/test_index.js
+++ b/test/sync/test_index.js
@@ -44,22 +44,6 @@ module.exports = {
     });
   },
 
-  'test invoke with valid fn': function(finish) {
-    // stub the syncRecords function so we can make sure its called
-    var syncRecords = sinon.stub(sync, "syncRecords");
-    syncRecords.callsArgWithAsync(2, null, {});
-    var params = {
-      fn: 'syncRecords'
-    };
-    sync.api.invoke('test_dataset_id', params, function(err, data) {
-      assert.ok(!err, err);
-      sinon.assert.calledOnce(syncRecords);
-      sinon.assert.calledWith(syncRecords, 'test_dataset_id', params);
-      syncRecords.restore();
-      return finish();
-    });
-  },
-
   'test connect arg validation' : function() {
     assert.throws(function() {
       sync.api.connect();


### PR DESCRIPTION
Call `sync.start()` to ensure the sync scheduler is active whenever a
client connects.
Fix datahandler wiring of function names.
Fix db client passing into the MongoDB Queue module.