### PR TITLE
[WIP] Fix invalid bulk operation from MongoDB when adding empty array

### DIFF
--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -87,8 +87,11 @@ MongodbQueue.prototype.getName = function() {
 };
 
 MongodbQueue.prototype.addMany = function(messages, cb) {
+  if (messages.length === 0) {
+    return cb(new Error('Message list length must be greater than 0'));
+  }
   var self = this;
-  self.add(messages, cb); //it supports an array of messages since v2.2.0
+  return self.add(messages, cb); //it supports an array of messages since v2.2.0
 };
 
 //TODO: add this to the mongodb-queue module

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -88,7 +88,7 @@ MongodbQueue.prototype.getName = function() {
 
 MongodbQueue.prototype.addMany = function(messages, cb) {
   if (messages.length === 0) {
-    return cb(new Error('Message list length must be greater than 0'));
+    return cb();
   }
   var self = this;
   return self.add(messages, cb); //it supports an array of messages since v2.2.0


### PR DESCRIPTION
Currently we allow for empty arrays to be added to the queue,
apparently MongoDB is a bit sensitive about that and throws an error.

This was discovered in the tests and the solution was discovered here:
https://github.com/toymachiner62/node-mongo-seeds/issues/6

A patch to `mongodb-queue` is also on the way.