### PR TITLE
add implementation for stop & stopAll. Update tests

### DIFF
--- a/integration/sync/helper.js
+++ b/integration/sync/helper.js
@@ -20,7 +20,6 @@ function resetDb(dburl, datasetId, cb){
       return done(err);
     }
     async.each([DATASETCLIENTS_COLLECTION, RECORDS_COLLECTION, UPDATES_COLLECTION, datasetId, 'fhsync_ack_queue', 'fhsync_pending_queue', 'fhsync_queue', 'fhsync_locks'], function(collection, cb){
-      console.log("dropping collection: " + collection);
       db.dropCollection(collection, function(err){
         if (err && err.message === 'ns not found'){
           return cb();

--- a/integration/sync/test_collision-handlers.js
+++ b/integration/sync/test_collision-handlers.js
@@ -36,6 +36,9 @@ module.exports = {
         return done(err);
       });
     },
+    'after': function(done) {
+      sync.api.stopAll(done);
+    },
     'afterEach': function(done) {
       mongodb.dropCollection(DATASETID + '_collision');
       dataHandlers = dataHandlersModule({
@@ -107,33 +110,31 @@ module.exports = {
           });
         });
       });
+    },
+    'test public api list collisions': function(done) {
+      var collisionData = getCollisionData();
+      dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err) {
+        assert.ok(!err);
+        sync.api.invoke(DATASETID, { fn: 'listCollisions' }, function(err, res) {
+          var collision = _.values(res)[0];
+          assert.equal(1, _.size(res));
+          assert.deepEqual(collisionData, collision);
+          done(err);
+        });
+      });     
+    },
+    'test public api remove collisions': function(done) {
+      var collisionData = getCollisionData();
+      dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
+        assert.ok(!err);
+        sync.api.invoke(DATASETID, { fn: 'removeCollision', hash: collisionData.hash }, function(err, res) {
+          dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
+            assert.equal(0, _.size(res));
+            assert.deepEqual({}, res);
+            done(err);
+          });
+        });
+      });
     }
-    //This is causing the build failing ATM, because we can't reset the sync loop.
-    //Will remove the comments once we have implemented stop & stopAll
-    // 'test public api list collisions': function(done) {
-    //   var collisionData = getCollisionData();
-    //   dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err) {
-    //     assert.ok(!err);
-    //     sync.api.invoke(DATASETID, { fn: 'listCollisions' }, function(err, res) {
-    //       var collision = _.values(res)[0];
-    //       assert.equal(1, _.size(res));
-    //       assert.deepEqual(collisionData, collision);
-    //       done(err);
-    //     });
-    //   });     
-    // },
-    // 'test public api remove collisions': function(done) {
-    //   var collisionData = getCollisionData();
-    //   dataHandlers.handleCollision(DATASETID, {}, collisionData, function(err, res) {
-    //     assert.ok(!err);
-    //     sync.api.invoke(DATASETID, { fn: 'removeCollision', hash: collisionData.hash }, function(err, res) {
-    //       dataHandlers.listCollisions(DATASETID, {}, function(err, res) {
-    //         assert.equal(0, _.size(res));
-    //         assert.deepEqual({}, res);
-    //         done(err);
-    //       });
-    //     });
-    //   });
-    // }
   }
 };

--- a/integration/sync/test_index.js
+++ b/integration/sync/test_index.js
@@ -1,23 +1,26 @@
 var sync = require('../../lib/sync');
+var helper = require('./helper');
 var assert = require('assert');
 var util = require('util');
 var async = require('async');
 
-var mClient;
-var rClient;
+var mongoDBUrl = 'mongodb://127.0.0.1:27017/test_index';
+var DATASETID = 'testSyncInitStop';
 
 module.exports = {
   'test sync connect': {
+    'before': function(done){
+      helper.resetDb(mongoDBUrl, DATASETID, done);
+    },
+    'after': function(done){
+      sync.api.stopAll(done);
+    },
     'should connect ok': function(finish) {
       // assume redis & mongodb on localhost with default ports
-
-      // mongodb://localhost:50000,localhost:50001/myproject
-      var mongoDBUrl = 'mongodb://127.0.0.1:27017/test';
-
       sync.api.connect(mongoDBUrl, null, {}, function(err, mongoDbClient, redisClient) {
         assert.ok(!err, util.inspect(err));
-        mClient = mongoDbClient;
-        rClient = redisClient;
+        var mClient = mongoDbClient;
+        var rClient = redisClient;
         assert.ok(mongoDbClient);
 
         async.series([function testMongoDBConnection(cb) {
@@ -34,6 +37,45 @@ module.exports = {
           assert.ok(!err, util.inspect(err));
           return finish();
         });
+      });
+    },
+
+    'should init & stop': function(done) {
+      var TESTCUID = 'testcuid';
+      var params = {
+        fn: 'sync',
+        query_params: {},
+        meta_data: {},
+        __fh: {
+          cuid: TESTCUID
+        },
+        pending: [{
+          action: 'create',
+          hash: 'a1',
+          uid: 'client-a1',
+          post: {
+            'a': '1',
+            'user': '1'
+          }
+        }]
+      };
+      async.series([
+        async.apply(sync.api.connect, mongoDBUrl, null, {}),
+        async.apply(sync.api.init, DATASETID, {}),
+        async.apply(sync.api.invoke, DATASETID, params),
+        async.apply(sync.api.stop, DATASETID),
+        function checkSyncCallFailed(callback){
+          sync.api.invoke(DATASETID, params, function(err){
+            assert.ok(err);
+            assert.ok(err.message.match(/stopped/ig));
+            callback();
+          });
+        },
+        async.apply(sync.api.init, DATASETID, {}),
+        async.apply(sync.api.invoke, DATASETID, params)
+      ], function(err){
+        assert.ok(!err);
+        done();
       });
     }
   }

--- a/integration/sync/test_storage.js
+++ b/integration/sync/test_storage.js
@@ -213,6 +213,21 @@ module.exports = {
         done();
       });
     },
+    'test update many dataset clients': function(done) {
+      async.series([
+        async.apply(storage.upsertDatasetClient, datasetClient1.id, datasetClient1),
+        async.apply(storage.upsertDatasetClient, datasetClient2.id, datasetClient2),
+        async.apply(storage.updateManyDatasetClients, {}, {stopped: true}),
+      ], function(err){
+        assert.ok(!err);
+        storage.listDatasetClients(function(err, savedDatasetClients){
+          assert.ok(!err);
+          assert.equal(savedDatasetClients[0].stopped, true);
+          assert.equal(savedDatasetClients[1].stopped, true);
+          done();
+        });
+      });
+    },
     'test operations on the sync updates': function(done) {
       async.series([
         async.apply(storage.saveUpdate, DATASETID, ack1),

--- a/integration/sync/test_sync_apis.js
+++ b/integration/sync/test_sync_apis.js
@@ -33,6 +33,9 @@ module.exports = {
         async.apply(sync.api.connect, mongoDBUrl, null, null)
       ], done);
     },
+    'after': function(done) {
+      sync.api.stopAll(done);
+    },
     'invoke sync': function(done) {
       var params = {
         fn: 'sync',

--- a/lib/sync/DatasetClient.js
+++ b/lib/sync/DatasetClient.js
@@ -22,6 +22,7 @@ function DatasetClient(datasetId, opts){
   this.props = opts.props || {};
   this.id = generateDatasetClientId(this);
   this.config = opts.config || datasets.getDatasetConfig(datasetId);
+  this.stopped = opts.stopped;
 }
 
 /**
@@ -35,7 +36,8 @@ DatasetClient.prototype.toJSON = function() {
     metaData: this.metaData,
     config: this.config,
     props: this.props,
-    globalHash: this.globalHash
+    globalHash: this.globalHash,
+    stopped: this.stopped
   };
 };
 
@@ -44,6 +46,9 @@ DatasetClient.prototype.toJSON = function() {
  */
 DatasetClient.prototype.shouldSync = function() {
   var self = this;
+  if (self.stopped === true) {
+    return false;
+  }
   if (!self.props.syncLoopStart) {
     // Dataset has never been synced before - do initial sync
     return true;

--- a/lib/sync/api-sync.js
+++ b/lib/sync/api-sync.js
@@ -43,9 +43,53 @@ function formatUpdates(processedUpdates) {
   return updates;
 }
 
+function processSyncAPI(datasetId, params, cb) {
+  var queryParams = params.query_params || {};
+  var metaData = params.meta_data || {};
+  var cuid = syncUtil.getCuid(params);
+  var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
+  async.parallel({
+    upsertDatasetClient: function(callback) {
+      syncUtil.doLog(datasetId, 'debug', 'upsert datasetClient id = ' + datasetClient.getId());
+      var datasetClientFields = {id: datasetClient.getId(), datasetId: datasetId,  queryParams: queryParams, metaData: metaData};
+      syncStorage.upsertDatasetClient(datasetClient.getId(), datasetClientFields, callback);
+    },
+    addAcks: function(callback) {
+      syncUtil.doLog(datasetId, 'debug', 'adding acks to queue. size = ' + (params.acknowledgements && params.acknowledgements.length || 0));
+      addToQueue(params.acknowledgements, {datasetId: datasetId, cuid: cuid}, ackQueue, callback);
+    },
+    addPendings: function(callback) {
+      syncUtil.doLog(datasetId, 'debug', 'adding pendings to queue. size = ' + (params.pending && params.pending.length || 0));
+      addToQueue(params.pending, {datasetId: datasetId, cuid: cuid, meta_data: metaData}, pendingQueue, callback);
+    },
+    processedUpdates: function(callback) {
+      syncUtil.doLog(datasetId, 'debug', 'list updates for client cuid = ' + cuid);
+      syncStorage.listUpdates(datasetId, {cuid: cuid}, callback);
+    }
+  }, function(err, results){
+    if (err) {
+      syncUtil.doLog(datasetId, 'error', 'sync request error = ' + util.inspect(err), params);
+      return cb(err);
+    } else {
+      syncUtil.doLog(datasetId, 'debug', 'syn API results ' + util.inspect(results));
+      var globalHash = results.upsertDatasetClient.globalHash;
+      var response = {hash: globalHash, updates: formatUpdates(results.processedUpdates)};
+      interceptors.responseInterceptor(datasetId, queryParams, function(err){
+        if (err) {
+          syncUtil.doLog(datasetId, 'info', 'sync response interceptor returns error = ' + util.inspect(err), params);
+          return cb(err);
+        }
+        syncUtil.doLog(datasetId, 'debug', 'sync API response ' + util.inspect(response));
+        return cb(null, response);
+      });
+    }
+  });
+}
+
 /**
  * Process the sync request. It will
- * - validate the request body vi the requestInterceptor
+ * - validate the request body via the requestInterceptor
+ * - check if the dataset client is stopped for sync
  * - create or update the dataset client
  * - process acknowledgements, push each of them to the ackQueue
  * - process pending changes, push each of them to the pendingQueue
@@ -63,48 +107,28 @@ function sync(datasetId, params, cb) {
   syncUtil.doLog(datasetId, 'info', 'process sync request for dataset ' + datasetId);
   var queryParams = params.query_params || {};
   var metaData = params.meta_data || {};
-  var cuid = syncUtil.getCuid(params);
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
   syncUtil.doLog(datasetId, 'debug', 'processing sync API request :: query_params = ' + util.inspect(queryParams) + ' :: meta_data = ' + util.inspect(metaData));
-  interceptors.requestInterceptor(datasetId, params, function(err){
+  async.series([
+    async.apply(interceptors.requestInterceptor, datasetId, params),
+    function checkDatasetclientStopped(callback) {
+      syncStorage.readDatasetClient(datasetClient.getId(), function(err, datasetClientJson){
+        if (err) {
+          return callback(err);
+        }
+        if (datasetClientJson && datasetClientJson.stopped === true) {
+          return callback(new Error('sync stopped for dataset ' + datasetId));
+        } else {
+          return callback();
+        }
+      });
+    }
+  ], function(err){
     if (err) {
-      syncUtil.doLog(datasetId, 'info', 'sync request interceptor returns error = ' + util.inspect(err), params);
+      syncUtil.doLog(datasetId, 'info', 'sync request returns error = ' + util.inspect(err), params);
       return cb(err);
     }
-    async.parallel({
-      upsertDatasetClient: function(callback) {
-        var datasetClientFields = {id: datasetClient.getId(), datasetId: datasetId,  queryParams: queryParams, metaData: metaData};
-        syncStorage.upsertDatasetClient(datasetClient.getId(), datasetClientFields, callback);
-      },
-      addAcks: function(callback) {
-        syncUtil.doLog(datasetId, 'debug', 'adding acks to queue. size = ' + (params.acknowledgements && params.acknowledgements.length || 0));
-        addToQueue(params.acknowledgements, {datasetId: datasetId, cuid: cuid}, ackQueue, callback);
-      },
-      addPendings: function(callback) {
-        syncUtil.doLog(datasetId, 'debug', 'adding pendings to queue. size = ' + (params.pending && params.pending.length || 0));
-        addToQueue(params.pending, {datasetId: datasetId, cuid: cuid, meta_data: metaData}, pendingQueue, callback);
-      },
-      processedUpdates: function(callback) {
-        syncStorage.listUpdates(datasetId, {cuid: cuid}, callback);
-      }
-    }, function(err, results){
-      if (err) {
-        syncUtil.doLog(datasetId, 'error', 'sync request error = ' + util.inspect(err), params);
-        return cb(err);
-      } else {
-        syncUtil.doLog(datasetId, 'debug', 'syn API results ' + util.inspect(results));
-        var globalHash = results.upsertDatasetClient.globalHash;
-        var response = {hash: globalHash, updates: formatUpdates(results.processedUpdates)};
-        interceptors.responseInterceptor(datasetId, queryParams, function(err){
-          if (err) {
-            syncUtil.doLog(datasetId, 'info', 'sync response interceptor returns error = ' + util.inspect(err), params);
-            return cb(err);
-          }
-          syncUtil.doLog(datasetId, 'debug', 'sync API response ' + util.inspect(response));
-          return cb(null, response);
-        });
-      }
-    });
+    return processSyncAPI(datasetId, params, cb);
   });
 }
 

--- a/lib/sync/api-syncRecords.js
+++ b/lib/sync/api-syncRecords.js
@@ -177,6 +177,22 @@ function syncRecords(datasetId, params, cb) {
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
   var clientRecords = params.clientRecs;
   async.waterfall([
+    function checkDatasetclientStopped(callback) {
+      syncStorage.readDatasetClient(datasetClient.getId(), function(err, datasetClientJson){
+        if (err) {
+          return callback(err);
+        }
+        if (!datasetClientJson) {
+          syncUtil.doLog(datasetId, 'error', "unknown dataset client datasetId = " + datasetId + " :: queryParams = " + util.inspect(queryParams));
+          return callback("unknown datasetClient id = " + datasetClient.getId());
+        }
+        if (datasetClientJson.stopped === true) {
+          return callback(new Error('sync stopped for dataset ' + datasetId));
+        } else {
+          return callback();
+        }
+      });
+    },
     async.apply(listLocalDatasetClientData, datasetClient),
     function listOtherChanges(localDatasetData, callback) {
       if (localDatasetData) {

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -285,7 +285,6 @@ module.exports = {
     stop: stop,
     stopAll: stopAll,
     connect: connect,
-    start: start, //TODO: looks like we don't need to expose this one anymore? init can be used as start
     toJSON: toJSON,
     setLogLevel: setLogLevel,
     globalHandleList: function() {},

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -78,27 +78,59 @@ function invoke(dataset_id, params, callback) {
 
 // Initialise cloud data sync service for specified dataset.
 function init(dataset_id, options, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'init');
-  datasets.init(dataset_id, options);
-  return cb && cb(null, {});
+  syncUtil.doLog(dataset_id, 'info', 'init sync for dataset');
+  start(function(err){
+    if (err) {
+      return cb(err);
+    }
+    datasets.init(dataset_id, options);
+    syncStorage.updateManyDatasetClients({datasetId: dataset_id}, {stopped: false}, cb);
+  });
 }
 
 // Stop cloud data sync for the specified dataset_id.
 function stop(dataset_id, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'stop');
-  
-  // TODO
-
-  cb(null, {});
+  if (!syncStarted) {
+    return cb();
+  }
+  syncUtil.doLog(dataset_id, 'info', 'stop sync for dataset');
+  syncStorage.updateManyDatasetClients({datasetId: dataset_id}, {stopped: true}, cb);
 }
 
-// Stop cloud data sync service for ALL datasets.
+// Stop cloud data sync service for ALL datasets and reset.
+// This should really only used by tests.
 function stopAll(cb) {
-  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'stopAll');
-  
-  // TODO
-
-  cb(null, {});
+  //sync is not started yet, but connect could be called already. In this case, just reset a few things
+  if (!syncStarted) {
+    mongoDbClient = null;
+    redisClient = null;
+    metricsClient = null;
+    return cb();
+  }
+  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'stopAll syncs');
+  async.parallel([
+    async.apply(syncStorage.updateManyDatasetClients, {}, {stopped: true}),
+    async.apply(syncWorker.stop.bind(syncWorker)),
+    async.apply(ackWorker.stop.bind(ackWorker)),
+    async.apply(pendingWorker.stop.bind(pendingWorker)),
+    async.apply(syncScheduler.stop.bind(syncScheduler))
+  ], function(err){
+    if (err) {
+      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Failed to stop sync due to error : ' + util.inspect(err));
+      return cb(err);
+    }
+    mongoDbClient = null;
+    redisClient = null;
+    metricsClient = null;
+    ackQueue = null;
+    pendingQueue = null;
+    syncQueue = null;
+    ackWorker = null;
+    pendingWorker = null;
+    syncWorker = null;
+    syncStarted = false;
+    return cb();
+  });
 }
 
 function listCollisions(dataset_id, params, cb) {
@@ -253,7 +285,7 @@ module.exports = {
     stop: stop,
     stopAll: stopAll,
     connect: connect,
-    start: start,
+    start: start, //TODO: looks like we don't need to expose this one anymore? init can be used as start
     toJSON: toJSON,
     setLogLevel: setLogLevel,
     globalHandleList: function() {},

--- a/lib/sync/storage.js
+++ b/lib/sync/storage.js
@@ -358,6 +358,18 @@ function doFindAndDeleteUpdate(datasetId, acknowledgement, callback) {
   });
 }
 
+function doUpdateManyDatasetClients(query, fields, callback) {
+  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'doUpdateManyDatasetClients query = ' + util.inspect(query) + ' :: fields = ' + util.inspect(fields));
+  var datasetClientsCollection = mongoClient.collection(DATASETCLIENTS_COLLECTION);
+  datasetClientsCollection.updateMany(query, {$set: fields}, function(err, result){
+    if (err) {
+      syncUtil.doLog(datasetId, 'error', ' Failed to doUpdateManyDatasetClients due to error ' + util.inspect(err) + ' :: fields = ' + util.inspect(fields));
+      return callback(err);
+    }
+    return callback(null, result);
+  });
+}
+
 /**
  * Save the sync update to the `fhsync-<datasetId>-updates` collection
  * 
@@ -452,6 +464,15 @@ module.exports = function(mongoClientImpl) {
      */
     updateDatasetClientWithRecords: function(datasetClientId, fields, records, callback) {
       return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doUpdateDatasetClientWithRecords)(datasetClientId, fields, records, callback);
+    },
+
+    readDatasetClient: function(datasetClientId, callback) {
+      return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doReadDatasetClient)(datasetClientId, callback);
+    },
+
+    updateManyDatasetClients: function(query, fields, callback) {
+      doUpdateManyDatasetClients(query, fields, callback);
+      //return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doUpdateManyDatasetClients)(query, fields, callback);
     },
 
     /**

--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -26,6 +26,7 @@ function SyncScheduler(syncQueueImpl, options) {
   this.syncSchedulerLockName = 'locks:sync:SyncScheduler' || options.syncSchedulerLockName;
   this.timeBetweenChecks = options.timeBetweenChecks || 500;
   this.timeBeforeCrashAssumed = options.timeBeforeCrashAssumed || 20000;
+  this.stopped = false;
 }
 
 /**
@@ -84,16 +85,18 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
 
 function tryNext(target, lockCode) {
   setTimeout(function(){
-    if (lockCode) {
-      syncLock.release(target.syncSchedulerLockName, lockCode, function(err){
-        if (err) {
-          //if failed, log the error. The lock will be release evetually when `timeBeforeCrashAssumed` is reached.
-          syncUtil.doLog(syncUtil.SYNC_LOGGER, 'warn', 'Failed to release lock due to error (' + util.inspect(err) + ')');
-        }
+    if (!target.stopped) {
+      if (lockCode) {
+        syncLock.release(target.syncSchedulerLockName, lockCode, function(err){
+          if (err) {
+            //if failed, log the error. The lock will be release evetually when `timeBeforeCrashAssumed` is reached.
+            syncUtil.doLog(syncUtil.SYNC_LOGGER, 'warn', 'Failed to release lock due to error (' + util.inspect(err) + ')');
+          }
+          target.start();
+        });
+      } else {
         target.start();
-      });
-    } else {
-      target.start();
+      }
     }
   }, target.timeBetweenChecks);
 }
@@ -123,6 +126,11 @@ SyncScheduler.prototype.start = function() {
     }
   });
 };
+
+SyncScheduler.prototype.stop = function(cb) {
+  this.stopped = true;
+  return cb && cb();
+}
 
 module.exports = function(syncLockImpl, syncStorageImpl, metricsClientImpl) {
   syncLock = syncLockImpl;

--- a/lib/sync/worker.js
+++ b/lib/sync/worker.js
@@ -28,11 +28,14 @@ function QueueWorker(queue, processor, metrics, opts) {
   this.opts = opts || {};
   this.interval = this.opts.interval || 1000;
   this.name = this.opts.name || 'noname';
+  this.stopped = false;
 }
 
 function next(worker) {
   setTimeout(function(){
-    worker.work();
+    if (!worker.stopped) {
+      worker.work();
+    }
   }, worker.interval);
 }
 
@@ -78,6 +81,14 @@ QueueWorker.prototype.work = function() {
       return next(self);
     }
   });
+};
+
+/**
+ * Stop the queue worker
+ */
+QueueWorker.prototype.stop = function(cb){
+  this.stopped = true;
+  return cb && cb();
 };
 
 module.exports = QueueWorker;

--- a/test/sync/test_api-sync.js
+++ b/test/sync/test_api-sync.js
@@ -9,7 +9,8 @@ var interceptors = {
 
 var syncStorage = {
   upsertDatasetClient: sinon.stub(),
-  listUpdates: sinon.stub()
+  listUpdates: sinon.stub(),
+  readDatasetClient: sinon.stub()
 };
 
 var ackQueue = {
@@ -33,6 +34,7 @@ var resetStubs = function(){
   interceptors.responseInterceptor.reset();
   syncStorage.upsertDatasetClient.reset();
   syncStorage.listUpdates.reset();
+  syncStorage.readDatasetClient.reset();
   ackQueue.addMany.reset();
   ackQueue.addMany.reset();
 };
@@ -76,6 +78,7 @@ module.exports = {
 
     interceptors.requestInterceptor.yieldsAsync();
     interceptors.responseInterceptor.yieldsAsync();
+    syncStorage.readDatasetClient.yieldsAsync();
     syncStorage.upsertDatasetClient.yieldsAsync(null, {globalHash: globalHash});
     syncStorage.listUpdates.yieldsAsync(null, updates);
     ackQueue.addMany.yieldsAsync();

--- a/test/sync/test_api-syncRecords.js
+++ b/test/sync/test_api-syncRecords.js
@@ -5,7 +5,8 @@ var syncRecordsModule = require('../../lib/sync/api-syncRecords');
 
 var syncStorage = {
   readDatasetClientWithRecords: sinon.stub(),
-  listUpdates: sinon.stub()
+  listUpdates: sinon.stub(),
+  readDatasetClient: sinon.stub()
 };
 
 var pendingQueue = {
@@ -52,6 +53,7 @@ module.exports = {
       post: 'd4'
     }];
 
+    syncStorage.readDatasetClient.yieldsAsync(null, {});
     syncStorage.readDatasetClientWithRecords.yieldsAsync(null, datasetClientsWithRecords);
     syncStorage.listUpdates.yieldsAsync(null, appliedUpdates);
     pendingQueue.search.yieldsAsync(null, pendingChanges);

--- a/test/sync/test_index.js
+++ b/test/sync/test_index.js
@@ -67,22 +67,6 @@ module.exports = {
     });
   },
 
-  'test start arg validation': function() {
-    assert.throws(function() {
-      sync.api.start();
-    }, function(err) {
-      assert.equal(err.message, 'start requires 1 argument');
-      return true;
-    });
-  },
-
-  'test start with connect not called': function(finish) {
-    sync.api.start(function(err) {
-      assert.equal(err, 'MongoDB Client & Redis Client are not connected. Ensure connect() is called before calling start');
-      finish();
-    });
-  },
-
   'test start with connect called': function() {
     // TODO
   }

--- a/test/sync/test_sync-scheduler.js
+++ b/test/sync/test_sync-scheduler.js
@@ -136,5 +136,21 @@ module.exports = {
     lockProvider.acquire.reset();
     lockProvider.acquire.yieldsAsync();
     testNoLock(done);
+  },
+
+  'test stop sync scheduler': function(done) {
+    lockProvider.acquire.reset();
+    lockProvider.acquire.yieldsAsync();
+    var SyncScheduler = syncSchedulerModule(lockProvider, syncStorage, metricsClient).SyncScheduler;
+    var scheduler = new SyncScheduler({}, {timeBetweenChecks: 50});
+    sinon.spy(scheduler, 'start');
+    scheduler.start();
+    setTimeout(function(){
+      scheduler.stop();
+      setTimeout(function(){
+        assert.equal(scheduler.start.callCount, 1);
+        done();
+      }, 20);
+    }, 40);
   }
 };

--- a/test/sync/test_worker.js
+++ b/test/sync/test_worker.js
@@ -4,7 +4,6 @@ var Worker = require('../../lib/sync/worker');
 var metricsKeys = require('../../lib/sync/sync-metrics').KEYS;
 
 var processor = function(task, finish) {
-  console.log("processing job", task);
   task.processed = true;
   setTimeout(finish, 0);
 };
@@ -47,5 +46,22 @@ module.exports = {
       assert.equal(counters[metricsKeys.WORKER_JOB_FAILURE_COUNT], undefined);
       done();
     }, 50);
+  },
+  'test_queue_worker stop': function(done) {
+    var q = {
+      get: sinon.stub(),
+      ack: sinon.stub()
+    };
+    var task1 = {id: 1};
+    q.get.onFirstCall().yields(null, task1);
+    var worker = new Worker(q, processor, metrics, {interval: 50});
+    worker.work();
+    setTimeout(function(){
+      worker.stop();
+      setTimeout(function(){
+        assert.ok(q.get.calledOnce);
+        done();
+      }, 20);
+    }, 40)
   }
 };


### PR DESCRIPTION
This PR will add the implementation for `sync.stop` and `sync.stopAll`. They are mainly used in tests.

ping @david-martin @aidenkeating @danbev for review