### PR TITLE
Minor cleanup in lib/sync/util before FH-3220

### DIFF
--- a/lib/sync/util.js
+++ b/lib/sync/util.js
@@ -40,15 +40,9 @@ var sortObject = function (object) {
 
 var sortedStringify = function (obj) {
   var str = '';
-  try {
-    if (obj) {
-      str = JSON.stringify(sortObject(obj));
-    }
-  } catch (e) {
-    doLog(SYNC_LOGGER, 'error', 'Error stringifying sorted object:' + e);
-    throw e;
+  if (obj) {
+    str = JSON.stringify(sortObject(obj));
   }
-
   return str;
 }
 

--- a/lib/sync/util.js
+++ b/lib/sync/util.js
@@ -39,11 +39,7 @@ var sortObject = function (object) {
 
 
 var sortedStringify = function (obj) {
-  var str = '';
-  if (obj) {
-    str = JSON.stringify(sortObject(obj));
-  }
-  return str;
+  return obj ? JSON.stringify(sortObject(obj)) : '';
 }
 
 var setLogger = function (dataset_id, options) {

--- a/lib/sync/util.js
+++ b/lib/sync/util.js
@@ -7,7 +7,7 @@ var _ = require('underscore');
 var SYNC_LOGGER = 'SYNC';
 var loggers = {};
 
-var generateHash = function (plainText) {
+function generateHash(plainText) {
   var hash;
   if (plainText) {
     if ('string' !== typeof plainText) {
@@ -20,7 +20,7 @@ var generateHash = function (plainText) {
   return hash;
 }
 
-var sortObject = function (object) {
+function sortObject(object) {
   if (typeof object !== "object" || object === null) {
     return object;
   }
@@ -38,11 +38,11 @@ var sortObject = function (object) {
 }
 
 
-var sortedStringify = function (obj) {
+function sortedStringify(obj) {
   return obj ? JSON.stringify(sortObject(obj)) : '';
 }
 
-var setLogger = function (dataset_id, options) {
+function setLogger(dataset_id, options) {
   var level = options.logLevel;
   var logger = new (winston.Logger)({
     transports: [
@@ -53,7 +53,7 @@ var setLogger = function (dataset_id, options) {
   loggers[dataset_id] = logger;
 }
 
-var doLog = function (dataset_id, level, msg, params) {
+function doLog(dataset_id, level, msg, params) {
 
   var logger = loggers[dataset_id] || loggers[SYNC_LOGGER];
   if (logger) {
@@ -65,7 +65,7 @@ var doLog = function (dataset_id, level, msg, params) {
   }
 }
 
-var getCuid = function (params) {
+function getCuid(params) {
   var cuid = '';
   if (params && params.__fh && params.__fh.cuid) {
     cuid = params.__fh.cuid;


### PR DESCRIPTION
@david-martin @wei-lee @aidenkeating would any of you like to review?

These changes basically come from looking at FH-3220, and trying to decide what to do with the logging line, I figured that it could maybe be removed (I can't find any inputs that `JSON.stringify` throws for), and then just cleaned up some other things in the process.

Does fh-mbaas-api just get used in NodeJS, or does it also get used in the browser. If it gets used in the browser, will changing the function expressions to function declarations here cause any issues? I'm not as familiar with JS in browsers. If we're not sure, I could change them to named function expressions instead. Basically I was just trying to not have anonymous functions.