### PR TITLE
RHMAP-12743 - databrowser export doesn't work if database not upgraded

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -190,11 +190,12 @@ function net_db(params, callback) {
       logger.warning('Problem contacting DITCH server: ' + err.message + "\n" + util.inspect(err.stack));
       return callback(err);
     });
-    req.end();
+
+    req.on('end', function () {
+      return callback(null, {stream: req})
+    });
 
     return callback(null, {stream: req});
   }
   return;
-
-
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=6.1.5
+sonar.projectVersion=6.1.6
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
## Motivation
Exporting data from databrowser doesn't work if the database is not upgraded, regardless of the selected format. The following error is thrown: 
{"message":"write after end","code":500}

The request to export was ended before the action was taken.

## Result
Remove the `req.end()`. Not sure why this was added.

Note: exporting of bson format doesn't work https://issues.jboss.org/browse/RHMAP-12745

## Jira 
https://issues.jboss.org/browse/RHMAP-12743