### PR TITLE
Use version 0.4.0 of mongodb-lock

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1241,8 +1241,8 @@
     },
     "mongodb-lock": {
       "version": "0.4.0",
-      "from": "git://github.com/aidenkeating/mongodb-lock.git#add_remove_expired_option",
-      "resolved": "git://github.com/aidenkeating/mongodb-lock.git#77c47d316fa2c9b28a357534a9a2c752f4628794"
+      "from": "https://registry.npmjs.org/mongodb-lock/-/mongodb-lock-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/mongodb-lock/-/mongodb-lock-0.4.0.tgz"
     },
     "mongodb-queue": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "memcached": "^2.0.0",
     "moment": "2.14.1",
     "mongodb": "2.1.18",
-    "mongodb-lock": "git://github.com/aidenkeating/mongodb-lock.git#add_remove_expired_option",
+    "mongodb-lock": "0.4.0",
     "mongodb-queue": "2.2.0",
     "mongodb-uri": "0.9.7",
     "optval": "1.0.1",


### PR DESCRIPTION
@david-martin Could you take a super-quick look? It's just bumping the version of mongodb-lock