### PR TITLE
add sync event hooks

### DIFF
--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -18,7 +18,6 @@ function generateGlobalSetter (handlerName, inst) {
 }
 
 var self = {
-
   globalListHandler: undefined,
   globalCreateHandler: undefined,
   globalReadHandler: undefined,
@@ -39,7 +38,7 @@ var self = {
     "clientSyncTimeout": 15,
     "logLevel": "info"
   },
-
+  events: undefined,
   datasets: {},
   datasetClientRecords: {},
   deletedDatasets: {},
@@ -51,6 +50,14 @@ var self = {
     defaultDataHandler.setFHDB(db);
   },
 
+
+  /**
+   * Pass an event emitter instance for this module to use
+   * @param {EventEmitter} ee
+   */
+  setEventEmitter: function (ee) {
+    self.events = ee;
+  },
 
   /**
    * Returns the hash fn for hashing records for a given dataset
@@ -107,6 +114,9 @@ var self = {
   doListHandler: function (dataset_id, query_params, cb, meta_data) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('list', dataset_id, query_params, meta_data);
+
       if (dataset.listHandler) {
         dataset.listHandler(dataset_id, query_params, cb, meta_data);
       }
@@ -119,6 +129,9 @@ var self = {
   doCreateHandler: function (dataset_id, data, cb, meta_data) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('create', dataset_id, data, meta_data);
+
       if (dataset.createHandler) {
         dataset.createHandler(dataset_id, data, cb, meta_data);
       }
@@ -131,6 +144,9 @@ var self = {
   doReadHandler: function (dataset_id, uid, cb, meta_data) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('read', dataset_id, uid, meta_data);
+
       if (dataset.readHandler) {
         dataset.readHandler(dataset_id, uid, cb, meta_data);
       }
@@ -143,6 +159,9 @@ var self = {
   doUpdateHandler: function (dataset_id, uid, data, cb, meta_data) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('update', dataset_id, uid, data, meta_data);
+
       if (dataset.updateHandler) {
         dataset.updateHandler(dataset_id, uid, data, cb, meta_data);
       }
@@ -155,6 +174,9 @@ var self = {
   doDeleteHandler: function (dataset_id, uid, cb, meta_data) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('delete', dataset_id, uid, meta_data);
+
       if (dataset.deleteHandler) {
         dataset.deleteHandler(dataset_id, uid, cb, meta_data);
       }
@@ -167,6 +189,9 @@ var self = {
   doCollisionHandler: function (dataset_id, hash, timestamp, uid, pre, post, meta_data) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('collision-handle', dataset_id, hash, timestamp, uid, pre, post, meta_data);
+
       if (dataset.collisionHandler) {
         dataset.collisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
       }
@@ -179,6 +204,9 @@ var self = {
   doCollisionLister: function (dataset_id, cb, meta_data) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('collision-list', dataset_id, meta_data);
+
       if (dataset.collisionLister) {
         dataset.collisionLister(dataset_id, cb, meta_data);
       }
@@ -191,6 +219,9 @@ var self = {
   doCollisionRemover: function (dataset_id, hash, cb, meta_data) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('collision-remove', dataset_id, hash, meta_data);
+
       if (dataset.collisionRemover) {
         dataset.collisionRemover(dataset_id, hash, cb, meta_data);
       }
@@ -203,6 +234,9 @@ var self = {
   doRequestInterceptor: function (dataset_id, params, cb) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('request', dataset_id, params);
+
       if (dataset.requestInterceptor) {
         dataset.requestInterceptor(dataset_id, params, cb);
       }
@@ -215,6 +249,9 @@ var self = {
   doResponseInterceptor: function (dataset_id, params, cb) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
+
+      self.events.emit('response', dataset_id, params);
+
       if (dataset.responseInterceptor) {
         dataset.responseInterceptor(dataset_id, params, cb);
       }
@@ -650,6 +687,7 @@ var init = function () {
 
 
 module.exports = {
+  setEventEmitter: self.setEventEmitter.bind(self),
   forceSyncList: self.forceSyncList,
   setGlobalListHandler: generateGlobalSetter('globalListHandler', self),
   setGlobalCreateHandler: generateGlobalSetter('globalCreateHandler', self),

--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -60,6 +60,25 @@ var self = {
   },
 
   /**
+   * Wraps a sync handler callback to add event emitter behaviour and timing
+   * @param  {String}   type      sync handler type, e.g "create"
+   * @param  {Object}   args      sync args for the given handler
+   * @param  {Function} callback
+   * @return {Function}
+   */
+  wrapHandlerCallback: function (type, args, callback) {
+    var startDt = Date.now();
+
+    return function syncHandlerCallbackWrapper (err, res) {
+      var evt = err ? 'failed' : 'success';
+
+      self.events.emit(type + '-' + evt, args, Date.now() - startDt);
+
+      callback(err, res);
+    };
+  },
+
+  /**
    * Returns the hash fn for hashing records for a given dataset
    * @param  {String}   dataset_id
    * @param  {Function} callback
@@ -115,13 +134,21 @@ var self = {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
 
-      self.events.emit('list', dataset_id, query_params, meta_data);
+      var done = self.wrapHandlerCallback(
+        'list',
+        {
+          dataset_id: dataset_id,
+          query_params: query_params,
+          meta_data: meta_data
+        },
+        cb
+      );
 
       if (dataset.listHandler) {
-        dataset.listHandler(dataset_id, query_params, cb, meta_data);
+        dataset.listHandler(dataset_id, query_params, done, meta_data);
       }
       else {
-        self.globalListHandler(dataset_id, query_params, cb, meta_data);
+        self.globalListHandler(dataset_id, query_params, done, meta_data);
       }
     });
   },
@@ -130,13 +157,21 @@ var self = {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
 
-      self.events.emit('create', dataset_id, data, meta_data);
+      var done = self.wrapHandlerCallback(
+        'create',
+        {
+          dataset_id: dataset_id,
+          data: data,
+          meta_data: meta_data
+        },
+        cb
+      );
 
       if (dataset.createHandler) {
-        dataset.createHandler(dataset_id, data, cb, meta_data);
+        dataset.createHandler(dataset_id, data, done, meta_data);
       }
       else {
-        self.globalCreateHandler(dataset_id, data, cb, meta_data);
+        self.globalCreateHandler(dataset_id, data, done, meta_data);
       }
     });
   },
@@ -145,13 +180,21 @@ var self = {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
 
-      self.events.emit('read', dataset_id, uid, meta_data);
+      var done = self.wrapHandlerCallback(
+        'read',
+        {
+          dataset_id: dataset_id,
+          uid: uid,
+          meta_data: meta_data
+        },
+        cb
+      );
 
       if (dataset.readHandler) {
-        dataset.readHandler(dataset_id, uid, cb, meta_data);
+        dataset.readHandler(dataset_id, uid, done, meta_data);
       }
       else {
-        self.globalReadHandler(dataset_id, uid, cb, meta_data);
+        self.globalReadHandler(dataset_id, uid, done, meta_data);
       }
     });
   },
@@ -160,13 +203,22 @@ var self = {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
 
-      self.events.emit('update', dataset_id, uid, data, meta_data);
+      var done = self.wrapHandlerCallback(
+        'update',
+        {
+          dataset_id: dataset_id,
+          uid: uid,
+          data: data,
+          meta_data: meta_data
+        },
+        cb
+      );
 
       if (dataset.updateHandler) {
-        dataset.updateHandler(dataset_id, uid, data, cb, meta_data);
+        dataset.updateHandler(dataset_id, uid, data, done, meta_data);
       }
       else {
-        self.globalUpdateHandler(dataset_id, uid, data, cb, meta_data);
+        self.globalUpdateHandler(dataset_id, uid, data, done, meta_data);
       }
     });
   },
@@ -175,13 +227,21 @@ var self = {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
 
-      self.events.emit('delete', dataset_id, uid, meta_data);
+      var done = self.wrapHandlerCallback(
+        'delete',
+        {
+          dataset_id: dataset_id,
+          uid: uid,
+          meta_data: meta_data
+        },
+        cb
+      );
 
       if (dataset.deleteHandler) {
-        dataset.deleteHandler(dataset_id, uid, cb, meta_data);
+        dataset.deleteHandler(dataset_id, uid, done, meta_data);
       }
       else {
-        self.globalDeleteHandler(dataset_id, uid, cb, meta_data);
+        self.globalDeleteHandler(dataset_id, uid, done, meta_data);
       }
     });
   },
@@ -190,7 +250,29 @@ var self = {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
 
-      self.events.emit('collision-handle', dataset_id, hash, timestamp, uid, pre, post, meta_data);
+      self.events.emit('collision-handle', {
+        dataset_id: dataset_id,
+        hash: hash,
+        timestamp: timestamp,
+        uid: uid,
+        pre: pre,
+        post: post,
+        meta_data: meta_data
+      });
+
+      // var done = wrapHandlerCallback(
+      //   'collision-handle',
+      //   {
+      //     dataset_id: dataset_id,
+      //     hash: hash,
+      //     timestamp: timestamp,
+      //     uid: uid,
+      //     pre: pre,
+      //     post: post,
+      //     meta_data: meta_data
+      //   },
+      //   cb
+      // );
 
       if (dataset.collisionHandler) {
         dataset.collisionHandler(dataset_id, hash, timestamp, uid, pre, post, meta_data);
@@ -205,13 +287,20 @@ var self = {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
 
-      self.events.emit('collision-list', dataset_id, meta_data);
+      var done = self.wrapHandlerCallback(
+        'collision-list',
+        {
+          dataset_id: dataset_id,
+          meta_data: meta_data
+        },
+        cb
+      );
 
       if (dataset.collisionLister) {
-        dataset.collisionLister(dataset_id, cb, meta_data);
+        dataset.collisionLister(dataset_id, done, meta_data);
       }
       else {
-        self.globalCollisionLister(dataset_id, cb, meta_data);
+        self.globalCollisionLister(dataset_id, done, meta_data);
       }
     });
   },
@@ -222,11 +311,21 @@ var self = {
 
       self.events.emit('collision-remove', dataset_id, hash, meta_data);
 
+      var done = self.wrapHandlerCallback(
+        'collision-remove',
+        {
+          dataset_id: dataset_id,
+          meta_data: meta_data,
+          hash: hash
+        },
+        cb
+      );
+
       if (dataset.collisionRemover) {
-        dataset.collisionRemover(dataset_id, hash, cb, meta_data);
+        dataset.collisionRemover(dataset_id, hash, done, meta_data);
       }
       else {
-        self.globalCollisionRemover(dataset_id, hash, cb, meta_data);
+        self.globalCollisionRemover(dataset_id, hash, done, meta_data);
       }
     });
   },
@@ -235,13 +334,20 @@ var self = {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
 
-      self.events.emit('request', dataset_id, params);
+      var done = self.wrapHandlerCallback(
+        'request-intercept',
+        {
+          dataset_id: dataset_id,
+          params: params
+        },
+        cb
+      );
 
       if (dataset.requestInterceptor) {
-        dataset.requestInterceptor(dataset_id, params, cb);
+        dataset.requestInterceptor(dataset_id, params, done);
       }
       else {
-        self.globalRequestInterceptor(dataset_id, params, cb);
+        self.globalRequestInterceptor(dataset_id, params, done);
       }
     });
   },
@@ -250,13 +356,20 @@ var self = {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return cb(err);
 
-      self.events.emit('response', dataset_id, params);
+      var done = self.wrapHandlerCallback(
+        'response-intercept',
+        {
+          dataset_id: dataset_id,
+          params: params
+        },
+        cb
+      );
 
       if (dataset.responseInterceptor) {
-        dataset.responseInterceptor(dataset_id, params, cb);
+        dataset.responseInterceptor(dataset_id, params, done);
       }
       else {
-        self.globalResponseInterceptor(dataset_id, params, cb);
+        self.globalResponseInterceptor(dataset_id, params, done);
       }
     });
   },

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -2,6 +2,7 @@ var async = require('async');
 var util = require('util');
 var DataSetModel = require('./sync-DataSetModel');
 var syncUtil = require('./sync-util');
+var EventEmitter = require('events').EventEmitter;
 var config;
 var db = require('./db');
 var fhdb;
@@ -78,6 +79,12 @@ var sync = function () {
 
   globalInit();
 
+  // Emitter to be used by the sync and dataset models
+  var emitter = new EventEmitter();
+
+  // Pass our event emitter for use by other sync components
+  DataSetModel.setEventEmitter(emitter);
+
   var instance = {
     init: DataSetModel.createDataset.bind(null),
     invoke: doInvoke.bind(null),
@@ -85,6 +92,7 @@ var sync = function () {
     stopAll: DataSetModel.stopAllDatasetSync.bind(null),
     toJSON: DataSetModel.toJSON.bind(null),
     setLogLevel: doSetLogLevel,
+    events: emitter,
     globalHandleList: DataSetModel.setGlobalListHandler.bind(null),
     globalHandleCreate: DataSetModel.setGlobalCreateHandler.bind(null),
     globalHandleRead: DataSetModel.setGlobalReadHandler.bind(null),

--- a/test/test_sync_datasetmodel.js
+++ b/test/test_sync_datasetmodel.js
@@ -1,5 +1,6 @@
 var sinon = require('sinon');
 var expect = require('chai').expect;
+var EventEmitter = require('events').EventEmitter;
 
 var mod;
 
@@ -23,6 +24,8 @@ var tests = {
     require('clear-require').all();
 
     mod = require('../lib/sync-DataSetModel');
+
+    mod.setEventEmitter(new EventEmitter());
   },
 
   'should use a custom "globalRequestInterceptor"': function (done) {

--- a/test/test_sync_handlers.js
+++ b/test/test_sync_handlers.js
@@ -44,7 +44,8 @@ module.exports = {
       setGlobalCollisionRemover: sinon.spy(),
       setGlobalRequestInterceptor: sinon.spy(),
       setGlobalResponseInterceptor: sinon.spy(),
-      setGlobalHashHandler: sinon.spy()
+      setGlobalHashHandler: sinon.spy(),
+      setEventEmitter: sinon.spy()
     };
 
     // Creates a new sync instance


### PR DESCRIPTION
NOTE: Will need to be merged #53 first since this is branched off of it and therefore the diff is a little heavy right now.

This PR would allow developers to hook into sync events and define behaviours based on this. 
Here's an example:

```js
const sync = require('fh-mbaas-api').sync;
const stats = require('lib/stats');
const activities = require('lib/models/activities');

// note event args is hash that matches doList params minus the callback
sync.events.on('list-success', function (dataset_id, args, time) {
  // Might be a fire and forget function that tracks operation call counts
  stats.increment('sync-list', dataset_id);

  console.log(args) // prints sync call args { params: params, meta_data: meta_data } 
})

// note event args is a hash that matches doUpdate params minus the callback
sync.events.on('update-success', function (dataset_id, args, time) {
  console.log('update took ${time} milliseconds');
  stats.increment('sync-update', dataset_id);

  // Perhaps we need to track updates for a home page event list for admins
  activities.record(`User ${args.meta_data.userId} updated record ${args.uid}`);
})
```

You could achieve this by writing custom handlers, but you might just want a very simple mechanism for recording events like this and writing custom handlers would be significantly more effort than hooking into an events