### PR TITLE
FH-3198 Test collision handlers

### DIFF
--- a/integration/sync/test_collision-handlers.js
+++ b/integration/sync/test_collision-handlers.js
@@ -1,0 +1,118 @@
+var MongoClient = require('mongodb').MongoClient;
+var assert = require('assert');
+var _ = require('underscore');
+var defaultDataHandlersModule = require('../../lib/sync/default-dataHandlers');
+var dataHandlersModule = require('../../lib/sync/dataHandlers');
+
+var DATASETID = "collisionHandlersTest";
+var MONGODB_URL = "mongodb://127.0.0.1:27017/test";
+
+var mongodb;
+var dataHandlers;
+
+function getCollisionData() {
+  return {
+    pre: { test: 'test1' },
+    post: { test: 'test2' },
+    hash: 'testhash',
+    ts: Date.now(),
+    uid: 'testUid'
+  };
+}
+
+module.exports = {
+  'before': function(done) {
+    MongoClient.connect(MONGODB_URL, function(err, db){
+      if (err) {
+        console.log('mongodb connection error', err);
+        return done(err);
+      }
+      mongodb = db;
+      mongodb.dropCollection(DATASETID + '_collision');
+      dataHandlers = dataHandlersModule({
+        defaultHandlers: defaultDataHandlersModule(mongodb)
+      });
+      return done(err);
+    });
+  },
+  'afterEach': function(done) {
+    mongodb.dropCollection(DATASETID + '_collision');
+    dataHandlers = dataHandlersModule({
+      defaultHandlers: defaultDataHandlersModule(mongodb)
+    });
+    return done();
+  },
+  'test default create and list collisions': function(done) {
+    var collisionData = getCollisionData();
+    dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
+      assert.ok(!err);
+      dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
+        var collision = _.values(res)[0];
+        assert.equal(1, _.size(res));
+        assert.equal(collisionData.hash, collision.hash);
+        assert.deepEqual(collisionData, collision);
+        done(err);
+      });
+    });
+  },
+  'test default removing collisions': function(done) {
+    var collisionData = getCollisionData();
+    dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
+      dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
+        var collisionId = Object.keys(res)[0];
+        var collision = _.values(res)[0];
+        assert.equal(1, _.size(res));
+        dataHandlers.removeCollision(DATASETID, collisionId, {}, function(err, res) {
+          dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
+            assert.ok(!err);
+            assert.equal(0, _.size(res));
+            return done();
+          });          
+        });
+      });
+    });
+  },
+  'test custom create collision': function(done) {
+    var stringData;
+    dataHandlers.collisionHandler(DATASETID, function(datasetId, metaData, collisionData, cb) {
+      var stringData = JSON.stringify(collisionData);
+      var collision = { data: stringData };
+      mongodb.collection(DATASETID + '_collision').insertOne(collision, function(err, res) {
+        assert.ok(!err);
+        return cb(err, res.ops[0]);
+      });
+    });
+    var collisionData = getCollisionData();
+    dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
+      assert.ok(!err);
+      assert(res.data, stringData);
+      return done();
+    });
+  },
+  'test custom list collision': function(done) {
+    var stubList = ['stubbed', 'list'];
+    dataHandlers.listCollisionsHandler(DATASETID, function(datasetId, metaData, cb) {
+      return cb(null, stubList);
+    });
+    dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
+      assert.ok(!err);
+      assert.deepEqual(stubList, res);
+      return done();
+    });
+  },
+  'test custom remove collision': function(done) {
+    dataHandlers.removeCollisionHandler(DATASETID, function(datasetId, dataHash, metaData, cb) {
+      return mongodb.collection(DATASETID + '_collision').remove({hash: dataHash}, cb);
+    });
+    var collisionData = getCollisionData();
+    dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
+      dataHandlers.removeCollision(DATASETID, collisionData.hash, {}, function(err, res) {
+        dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
+          assert.ok(!err);
+          assert.deepEqual({}, res);
+          return done();
+        });
+      });
+    });
+  }
+};

--- a/integration/sync/test_collision-handlers.js
+++ b/integration/sync/test_collision-handlers.js
@@ -1,5 +1,6 @@
 var MongoClient = require('mongodb').MongoClient;
 var assert = require('assert');
+var sinon = require('sinon');
 var _ = require('underscore');
 var defaultDataHandlersModule = require('../../lib/sync/default-dataHandlers');
 var dataHandlersModule = require('../../lib/sync/dataHandlers');
@@ -9,6 +10,7 @@ var MONGODB_URL = "mongodb://127.0.0.1:27017/test";
 
 var mongodb;
 var dataHandlers;
+var defaultHandlers;
 
 function getCollisionData() {
   return {
@@ -21,98 +23,95 @@ function getCollisionData() {
 }
 
 module.exports = {
-  'before': function(done) {
-    MongoClient.connect(MONGODB_URL, function(err, db){
-      if (err) {
-        console.log('mongodb connection error', err);
+  'test collision handlers': {
+    'before': function(done) {
+      MongoClient.connect(MONGODB_URL, function(err, db){
+        if (err) {
+          console.log('mongodb connection error', err);
+          return done(err);
+        }
+        mongodb = db;
+        mongodb.dropCollection(DATASETID + '_collision');
+        defaultHandlers = defaultDataHandlersModule(mongodb);
+        dataHandlers = dataHandlersModule({
+          defaultHandlers: defaultHandlers
+        });
         return done(err);
-      }
-      mongodb = db;
+      });
+    },
+    'afterEach': function(done) {
       mongodb.dropCollection(DATASETID + '_collision');
       dataHandlers = dataHandlersModule({
         defaultHandlers: defaultDataHandlersModule(mongodb)
       });
-      return done(err);
-    });
-  },
-  'afterEach': function(done) {
-    mongodb.dropCollection(DATASETID + '_collision');
-    dataHandlers = dataHandlersModule({
-      defaultHandlers: defaultDataHandlersModule(mongodb)
-    });
-    return done();
-  },
-  'test default create and list collisions': function(done) {
-    var collisionData = getCollisionData();
-    dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
-      assert.ok(!err);
-      dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
-        var collision = _.values(res)[0];
-        assert.equal(1, _.size(res));
-        assert.equal(collisionData.hash, collision.hash);
-        assert.deepEqual(collisionData, collision);
-        done(err);
-      });
-    });
-  },
-  'test default removing collisions': function(done) {
-    var collisionData = getCollisionData();
-    dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
-      dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
-        var collisionId = Object.keys(res)[0];
-        var collision = _.values(res)[0];
-        assert.equal(1, _.size(res));
-        dataHandlers.removeCollision(DATASETID, collisionId, {}, function(err, res) {
-          dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
-            assert.ok(!err);
-            assert.equal(0, _.size(res));
-            return done();
-          });          
-        });
-      });
-    });
-  },
-  'test custom create collision': function(done) {
-    var stringData;
-    dataHandlers.collisionHandler(DATASETID, function(datasetId, metaData, collisionData, cb) {
-      var stringData = JSON.stringify(collisionData);
-      var collision = { data: stringData };
-      mongodb.collection(DATASETID + '_collision').insertOne(collision, function(err, res) {
+      return done();
+    },
+    'test default create and list collisions': function(done) {
+      var collisionData = getCollisionData();
+      dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
         assert.ok(!err);
-        return cb(err, res.ops[0]);
-      });
-    });
-    var collisionData = getCollisionData();
-    dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
-      assert.ok(!err);
-      assert(res.data, stringData);
-      return done();
-    });
-  },
-  'test custom list collision': function(done) {
-    var stubList = ['stubbed', 'list'];
-    dataHandlers.listCollisionsHandler(DATASETID, function(datasetId, metaData, cb) {
-      return cb(null, stubList);
-    });
-    dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
-      assert.ok(!err);
-      assert.deepEqual(stubList, res);
-      return done();
-    });
-  },
-  'test custom remove collision': function(done) {
-    dataHandlers.removeCollisionHandler(DATASETID, function(datasetId, dataHash, metaData, cb) {
-      return mongodb.collection(DATASETID + '_collision').remove({hash: dataHash}, cb);
-    });
-    var collisionData = getCollisionData();
-    dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
-      dataHandlers.removeCollision(DATASETID, collisionData.hash, {}, function(err, res) {
         dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
-          assert.ok(!err);
-          assert.deepEqual({}, res);
-          return done();
+          var collision = _.values(res)[0];
+          assert.equal(1, _.size(res));
+          assert.equal(collisionData.hash, collision.hash);
+          assert.deepEqual(collisionData, collision);
+          done(err);
         });
       });
-    });
+    },
+    'test default removing collisions': function(done) {
+      var collisionData = getCollisionData();
+      dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
+        dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
+          var collisionId = Object.keys(res)[0];
+          var collision = _.values(res)[0];
+          assert.equal(1, _.size(res));
+          dataHandlers.removeCollision(DATASETID, collisionId, {}, function(err, res) {
+            dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
+              assert.ok(!err);
+              assert.equal(0, _.size(res));
+              return done();
+            });          
+          });
+        });
+      });
+    },
+    'test custom create collision': function(done) {
+      // Wrap the default handler, as long as we know a custom one is called.
+      var customHandler = sinon.spy(defaultHandlers, 'handleCollision');
+      dataHandlers.collisionHandler(DATASETID, customHandler);
+
+      var collisionData = getCollisionData();
+      dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err) {
+        assert.ok(!err);
+        assert.ok(customHandler.calledOnce);
+        return done();
+      });
+    },
+    'test custom list collision': function(done) {
+      var customHandler = sinon.spy(defaultHandlers, 'listCollisions');
+      dataHandlers.listCollisionsHandler(DATASETID, customHandler);
+      dataHandlers.listCollisions(DATASETID, {}, function(err) {
+        assert.ok(!err);
+        assert.ok(customHandler.calledOnce);
+        return done();
+      });
+    },
+    'test custom remove collision': function(done) {
+      var customHandler = sinon.spy(defaultHandlers, 'removeCollision');
+      dataHandlers.removeCollisionHandler(DATASETID, customHandler);
+
+      var collisionData = getCollisionData();
+      dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
+        dataHandlers.removeCollision(DATASETID, res.uid, {}, function(err) {
+          assert.ok(!err);
+          dataHandlers.listCollisions(DATASETID, {}, function(err) {
+            assert.ok(!err);
+            assert.ok(customHandler.calledOnce);
+            return done();
+          });
+        });
+      });
+    }
   }
 };

--- a/integration/sync/test_storage.js
+++ b/integration/sync/test_storage.js
@@ -130,7 +130,6 @@ module.exports = {
         async.apply(storage.removeDatasetClients, [datasetClient1])
       ], function(err){
         assert.ok(!err);
-        
         storage.listDatasetClients(function(err, savedDatasetClients){
           assert.ok(!err);
           assert.equal(savedDatasetClients.length, 1);

--- a/lib/sync/dataHandlers.js
+++ b/lib/sync/dataHandlers.js
@@ -73,6 +73,24 @@ module.exports = function(options) {
     },
 
     /**
+     * Sets a custom list collision handler for the passed-in dataset
+     * @param datasetId
+     * @param handler
+     */
+    listCollisionsHandler: function(datasetId, handler) {
+      setHandler(datasetId, names.LIST_COLLISIONS, handler);
+    },
+
+    /**
+     * Sets a custom remove collision handler for the passed-in dataset
+     * @param datasetId
+     * @param handler
+     */
+    removeCollisionHandler: function(datasetId, handler) {
+      setHandler(datasetId, names.REMOVE_COLLISION, handler);
+    },
+
+    /**
      * @param datasetId
      * @param queryParams
      * @param metaData

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -1,6 +1,5 @@
 var syncUtil = require('../sync-util');
 var util = require('util');
-var ObjectID = require('mongodb').ObjectID;
 
 var mongo;
 
@@ -86,12 +85,12 @@ module.exports = function (db) {
       });
     },
 
-    removeCollision: function (dataset_id, uid, meta_data, cb) {
+    removeCollision: function (dataset_id, hash, meta_data, cb) {
       syncUtil.doLog(dataset_id, 'verbose',
                      'removeCollision : ' + dataset_id +
-                     ' :: uid=' + uid +
+                     ' :: hash=' + hash +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(collisionCollection(dataset_id)).remove({"_id" : ObjectID(uid)}, cb);
+      mongo.collection(collisionCollection(dataset_id)).remove({hash : hash}, cb);
     }
 
   };

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -1,5 +1,6 @@
 var syncUtil = require('../sync-util');
 var util = require('util');
+var ObjectID = require('mongodb').ObjectID;
 
 var mongo;
 
@@ -90,7 +91,7 @@ module.exports = function (db) {
                      'removeCollision : ' + dataset_id +
                      ' :: uid=' + uid +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(collisionCollection(dataset_id)).remove({"_id" : uid}, cb);
+      mongo.collection(collisionCollection(dataset_id)).remove({"_id" : ObjectID(uid)}, cb);
     }
 
   };


### PR DESCRIPTION
This adds tests for overriding the collision handlers and the default
collision handlers.

This also includes fixes for the collision handling itself that were
uncovered during testing.