### PR TITLE
make sure only 1 sync request is put on the queue when a dataset clie…

### DIFF
--- a/lib/sync/DatasetClient.js
+++ b/lib/sync/DatasetClient.js
@@ -11,7 +11,6 @@ function generateDatasetClientId(datasetClient) {
  * @param {Object} opts options of the dataset client
  * @param {Object} opts.queryParams the query parameters of the dataset client. Will be passed to the data handler to list data.
  * @param {Object} opts.metaData the meta data of the dataset client. Will be passed to the data handler to list data.
- * @param {Object} opts.props some properties of the dataset client. Mainly for record the internal status of the dataset client
  * @param {Object} opts.config the configuration option of the dataset client
  */
 function DatasetClient(datasetId, opts){
@@ -19,10 +18,14 @@ function DatasetClient(datasetId, opts){
   this.datasetId = datasetId;
   this.queryParams = opts.queryParams || {};
   this.metaData = opts.metaData || {};
-  this.props = opts.props || {};
   this.id = generateDatasetClientId(this);
   this.config = opts.config || datasets.getDatasetConfig(datasetId);
   this.stopped = opts.stopped;
+  this.syncScheduled = null;
+  this.syncCompleted = opts.syncCompleted;
+  this.syncLoopStart = opts.syncLoopStart;
+  this.syncLoopEnd = opts.syncLoopEnd;
+  this.lastAccessed = opts.lastAccessed;
 }
 
 /**
@@ -35,9 +38,13 @@ DatasetClient.prototype.toJSON = function() {
     queryParams: this.queryParams,
     metaData: this.metaData,
     config: this.config,
-    props: this.props,
     globalHash: this.globalHash,
-    stopped: this.stopped
+    stopped: this.stopped,
+    syncScheduled : this.syncScheduled,
+    syncCompleted : this.syncCompleted,
+    syncLoopStart : this.syncLoopStart,
+    syncLoopEnd : this.syncLoopEnd,
+    lastAccessed : this.lastAccessed
   };
 };
 
@@ -46,15 +53,16 @@ DatasetClient.prototype.toJSON = function() {
  */
 DatasetClient.prototype.shouldSync = function() {
   var self = this;
-  if (self.stopped === true) {
+  if (self.stopped === true || self.syncScheduled) {
     return false;
   }
-  if (!self.props.syncLoopStart) {
+
+  if (!self.syncLoopStart) {
     // Dataset has never been synced before - do initial sync
     return true;
   }
   // Time between sync loops has passed - do another sync
-  var lastSyncCmp = self.props.syncLoopEnd;
+  var lastSyncCmp = self.syncLoopEnd;
   if (!lastSyncCmp) {
     //the sync run hasn't been finished before, can't decide
     return false;
@@ -69,12 +77,12 @@ DatasetClient.prototype.shouldSync = function() {
  */
 DatasetClient.prototype.shouldDeactiveSync = function() {
   var self = this;
-  if (!self.props.syncLoopStart || !self.props.syncLoopEnd) {
+  if (!self.syncLoopStart || !self.syncLoopEnd) {
     return false;
   }
   // Check to see if this sync needs to be deactivated because
   // of lack of active clients.
-  var lastAccessed = self.props.lastAccessed;
+  var lastAccessed = self.lastAccessed;
   var syncClientTimeout = self.config.clientSyncTimeout * 1000;
   var now = Date.now();
   return lastAccessed + syncClientTimeout < now

--- a/lib/sync/api-sync.js
+++ b/lib/sync/api-sync.js
@@ -51,7 +51,7 @@ function processSyncAPI(datasetId, params, cb) {
   async.parallel({
     upsertDatasetClient: function(callback) {
       syncUtil.doLog(datasetId, 'debug', 'upsert datasetClient id = ' + datasetClient.getId());
-      var datasetClientFields = {id: datasetClient.getId(), datasetId: datasetId,  queryParams: queryParams, metaData: metaData};
+      var datasetClientFields = {id: datasetClient.getId(), datasetId: datasetId,  queryParams: queryParams, metaData: metaData, lastAccessed: Date.now()};
       syncStorage.upsertDatasetClient(datasetClient.getId(), datasetClientFields, callback);
     },
     addAcks: function(callback) {

--- a/lib/sync/api-syncRecords.js
+++ b/lib/sync/api-syncRecords.js
@@ -170,7 +170,7 @@ function computeDelta(datasetId, clientRecords, serverRecords) {
  * @param {Function} cb
  */
 function syncRecords(datasetId, params, cb) {
-  syncUtil.doLog(datasetId, 'info', 'process sync request for dataset ' + datasetId);
+  syncUtil.doLog(datasetId, 'info', 'process syncRecords request for dataset ' + datasetId);
   var queryParams = params.query_params || {};
   var metaData = params.meta_data || {}; //NOTE: the client doesn't send in this value for syncRecords ATM
   var cuid = syncUtil.getCuid(params);

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -96,12 +96,12 @@ function setConfig(conf) {
 
 // Initialise cloud data sync service for specified dataset.
 function init(dataset_id, options, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'init sync for dataset');
+  syncUtil.doLog(dataset_id, 'info', 'init sync for dataset ' + dataset_id + ' with options ' + util.inspect(options));
+  datasets.init(dataset_id, options);
   start(function(err){
     if (err) {
       return cb(err);
     }
-    datasets.init(dataset_id, options);
     syncStorage.updateManyDatasetClients({datasetId: dataset_id}, {stopped: false}, cb);
   });
 }

--- a/lib/sync/sync-processor.js
+++ b/lib/sync/sync-processor.js
@@ -49,6 +49,16 @@ function recordProcessTime(startTime, success) {
   metricsClient.gauge(metrics.KEYS.SYNC_REQUEST_TOTAL_PROCESS_TIME, {success: success}, totalTime);
 }
 
+function markDatasetClientAsCompleted(datasetClientId, startTime, callback) {
+  syncStorage.updateDatasetClient(datasetClientId, {syncLoopEnd: Date.now(), syncCompleted: true, syncScheduled: null}, function(err){
+    if (err) {
+      syncUtil.doLog(datasetId, "error", "Error when update dataset client with id " + datasetClientId + ". error = " + util.inspect(err));
+    }
+    recordProcessTime(startTime, !err);
+    return callback();
+  });
+}
+
 /**
  * Perform the sync operation
  * @param {Object} payload the payload of the sync request
@@ -56,10 +66,11 @@ function recordProcessTime(startTime, success) {
  * @param {String} payload.datasetId the id of the dataset that needs to be synced
  * @param {Object} payload.queryParams the query params that is associated with the dataset
  * @param {Object} payload.metaData the meta data that is associated with the dataset
- * @param {Timestamp} payload.startTime when the sync request is created 
+ * @param {Timestamp} payload.startTime when the sync request is created
+ * @param {Number} tries the number of tries of the request
  * @param {Function} callback
  */
-function syncWithBackend(payload, callback) {
+function syncWithBackend(payload, tries, callback) {
   var datasetClientId = payload.id;
   var datasetId = payload.datasetId;
   var startTime = payload.startTime;
@@ -68,6 +79,12 @@ function syncWithBackend(payload, callback) {
     recordProcessTime(startTime, false);
     syncUtil.doLog(syncUtil.SYNC_LOGGER, "error", "no datasetId value found in sync request payload" + util.inspect(payload));
     return callback();
+  }
+
+  if (tries > 1) {
+    //the request is already run once, but for some reason is not acked, we just make sure it's completed and ack it
+    markDatasetClientAsCompleted(datasetClientId, startTime, callback);
+    return;
   }
 
   var queryParams = payload.queryParams || {};
@@ -94,13 +111,7 @@ function syncWithBackend(payload, callback) {
       syncUtil.doLog(datasetId, "error", "Error when sync data with backend. error = " + util.inspect(err));
     }
 
-    syncStorage.updateDatasetClient(datasetClientId, {syncLoopEnd: Date.now(), syncCompleted: true}, function(err){
-      if (err) {
-        syncUtil.doLog(datasetId, "error", "Error when update dataset client with id " + datasetClientId + ". error = " + util.inspect(err));
-      }
-      recordProcessTime(startTime, !err);
-      return callback();
-    });
+    markDatasetClientAsCompleted(datasetClientId, startTime, callback);
   });
 }
 
@@ -113,6 +124,6 @@ module.exports = function(syncStorageImpl, dataHandlersImpl, metricsClientImpl, 
 
   return function(syncRequest, done) {
     var payload = syncRequest.payload;
-    return syncWithBackend(payload, done);
+    return syncWithBackend(payload, syncRequest.tries, done);
   }
 };

--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -49,7 +49,7 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
       var datasetClient = DatasetClient.fromJSON(datasetClientJson);
       var datasetId = datasetClient.getDatasetId();
       if (datasetClient.shouldSync()) {
-        syncUtil.doLog(datasetId, 'verbose', 'schedule sync run');
+        syncUtil.doLog(datasetId, 'info', 'schedule sync run for datasetClient ' + datasetClient.id);
         var syncRequest = datasetClient.toJSON();
         //record the start time to allow us measure the overall time it takes to process a sync request
         syncRequest.startTime = Date.now();
@@ -60,23 +60,33 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
       }
     });
 
-    async.series([function addDatasetClientsToSyncQueue(wcb) {
-      self.syncQueue.addMany(datasetClientsToSync, function(err) {
-        // if there's a problem, log it and continue.
-        // There's nothing we can or should do as it may be an intermittent problem
-        if (err) {
-          syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Error adding datasetClients to sync queue (' + util.inspect(err) + ')');
-        }
+    async.series([
+      function addDatasetClientsToSyncQueue(wcb) {
+        self.syncQueue.addMany(datasetClientsToSync, function(err) {
+          // if there's a problem, log it and continue.
+          // There's nothing we can or should do as it may be an intermittent problem
+          if (err) {
+            syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Error adding datasetClients to sync queue (' + util.inspect(err) + ')');
+          }
+          return wcb();
+        });
+      },
+      //make sure each dataset client is marked to be scheduled
+      function updateDatasetClients(wcb) {
+        async.each(datasetClientsToSync, function(datasetClient, cb){
+          syncStorage.updateDatasetClient(datasetClient.id, {syncScheduled: Date.now()}, cb);
+        }, wcb);
+      },
+      function removeDatasetClientsFromSyncList(wcb) {
+        syncStorage.removeDatasetClients(datasetClientsToRemove, function(err){
+          if (err) {
+            syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Error removing datasetClients from storage (' + util.inspect(err) + ')');
+          }
+        });
         return wcb();
-      });
-    }, function removeDatasetClientsFromSyncList(wcb) {
-      syncStorage.removeDatasetClients(datasetClientsToRemove, function(err){
-        if (err) {
-          syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Error removing datasetClients from storage (' + util.inspect(err) + ')');
-        }
-      });
-      return wcb();
-    }], function(){
+      }
+    ],
+    function(){
       metricsClient.gauge(metrics.KEYS.SYNC_SCHEDULER_CHECK_TIME, {success: true}, timer.stop());
       return cb();
     });


### PR DESCRIPTION
…nt is due to a sync call

During the loading tests, we noticed when a dataset client is due to be synced, the scheduler could put multiple requests on the queue. To solve that, we added a new flag to the dataset client so that only one request will be put on the queue until the previous one is being resolved.

Also fixed an issue where the wrong fields are being used when check if a dataset client is due to sync.

ping @david-martin @aidenkeating for review