### PR TITLE
FH-3238 Configure mongodb-lock to remove expired locks

### DIFF
--- a/lib/sync/lock.js
+++ b/lib/sync/lock.js
@@ -7,7 +7,11 @@ function findOrCreate(mongoClient, collectionName, lockName, timeout) {
     return locks[lockName];
   }
   // Lock doesn't exist, create it.
-  var lock = mongoLock(mongoClient, collectionName, lockName, { timeout: timeout });
+  var lockOptions = {
+    timeout: timeout,
+    removeExpired: true
+  }
+  var lock = mongoLock(mongoClient, collectionName, lockName, lockOptions);
   locks[lockName] = lock;
   return lock;
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1240,9 +1240,9 @@
       }
     },
     "mongodb-lock": {
-      "version": "0.3.0",
-      "from": "git://github.com/aidenkeating/mongodb-lock.git#mongodb-2.x-client-support",
-      "resolved": "git://github.com/aidenkeating/mongodb-lock.git#b651361295dad56fb90837dd4ae334b7302c5b63"
+      "version": "0.4.0",
+      "from": "git://github.com/aidenkeating/mongodb-lock.git#add_remove_expired_option",
+      "resolved": "git://github.com/aidenkeating/mongodb-lock.git#77c47d316fa2c9b28a357534a9a2c752f4628794"
     },
     "mongodb-queue": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "memcached": "^2.0.0",
     "moment": "2.14.1",
     "mongodb": "2.1.18",
-    "mongodb-lock": "git://github.com/aidenkeating/mongodb-lock.git#mongodb-2.x-client-support",
+    "mongodb-lock": "git://github.com/aidenkeating/mongodb-lock.git#add_remove_expired_option",
     "mongodb-queue": "2.2.0",
     "mongodb-uri": "0.9.7",
     "optval": "1.0.1",


### PR DESCRIPTION
Currently, due to the way `mongodb-lock` works many records are being
created in MongoDB over a short period of time. This is causing issues
on `findAndModify` after some time.

This updates the branch of `mongodb-lock` to one that has an option
to remove records when they have expired. This may be published as
version `0.4.0` of `mongodb-lock`.