### PR TITLE
Use ObjectID when referencing _id in MongoDB

### DIFF
--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -1,5 +1,6 @@
 var syncUtil = require('./util');
 var util = require('util');
+var ObjectID = require('mongodb').ObjectID;
 
 var mongo;
 
@@ -42,7 +43,7 @@ module.exports = function (db) {
                      'doRead : ' + dataset_id +
                       ' :: ' + uid +
                       ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(dataset_id).findOne({"_id" : uid}, cb);
+      mongo.collection(dataset_id).findOne({"_id" : ObjectID(uid)}, cb);
     },
 
     doUpdate: function (dataset_id, uid, data, meta_data, cb) {
@@ -50,7 +51,7 @@ module.exports = function (db) {
                      'doUpdate : ' + dataset_id +
                      ' :: ' + uid + ' :: ' + util.inspect(data) +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(dataset_id).updateOne({"_id" : uid}, data, cb);
+      mongo.collection(dataset_id).updateOne({"_id" : ObjectID(uid)}, data, cb);
     },
 
     doDelete: function (dataset_id, uid, meta_data, cb) {
@@ -58,7 +59,7 @@ module.exports = function (db) {
                      'doDelete : ' + dataset_id +
                      ' :: ' + uid +
                      ' :: meta=' + util.inspect(meta_data));
-      mongo.collection(dataset_id).remove({"_id" : uid}, cb);
+      mongo.collection(dataset_id).remove({"_id" : ObjectID(uid)}, cb);
     },
 
     handleCollision: function (dataset_id, meta_data, collisionFields, cb) {


### PR DESCRIPTION
Currently we are trying to remove and update records in mongo using
`fields: { _id: <recordId> }`. This won't work, the ID needs to be
converted into a mongodb.ObjectID object first.

We didn't see this before because it was hidden behind fh-db.