### PR TITLE
🎨 Try to make logging a little more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-#Overview
+# fh-mbaas-api
+
+fh-mbaas-api provides FeedHenry MBaaS APIs for Node.js cloud apps.
 
 [![npm package](https://nodei.co/npm/fh-mbaas-api.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/fh-mbaas-api/)
 
@@ -6,8 +8,6 @@
 [![Dependency Status](https://img.shields.io/david/feedhenry/fh-mbaas-api.svg?style=flat-square)](https://david-dm.org/feedhenry/fh-mbaas-api)
 [![Known Vulnerabilities](https://snyk.io/test/npm/fh-mbaas-api/badge.svg?style=flat-square)](https://snyk.io/test/npm/fh-mbaas-api)
 
-
-fh-mbaas-api provides FeedHenry MBaaS APIs to Node.js cloud apps.
 
 |                 | Project Info  |
 | --------------- | ------------- |
@@ -18,7 +18,7 @@ fh-mbaas-api provides FeedHenry MBaaS APIs to Node.js cloud apps.
 | Mailing list:   | [feedhenry-dev](https://www.redhat.com/archives/feedhenry-dev/) ([subscribe](https://www.redhat.com/mailman/listinfo/feedhenry-dev))  |
 | IRC:            | [#feedhenry](https://webchat.freenode.net/?channels=feedhenry) channel in the [freenode](http://freenode.net/) network.  |
 
-#Usage
+## Usage
 fh-mbaas-api is included as standard with your cloud app code.
 
 For custom apps, add the module via npm by running the following for the root of your app
@@ -29,18 +29,18 @@ npm install --save fh-mbaas-api
 
 This will install the latest version of fh-mbaas-api and save the installed version in your package.json
 
-#Documentation
+## Documentation
 Documentation for the $fh cloud API is maintained at the [FeedHenry API Docs.](http://docs.feedhenry.com/v3/api/cloud_api.html)
 
-#Deprecated
-Legacy Rhino functions have been deprecated. These are listed below - with their replacements **in bold**. All replacements listed but '$fh.web' have drop-in replacements available.  
+## Deprecated
+Legacy Rhino functions have been deprecated. These are listed below - with their replacements **in bold**. All replacements listed but '$fh.web' have drop-in replacements available.
 
 * $fh.web -> **[request](https://github.com/mikeal/request)**
 * $fh.log -> **console.log**
 * $fh.parse -> **JSON.parse**
 * $fh.stringify  **JSON.stringify**
 
-#Tests
+## Tests
 In order to run the tests, please make sure you have [Docker](https://www.docker.com/) installed.
 
 Before running tests do:
@@ -54,9 +54,9 @@ Then to run the tests use ```npm test```
 
 On Windows, use ```npm run testwindows```
 
-# Caveats
+## Caveats
 
-## Two sync loops per sync frequency
+### Two sync loops per sync frequency
 Two sync loops may be invoked per sync frequency if the server-side sync frequency
 differs from the client-side frequency.
 
@@ -64,9 +64,18 @@ This is because the client and server sync frequencies are set independently.
 Setting a long frequency on a client does not change the sync frequency on the
 server.
 
-The `syncFrequency` value of the dataset on the server should be set to the 
+The `syncFrequency` value of the dataset on the server should be set to the
 `sync_frequency` value of the corresponding dataset on the client to avoid this.
 
 For example:
   * `sync_frequency` on the client-side dataset is also set to 120 seconds.
   * `syncFrequency` on the server-side dataset is set to 120 seconds.
+
+## Sync API logging
+
+The Sync API logs messages at debug level, except in error scenarios
+ where additional context is available that can't easily be passed to
+ the calling code.  This idea comes from the
+ [level suggestions for libraries in the Bunyan project](https://github.com/trentm/node-bunyan#level-suggestions).
+ Users of the Sync API can then enable debug-level logging if they
+ would like to see more output.

--- a/integration/sync/test_sync_apis.js
+++ b/integration/sync/test_sync_apis.js
@@ -3,7 +3,7 @@ var assert = require('assert');
 var util = require('util');
 var async = require('async');
 var helper = require('./helper');
-var syncUitl = require('../../lib/sync/util');
+var syncUtil = require('../../lib/sync/util');
 var storageModule = require('../../lib/sync/storage');
 var _ = require('underscore');
 
@@ -20,7 +20,7 @@ module.exports = {
     'before': function(done) {
       sync.api.setConfig({workerInterval: 100, schedulerInterval: 100, schedulerLockName: 'test:syncApi:lock'});
       sync.api.setLogLevel(DATASETID, {logLevel: 'debug'});
-      sync.api.setLogLevel(syncUitl.SYNC_LOGGER, {logLevel: 'debug'});
+      sync.api.setLogLevel(syncUtil.SYNC_LOGGER, {logLevel: 'debug'});
       async.series([
         async.apply(sync.api.connect, mongoDBUrl, null, null),
         async.apply(sync.api.init, DATASETID, {syncFrequency: 1}),
@@ -74,7 +74,7 @@ module.exports = {
           hash: 'b1',
           uid: recordBUid,
           pre: {
-            'b': '2', 
+            'b': '2',
             'user': '1'
           },
           post: {
@@ -86,7 +86,7 @@ module.exports = {
           hash: 'c1',
           uid: recordCUid,
           pre: {
-            'c': '3', 
+            'c': '3',
             'user': '1'
           }
         }]

--- a/lib/sync/ack-processor.js
+++ b/lib/sync/ack-processor.js
@@ -14,16 +14,16 @@ var syncStorage;
 function processAcknowledgement(acknowledgement, callback) {
   var datasetId = acknowledgement.datasetId;
   if (!datasetId || !acknowledgement.cuid || !acknowledgement.hash) {
-    syncUtil.doLog(syncUtil.SYNC_LOGGER, "error", "acknowledgement missing info " + util.inspect(acknowledgement));
+    syncUtil.doLog(syncUtil.SYNC_LOGGER, "debug", "acknowledgement missing info " + util.inspect(acknowledgement));
     return callback();
   }
   syncUtil.doLog(datasetId, 'debug', 'processAcknowledge :: processing acknowledge ' + util.inspect(acknowledgement));
   syncStorage.findAndDeleteUpdate(datasetId, acknowledgement, function(err){
     if (err) {
-      syncUtil.doLog(datasetId, 'info', 'END processAcknowledge - err=' + util.inspect(err));
+      syncUtil.doLog(datasetId, 'error', 'END processAcknowledge - err=' + util.inspect(err));
       return callback(err);
     } else {
-      syncUtil.doLog(datasetId, 'info', 'acknowledgement processed successfully. hash = ' + acknowledgement.hash);
+      syncUtil.doLog(datasetId, 'debug', 'acknowledgement processed successfully. hash = ' + acknowledgement.hash);
       return callback();
     }
   });

--- a/lib/sync/api-sync.js
+++ b/lib/sync/api-sync.js
@@ -76,7 +76,7 @@ function processSyncAPI(datasetId, params, cb) {
       var response = {hash: globalHash, updates: formatUpdates(results.processedUpdates)};
       interceptors.responseInterceptor(datasetId, queryParams, function(err){
         if (err) {
-          syncUtil.doLog(datasetId, 'info', 'sync response interceptor returns error = ' + util.inspect(err), params);
+          syncUtil.doLog(datasetId, 'debug', 'sync response interceptor returns error = ' + util.inspect(err), params);
           return cb(err);
         }
         syncUtil.doLog(datasetId, 'debug', 'sync API response ' + util.inspect(response));
@@ -104,7 +104,7 @@ function processSyncAPI(datasetId, params, cb) {
  * @param {Function} cb the callback function
  */
 function sync(datasetId, params, cb) {
-  syncUtil.doLog(datasetId, 'info', 'process sync request for dataset ' + datasetId);
+  syncUtil.doLog(datasetId, 'debug', 'process sync request for dataset ' + datasetId);
   var queryParams = params.query_params || {};
   var metaData = params.meta_data || {};
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
@@ -125,7 +125,7 @@ function sync(datasetId, params, cb) {
     }
   ], function(err){
     if (err) {
-      syncUtil.doLog(datasetId, 'info', 'sync request returns error = ' + util.inspect(err), params);
+      syncUtil.doLog(datasetId, 'debug', 'sync request returns error = ' + util.inspect(err), params);
       return cb(err);
     }
     return processSyncAPI(datasetId, params, cb);

--- a/lib/sync/api-syncRecords.js
+++ b/lib/sync/api-syncRecords.js
@@ -9,7 +9,7 @@ var syncStorage, pendingQueue;
 
 /**
  * List the records for the given datasetClient
- * @param {DatasetClient} datasetClient 
+ * @param {DatasetClient} datasetClient
  * @param {Function} cb
  */
 function listLocalDatasetClientData(datasetClient, cb) {
@@ -70,12 +70,12 @@ function listChangesNotInLocalDataset(datasetId, lastSyncTime, clientInfo, cb) {
 }
 
 /**
- * We have some updates that are applied to the backed since last sync run. However, those updates are not in the 
- * localDatasetClient yet (they will in after next sync run). But those updates are applied on the client already. 
+ * We have some updates that are applied to the backed since last sync run. However, those updates are not in the
+ * localDatasetClient yet (they will in after next sync run). But those updates are applied on the client already.
  * This means when we compute the delta between the client records and the localDatasetClient, those changes will be reverted from the client.
  * To avoid that, we loop through those updates and remove them both from the clientRecords and localDatasetClient.
  * This way there will be no delta for those records and the client will keep there records.
- * 
+ *
  * @param {any} clientRecords
  * @param {any} localDatasetClient
  * @param {any} appliedUpdates
@@ -134,12 +134,12 @@ function computeDelta(datasetId, clientRecords, serverRecords) {
     if (clientRecords[serverRecordUid]) {
       //hash value doesn't match, needs update
       if (clientRecords[serverRecordUid] !== serverRecHash) {
-        syncUtil.doLog(datasetId, 'verbose', 'Updating client record ' + serverRecordUid + ' client hash=' + clientRecords[serverRecordUid]);
+        syncUtil.doLog(datasetId, 'debug', 'Updating client record ' + serverRecordUid + ' client hash=' + clientRecords[serverRecordUid]);
         updates[serverRecordUid] = serverRecord;
       }
     } else {
       //record is not in the client, needs create
-      syncUtil.doLog(datasetId, 'verbose', 'Creating client record ' + serverRecordUid);
+      syncUtil.doLog(datasetId, 'debug', 'Creating client record ' + serverRecordUid);
       creates[serverRecordUid] = serverRecord;
     }
   });
@@ -147,7 +147,7 @@ function computeDelta(datasetId, clientRecords, serverRecords) {
   _.each(clientRecords, function(clientRecordHash, clientRecordUid){
     if (!serverRecords[clientRecordUid]) {
       //the record is in the client but not in the server, need delete
-      syncUtil.doLog(datasetId, 'verbose', 'Deleting client record ' + clientRecordUid);
+      syncUtil.doLog(datasetId, 'debug', 'Deleting client record ' + clientRecordUid);
       deletes[clientRecordUid] = {};
     }
   });
@@ -161,7 +161,7 @@ function computeDelta(datasetId, clientRecords, serverRecords) {
 
 /**
  * Sync the data records for the given client
- * @param {String} datasetId 
+ * @param {String} datasetId
  * @param {Object} params the request body, it normally contain those fields:
  * @param {Object} params.query_params the query parameter for the dataset from the client
  * @param {Object} params.meta_data the meta data for the dataset from the client
@@ -170,7 +170,7 @@ function computeDelta(datasetId, clientRecords, serverRecords) {
  * @param {Function} cb
  */
 function syncRecords(datasetId, params, cb) {
-  syncUtil.doLog(datasetId, 'info', 'process syncRecords request for dataset ' + datasetId);
+  syncUtil.doLog(datasetId, 'debug', 'process syncRecords request for dataset ' + datasetId);
   var queryParams = params.query_params || {};
   var metaData = params.meta_data || {}; //NOTE: the client doesn't send in this value for syncRecords ATM
   var cuid = syncUtil.getCuid(params);
@@ -183,8 +183,9 @@ function syncRecords(datasetId, params, cb) {
           return callback(err);
         }
         if (!datasetClientJson) {
-          syncUtil.doLog(datasetId, 'error', "unknown dataset client datasetId = " + datasetId + " :: queryParams = " + util.inspect(queryParams));
-          return callback("unknown datasetClient id = " + datasetClient.getId());
+          var errMsg = "unknown dataset client datasetId = " + datasetId + " :: queryParams = " + util.inspect(queryParams);
+          syncUtil.doLog(datasetId, 'debug', errMsg);
+          return callback(errMsg);
         }
         if (datasetClientJson.stopped === true) {
           return callback(new Error('sync stopped for dataset ' + datasetId));
@@ -213,7 +214,7 @@ function syncRecords(datasetId, params, cb) {
     var localDatasetDataObj = convertToObject(localDatasetData.records);
     var appliedUpdatesSinceLastSyncObj = convertToObject(appliedUpdatesSinceLastSync);
     var pendingUpdatesObj = convertToObject(pendingUpdates);
-    
+
     removeAppliedUpdates(clientRecords, localDatasetDataObj, appliedUpdatesSinceLastSyncObj);
     removePendingChanges(clientRecords, localDatasetDataObj, pendingUpdatesObj);
 

--- a/lib/sync/default-dataHandlers.js
+++ b/lib/sync/default-dataHandlers.js
@@ -49,7 +49,7 @@ module.exports = function (db) {
     },
 
     doRead: function (dataset_id, uid, meta_data, cb) {
-      syncUtil.doLog(dataset_id, 'verbose',
+      syncUtil.doLog(dataset_id, 'debug',
                      'doRead : ' + dataset_id +
                       ' :: ' + uid +
                       ' :: meta=' + util.inspect(meta_data));
@@ -65,7 +65,7 @@ module.exports = function (db) {
     },
 
     doUpdate: function (dataset_id, uid, data, meta_data, cb) {
-      syncUtil.doLog(dataset_id, 'verbose',
+      syncUtil.doLog(dataset_id, 'debug',
                      'doUpdate : ' + dataset_id +
                      ' :: ' + uid + ' :: ' + util.inspect(data) +
                      ' :: meta=' + util.inspect(meta_data));
@@ -73,7 +73,7 @@ module.exports = function (db) {
     },
 
     doDelete: function (dataset_id, uid, meta_data, cb) {
-      syncUtil.doLog(dataset_id, 'verbose',
+      syncUtil.doLog(dataset_id, 'debug',
                      'doDelete : ' + dataset_id +
                      ' :: ' + uid +
                      ' :: meta=' + util.inspect(meta_data));
@@ -81,7 +81,7 @@ module.exports = function (db) {
     },
 
     handleCollision: function (dataset_id, meta_data, collisionFields, cb) {
-      syncUtil.doLog(dataset_id, 'verbose',
+      syncUtil.doLog(dataset_id, 'debug',
                      'doCollision : ' + dataset_id +
                      ' :: collisionFields=' + util.inspect(collisionFields) +
                      ' :: meta=' + util.inspect(meta_data));
@@ -94,7 +94,7 @@ module.exports = function (db) {
     },
 
     listCollisions: function (dataset_id, meta_data, cb) {
-      syncUtil.doLog(dataset_id, 'verbose',
+      syncUtil.doLog(dataset_id, 'debug',
                      'listCollisions : ' + dataset_id +
                      ' :: meta=' + util.inspect(meta_data));
       mongo.collection(collisionCollection(dataset_id)).find().toArray(function (err, array) {
@@ -106,7 +106,7 @@ module.exports = function (db) {
     },
 
     removeCollision: function (dataset_id, hash, meta_data, cb) {
-      syncUtil.doLog(dataset_id, 'verbose',
+      syncUtil.doLog(dataset_id, 'debug',
                      'removeCollision : ' + dataset_id +
                      ' :: hash=' + hash +
                      ' :: meta=' + util.inspect(meta_data));

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -46,6 +46,7 @@ var syncLock = null;
 var interceptors = null;
 var apiSync = null;
 var apiSyncRecords = null;
+var syncScheduler = null;
 
 var syncStarted = false;
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -51,7 +51,7 @@ var syncStarted = false;
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
 
 function toJSON(dataset_id, returnData, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'toJSON');
+  syncUtil.doLog(dataset_id, 'debug', 'toJSON');
 
   // TODO
 
@@ -63,14 +63,14 @@ var invokeFunctions = ['sync', 'syncRecords', 'listCollisions', 'removeCollision
 
 // Invoke the Sync Server.
 function invoke(dataset_id, params, callback) {
-  syncUtil.doLog(dataset_id, 'info', 'invoke');
+  syncUtil.doLog(dataset_id, 'debug', 'invoke');
 
   if (arguments.length < 3) throw new Error('invoke requires 3 arguments');
 
   // Verify that fn param has been passed
   if (!params || !params.fn) {
     var err = 'no fn parameter provided in params "' + util.inspect(params) + '"';
-    syncUtil.doLog(dataset_id, 'warn', err, params);
+    syncUtil.doLog(dataset_id, 'debug', err, params);
     return callback(err, null);
   }
 
@@ -96,7 +96,7 @@ function setConfig(conf) {
 
 // Initialise cloud data sync service for specified dataset.
 function init(dataset_id, options, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'init sync for dataset ' + dataset_id + ' with options ' + util.inspect(options));
+  syncUtil.doLog(dataset_id, 'debug', 'init sync for dataset ' + dataset_id + ' with options ' + util.inspect(options));
   datasets.init(dataset_id, options);
   start(function(err){
     if (err) {
@@ -111,7 +111,7 @@ function stop(dataset_id, cb) {
   if (!syncStarted) {
     return cb();
   }
-  syncUtil.doLog(dataset_id, 'info', 'stop sync for dataset');
+  syncUtil.doLog(dataset_id, 'debug', 'stop sync for dataset');
   syncStorage.updateManyDatasetClients({datasetId: dataset_id}, {stopped: true}, cb);
 }
 
@@ -125,7 +125,7 @@ function stopAll(cb) {
     metricsClient = null;
     return cb();
   }
-  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'stopAll syncs');
+  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'stopAll syncs');
   ackQueue.stopPruneJob();
   pendingQueue.stopPruneJob();
   syncQueue.stopPruneJob();
@@ -162,21 +162,21 @@ function stopAll(cb) {
 }
 
 function listCollisions(dataset_id, params, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'listCollisions');
+  syncUtil.doLog(dataset_id, 'debug', 'listCollisions');
   return dataHandlers.listCollisions(dataset_id, params.meta_data, cb);
 }
 
 // Defines a handler function for deleting a collision from the collisions list.
 // Should be called after the dataset is initialised.
 function removeCollision(dataset_id, params, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'removeCollision');
+  syncUtil.doLog(dataset_id, 'debug', 'removeCollision');
   return dataHandlers.removeCollision(dataset_id, params.hash, params.meta_data, cb);
 }
 
 function setLogLevel(dataset_id, params, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'setLogLevel');
+  syncUtil.doLog(dataset_id, 'debug', 'setLogLevel');
   if (params && params.logLevel) {
-    syncUtil.doLog(dataset_id, 'info', 'Setting logLevel to "' + params.logLevel + '"');
+    syncUtil.doLog(dataset_id, 'debug', 'Setting logLevel to "' + params.logLevel + '"');
     syncUtil.setLogger(dataset_id, params);
     cb && cb(null, {"status": "ok"});
   }
@@ -197,11 +197,11 @@ function syncRecords(datasetId, params, cb) {
 /**
  * Connect to mongodb & redis with the given connection urls.
  * This should be called before `start()` is called
- * 
+ *
  * @param {string} mongoDBConnectionUrl A MongoDB connection uril in a format supported by the `mongodb` module
  * @param {string} redisUrl A redis connection url in a format supported by the `redis` module
  * @param {Object} metricsConf Metrics configuration
- * @param {function} cb 
+ * @param {function} cb
  */
 function connect(mongoDBConnectionUrl, redisUrl, metricsConf, cb) {
   if (arguments.length < 4) throw new Error('connect requires 4 arguments');
@@ -244,7 +244,7 @@ function connect(mongoDBConnectionUrl, redisUrl, metricsConf, cb) {
  * If this is not explicitly called before clients send sync requests,
  * it will be called when a client sends a sync request.
  * It is OK for this to be called multiple times.
- * 
+ *
  * @param {function} cb
  */
 function start(cb) {
@@ -255,7 +255,7 @@ function start(cb) {
   if (mongoDbClient === null || redisClient === null) {
     return cb('MongoDB Client & Redis Client are not connected. Ensure connect() is called before calling start');
   }
-  
+
   async.series([
     function createQueues(callback) {
       ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, {mongodb: mongoDbClient});
@@ -358,5 +358,3 @@ _.each(handlerOverrides, function(target, methodName) {
     dataHandlers[target].apply(null, arguments);
   }
 });
-
-

--- a/lib/sync/pending-processor.js
+++ b/lib/sync/pending-processor.js
@@ -39,7 +39,7 @@ function handleCollision(datasetId, metaData, pendingChange, dataHash, callback)
 }
 
 /**
- * Create the given pending change in the backend. 
+ * Create the given pending change in the backend.
  * It will always create the record in the backend.
  * @param {String} datasetId the dataset id
  * @param {Object} pendingChange the pending change. It should have the following fields
@@ -58,9 +58,9 @@ function doCreate(datasetId, pendingChange, callback) {
   syncUtil.doLog(datasetId, 'debug', 'CREATE Start data = ' + util.inspect(record));
   dataHandlers.doCreate(datasetId, record, metaData, function(err, data){
     if (err) {
-      syncUtil.doLog(datasetId, 'warn', 'CREATE Failed - : err = ' + util.inspect(err));
+      syncUtil.doLog(datasetId, 'debug', 'CREATE Failed - : err = ' + util.inspect(err));
     } else {
-      syncUtil.doLog(datasetId, 'info', 'CREATE Success - uid=' + data.uid);
+      syncUtil.doLog(datasetId, 'debug', 'CREATE Success - uid=' + data.uid);
       pendingChange.oldUid = pendingChange.uid;
       pendingChange.uid = data.uid;
     }
@@ -69,7 +69,7 @@ function doCreate(datasetId, pendingChange, callback) {
 }
 
 /**
- * Update the given pending change in the backend. 
+ * Update the given pending change in the backend.
  * It will only update the record if the hash value of the `pre` record matches the hash value of the record from backend.
  * Otherwise the change is either already applied, or a collision will be generated.
  * @param {String} datasetId the dataset id
@@ -90,11 +90,11 @@ function doUpdate(datasetId, pendingChange, callback) {
   var uid = pendingChange.uid;
   dataHandlers.doRead(datasetId, uid, metaData, function(err, data) {
     if (err) {
-      syncUtil.doLog(datasetId, 'warn', 'READ for UPDATE Failed - uid=' + uid + ' : err = ' + util.inspect(err));
+      syncUtil.doLog(datasetId, 'debug', 'READ for UPDATE Failed - uid=' + uid + ' : err = ' + util.inspect(err));
       return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.FAILED, util.inspect(err), callback);
     }
     syncUtil.doLog(datasetId, 'debug', ' READ for UPDATE Success');
-    syncUtil.doLog(datasetId, 'silly', 'READ for UPDATE Data : \n' + util.inspect(data));
+    syncUtil.doLog(datasetId, 'debug', 'READ for UPDATE Data : \n' + util.inspect(data));
 
     var preHash = hashProvider.recordHash(datasetId, pendingChange.pre);
     var dataHash = hashProvider.recordHash(datasetId, data);
@@ -104,9 +104,9 @@ function doUpdate(datasetId, pendingChange, callback) {
     if (preHash === dataHash) {
       dataHandlers.doUpdate(datasetId, uid, pendingChange.post, metaData, function (err) {
         if (err) {
-          syncUtil.doLog(datasetId, 'warn', 'UPDATE Failed - uid=' + uid + ' : err = ' + util.inspect(err));
+          syncUtil.doLog(datasetId, 'debug', 'UPDATE Failed - uid=' + uid + ' : err = ' + util.inspect(err));
         } else {
-          syncUtil.doLog(datasetId, 'info', 'UPDATE Success - uid=' + uid + ' : hash = ' + dataHash);
+          syncUtil.doLog(datasetId, 'debug', 'UPDATE Success - uid=' + uid + ' : hash = ' + dataHash);
         }
         return saveUpdate(datasetId, pendingChange, err? SYNC_UPDATE_TYPES.FAILED: SYNC_UPDATE_TYPES.APPLIED, err? util.inspect(err): null, callback);
       });
@@ -114,14 +114,14 @@ function doUpdate(datasetId, pendingChange, callback) {
       var postHash = hashProvider.recordHash(datasetId, pendingChange.post);
       if (postHash === dataHash) {
         // Update has already been applied
-        syncUtil.doLog(datasetId, 'info', 'UPDATE Already Applied - uid=' + uid + ' : hash = ' + dataHash);
+        syncUtil.doLog(datasetId, 'debug', 'UPDATE Already Applied - uid=' + uid + ' : hash = ' + dataHash);
         return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.APPLIED, null, callback);
       }
       else {
-        syncUtil.doLog(datasetId, 'warn', 'UPDATE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pendingChange.pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)));
+        syncUtil.doLog(datasetId, 'debug', 'UPDATE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pendingChange.pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)));
         handleCollision(datasetId, metaData, pendingChange, dataHash, function(err){
           if (err) {
-            syncUtil.doLog(datasetId, 'warn', 'Failed to save collision uid =' + uid + ' : err = ' + util.inspect(err));
+            syncUtil.doLog(datasetId, 'debug', 'Failed to save collision uid =' + uid + ' : err = ' + util.inspect(err));
           }
           return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.COLLISION,  null, callback);
         });
@@ -131,7 +131,7 @@ function doUpdate(datasetId, pendingChange, callback) {
 }
 
 /**
- * Delete the given pending change from the backend. 
+ * Delete the given pending change from the backend.
  * It will only delete the record if the hash value of the `pre` record matches the hash value of the record from backend.
  * Otherwise the change is either already applied, or a collision will be generated.
  * @param {String} datasetId the dataset id
@@ -151,11 +151,11 @@ function doDelete(datasetId, pendingChange, callback) {
   var uid = pendingChange.uid;
   dataHandlers.doRead(datasetId, uid, metaData, function(err, data) {
     if (err) {
-      syncUtil.doLog(datasetId, 'warn', 'READ for DELETE Failed - uid=' + uid + ' : err = ' + util.inspect(err));
+      syncUtil.doLog(datasetId, 'debug', 'READ for DELETE Failed - uid=' + uid + ' : err = ' + util.inspect(err));
       return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.FAILED, util.inspect(err), callback);
     }
     syncUtil.doLog(datasetId, 'debug', ' READ for DELETE Success');
-    syncUtil.doLog(datasetId, 'silly', ' READ for DELETE Data : \n' + util.inspect(data));
+    syncUtil.doLog(datasetId, 'debug', ' READ for DELETE Data : \n' + util.inspect(data));
 
     var preHash = hashProvider.recordHash(datasetId, pendingChange.pre);
     var dataHash = hashProvider.recordHash(datasetId, data);
@@ -164,24 +164,24 @@ function doDelete(datasetId, pendingChange, callback) {
 
     if (!dataHash) {
       //record has already been deleted
-      syncUtil.doLog(datasetId, 'info', 'DELETE Already performed - uid=' + uid );
+      syncUtil.doLog(datasetId, 'debug', 'DELETE Already performed - uid=' + uid );
       return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.APPLIED, null, callback);
     }
     else {
       if (preHash === dataHash) {
         dataHandlers.doDelete(datasetId, uid, metaData, function(err) {
           if (err) {
-            syncUtil.doLog(datasetId, 'warn', 'DELETE Failed - uid=' + uid + ' : err = ' + util.inspect(err));
+            syncUtil.doLog(datasetId, 'debug', 'DELETE Failed - uid=' + uid + ' : err = ' + util.inspect(err));
           } else {
-            syncUtil.doLog(datasetId, 'info', 'DELETE Success - uid=' + uid + ' : hash = ' + dataHash);
+            syncUtil.doLog(datasetId, 'debug', 'DELETE Success - uid=' + uid + ' : hash = ' + dataHash);
           }
           return saveUpdate(datasetId, pendingChange, err? SYNC_UPDATE_TYPES.FAILED: SYNC_UPDATE_TYPES.APPLIED, err? util.inspect(err): null, callback);
         });
       } else {
-        syncUtil.doLog(datasetId, 'warn', 'DELETE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pendingChange.pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)));
+        syncUtil.doLog(datasetId, 'debug', 'DELETE COLLISION \n Pre record from client:\n' + util.inspect(syncUtil.sortObject(pendingChange.pre)) + '\n Current record from data store:\n' + util.inspect(syncUtil.sortObject(data)));
         handleCollision(datasetId, metaData, pendingChange, dataHash, function(err){
           if(err) {
-            syncUtil.doLog(datasetId, 'warn', 'Failed to save collision uid =' + uid + ' : err = ' + util.inspect(err));
+            syncUtil.doLog(datasetId, 'debug', 'Failed to save collision uid =' + uid + ' : err = ' + util.inspect(err));
           }
           return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.COLLISION,  null, callback);
         });
@@ -200,7 +200,7 @@ function doDelete(datasetId, pendingChange, callback) {
  * @param {String} pendingChange.cuid the unique client id of the client device
  * @param {String} pendingChange.hash a unique id of the pending change, normally it is a hash value generated from the content of the pendingChange object
  * @param {Object} pendingChange.pre the record before change. Optional.
- * @param {Object} pendingChange.post the record after change. Optional. 
+ * @param {Object} pendingChange.post the record after change. Optional.
  * @param {Number} tries a counter to record how many times the given pending change has been executed
  * @param {Function} callback the callback function
  * @returns
@@ -208,13 +208,13 @@ function doDelete(datasetId, pendingChange, callback) {
 function applyPendingChange(pendingChange, tries, callback) {
   var datasetId = pendingChange.datasetId;
   if (!datasetId || !pendingChange.action || !pendingChange.uid || !pendingChange.cuid || !pendingChange.hash) {
-    syncUtil.doLog(syncUtil.SYNC_LOGGER, "info", "invalid pendingChange request dropped :: item = " + util.inspect(pendingChange));
+    syncUtil.doLog(syncUtil.SYNC_LOGGER, "debug", "invalid pendingChange request dropped :: item = " + util.inspect(pendingChange));
     return callback();
   }
-  syncUtil.doLog(datasetId, 'silly', 'processPending :: item = ' + util.inspect(pendingChange));
+  syncUtil.doLog(datasetId, 'debug', 'processPending :: item = ' + util.inspect(pendingChange));
   if (tries > 1) {
     //the pendingChange has been processed before but it didn't complete, most likely the process crashedd. Mark it as failed
-    syncUtil.doLog(datasetId, 'silly', 'processPending failed :: tries = ' + tries + '  :: item = ' + util.inspect(pendingChange));
+    syncUtil.doLog(datasetId, 'debug', 'processPending failed :: tries = ' + tries + '  :: item = ' + util.inspect(pendingChange));
     return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.FAILED, "crashed", callback);
   }
   var action = pendingChange.action.toLowerCase();
@@ -236,7 +236,7 @@ function applyPendingChange(pendingChange, tries, callback) {
       doDelete(datasetId, pendingChange, onComplete);
       break;
     default:
-      syncUtil.doLog(datasetId, "info", "invalid pendingChange request dropped :: item = " + util.inspect(pendingChange));
+      syncUtil.doLog(datasetId, "debug", "invalid pendingChange request dropped :: item = " + util.inspect(pendingChange));
       return onComplete();
   }
 }

--- a/lib/sync/sync-metrics.js
+++ b/lib/sync/sync-metrics.js
@@ -15,7 +15,7 @@ var timeAsyncFunc = function(metricKey, targetFn) {
   return function() {
     var args = [].slice.call(arguments);
     if (typeof args[args.length - 1] !== 'function') {
-      syncUtils.doLog(syncUtils.SYNC_LOGGER, 'info', 'can not time the target function ' + targetFn.name + ' as last argument is not a function');
+      syncUtils.doLog(syncUtils.SYNC_LOGGER, 'debug', 'can not time the target function ' + targetFn.name + ' as last argument is not a function');
     } else {
       var callback = args.pop();
       var timer = new Timer();

--- a/lib/sync/sync-processor.js
+++ b/lib/sync/sync-processor.js
@@ -52,7 +52,8 @@ function recordProcessTime(startTime, success) {
 function markDatasetClientAsCompleted(datasetClientId, startTime, callback) {
   syncStorage.updateDatasetClient(datasetClientId, {syncLoopEnd: Date.now(), syncCompleted: true, syncScheduled: null}, function(err){
     if (err) {
-      syncUtil.doLog(datasetId, "error", "Error when update dataset client with id " + datasetClientId + ". error = " + util.inspect(err));
+      // TODO: datasetId here isn't defined, is it?
+      syncUtil.doLog(datasetId, "debug", "Error when update dataset client with id " + datasetClientId + ". error = " + util.inspect(err));
     }
     recordProcessTime(startTime, !err);
     return callback();
@@ -77,7 +78,7 @@ function syncWithBackend(payload, tries, callback) {
 
   if (!datasetClientId || !datasetId) {
     recordProcessTime(startTime, false);
-    syncUtil.doLog(syncUtil.SYNC_LOGGER, "error", "no datasetId value found in sync request payload" + util.inspect(payload));
+    syncUtil.doLog(syncUtil.SYNC_LOGGER, "debug", "no datasetId value found in sync request payload" + util.inspect(payload));
     return callback();
   }
 

--- a/lib/sync/sync-processor.js
+++ b/lib/sync/sync-processor.js
@@ -52,8 +52,7 @@ function recordProcessTime(startTime, success) {
 function markDatasetClientAsCompleted(datasetClientId, startTime, callback) {
   syncStorage.updateDatasetClient(datasetClientId, {syncLoopEnd: Date.now(), syncCompleted: true, syncScheduled: null}, function(err){
     if (err) {
-      // TODO: datasetId here isn't defined, is it?
-      syncUtil.doLog(datasetId, "debug", "Error when update dataset client with id " + datasetClientId + ". error = " + util.inspect(err));
+      syncUtil.doLog(syncUtil.SYNC_LOGGER, "debug", "Error when update dataset client with id " + datasetClientId + ". error = " + util.inspect(err));
     }
     recordProcessTime(startTime, !err);
     return callback();

--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -65,7 +65,7 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
           // if there's a problem, log it and continue.
           // There's nothing we can or should do as it may be an intermittent problem
           if (err) {
-            syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Error adding datasetClients to sync queue (' + util.inspect(err) + ')');
+            syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'Error adding datasetClients to sync queue (' + util.inspect(err) + ')');
           }
           return wcb();
         });
@@ -92,7 +92,7 @@ function tryNext(target, lockCode) {
         syncLock.release(target.syncSchedulerLockName, lockCode, function(err){
           if (err) {
             //if failed, log the error. The lock will be release evetually when `timeBeforeCrashAssumed` is reached.
-            syncUtil.doLog(syncUtil.SYNC_LOGGER, 'warn', 'Failed to release lock due to error (' + util.inspect(err) + ')');
+            syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'Failed to release lock due to error (' + util.inspect(err) + ')');
           }
           target.start();
         });
@@ -118,7 +118,7 @@ SyncScheduler.prototype.start = function() {
       self.checkDatasetsForSyncing(function(err) {
         if (err) {
           // Any error may be intermittent, so log it and continue as normal
-          syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Error checking datasets for syncing ' + util.inspect(err));
+          syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'Error checking datasets for syncing ' + util.inspect(err));
         }
         tryNext(self, lockCode);
       });
@@ -143,6 +143,3 @@ module.exports = function(syncLockImpl, syncStorageImpl, metricsClientImpl) {
     SyncScheduler: SyncScheduler
   };
 };
-
-
- 

--- a/lib/sync/worker.js
+++ b/lib/sync/worker.js
@@ -67,9 +67,9 @@ QueueWorker.prototype.work = function() {
         self.metrics.gauge(metrics.KEYS.WORKER_JOB_PROCESS_TIME, {name: self.name}, timing);
         if (err) {
           self.metrics.inc(metrics.KEYS.WORKER_JOB_FAILURE_COUNT, {name: self.name});
-          //if the processor reports an error, we will not delete the job (ack it). 
-          //This will allow the processor to get the job again and decide if the job should be retried (using the `tries` value). 
-          //If the processor doesn't allow retry, it can call `done` with no error, and that will remove the job. 
+          //if the processor reports an error, we will not delete the job (ack it).
+          //This will allow the processor to get the job again and decide if the job should be retried (using the `tries` value).
+          //If the processor doesn't allow retry, it can call `done` with no error, and that will remove the job.
           //Otherwise the processor can try it again.
           syncUtil.doLog(LOGGER_NAME, 'error', 'Error occured processing job. Job = ' + util.inspect(job)  + ' Error = ' + util.inspect(err));
           return next(self);
@@ -77,7 +77,7 @@ QueueWorker.prototype.work = function() {
           self.metrics.inc(metrics.KEYS.WORKER_JOB_SUCCESS_COUNT, {name: self.name});
           self.queue.ack(job.ack, function(err){
             if (err) {
-              syncUtil.doLog(LOGGER_NAME, 'error', 'Error occured acking job. Job = ' + util.inspect(job)  + ' Error = ' + util.inspect(err));
+              syncUtil.doLog(LOGGER_NAME, 'debug', 'Error occured acking job. Job = ' + util.inspect(job)  + ' Error = ' + util.inspect(err));
             }
             return next(self);
           });


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/FH-3220

Motivation:

See the conversation in the JIRA issue for more details, but basically we want to try to achieve some sort of consistency in the logging from the sync framework.

Modification:

We attempt to follow the suggestions in the bunyan level suggestions section:

https://github.com/trentm/node-bunyan#level-suggestions

Since this is a library rather than an app, almost all logs are turned down to "debug" level (bunyan suggest "trace", but not all loggers have a "trace" level, such as winston, which is what is currently being used).

Result:

* Most log entries are debug level
* Some log entries are error level, when they add context to an error that occurs, and it's difficult to pass that information up to a caller.

Additional Notes:

It's not always clear whether we're passing an `Error` object or a `String` as the *err* first param to a callback. In fact, there's at least one function here in the sync code which passes an `Error` object in one case, and a `String` in another case.

That may be something that's difficult to change now. If we could though, and we choose to pass an `Error` object always, we could consider using the [verror](https://www.npmjs.com/package/verror) module to wrap errors with context as they bubble up to the app, rather than having to log at error level at the points we do.