### PR TITLE
⚡ Improve mongodb query performance by adding the missing indexes

### DIFF
--- a/lib/sync/storage.js
+++ b/lib/sync/storage.js
@@ -136,6 +136,8 @@ function doUpdateDatasetClient(datasetClientId, fields, upsert, cb) {
       syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Failed to update datasetClients due to error ' + util.inspect(err) + ' :: datasetClientId = ' + datasetClientId + ' :: fields = ' + util.inspect(fields));
       return cb(err);
     }
+    //ensure the indexes are create for a given dataset
+    ensureIndexesForDataset(result.value.datasetId);
     return cb(null, result.value);
   });
 }
@@ -331,6 +333,9 @@ function doReadDatasetClientWithRecords(datasetClientId, callback) {
   });
 }
 
+/** Functions related to the updates (acknowledgements) collection*/
+
+
 /**
  * Get the collection name of the updates team
  * @param {String} datasetId
@@ -338,6 +343,18 @@ function doReadDatasetClientWithRecords(datasetClientId, callback) {
  */
 function getDatasetUpdatesCollectionName(datasetId) {
   return ['fhsync', datasetId, 'updates'].join('_');
+}
+
+function doUpdateManyDatasetClients(query, fields, callback) {
+  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'doUpdateManyDatasetClients query = ' + util.inspect(query) + ' :: fields = ' + util.inspect(fields));
+  var datasetClientsCollection = mongoClient.collection(DATASETCLIENTS_COLLECTION);
+  datasetClientsCollection.updateMany(query, {$set: fields}, function(err, result){
+    if (err) {
+      syncUtil.doLog(datasetId, 'error', ' Failed to doUpdateManyDatasetClients due to error ' + util.inspect(err) + ' :: fields = ' + util.inspect(fields));
+      return callback(err);
+    }
+    return callback(null, result);
+  });
 }
 
 /**
@@ -358,18 +375,6 @@ function doFindAndDeleteUpdate(datasetId, acknowledgement, callback) {
   });
 }
 
-function doUpdateManyDatasetClients(query, fields, callback) {
-  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'doUpdateManyDatasetClients query = ' + util.inspect(query) + ' :: fields = ' + util.inspect(fields));
-  var datasetClientsCollection = mongoClient.collection(DATASETCLIENTS_COLLECTION);
-  datasetClientsCollection.updateMany(query, {$set: fields}, function(err, result){
-    if (err) {
-      syncUtil.doLog(datasetId, 'error', ' Failed to doUpdateManyDatasetClients due to error ' + util.inspect(err) + ' :: fields = ' + util.inspect(fields));
-      return callback(err);
-    }
-    return callback(null, result);
-  });
-}
-
 /**
  * Save the sync update to the `fhsync-<datasetId>-updates` collection
  * 
@@ -380,7 +385,7 @@ function doUpdateManyDatasetClients(query, fields, callback) {
 function doSaveUpdate(datasetId, acknowledgementFields, callback) {
   syncUtil.doLog(datasetId, 'debug', 'doSaveUpdate acknowledgementFields = ' + util.inspect(acknowledgementFields));
   var updatesCollection = mongoClient.collection(getDatasetUpdatesCollectionName(datasetId));
-  updatesCollection.findOneAndUpdate({hash: acknowledgementFields.hash, cuid: acknowledgementFields.cuid}, {'$set': acknowledgementFields}, {upsert: true, returnOriginal: false}, function(err, updateResult){
+  updatesCollection.findOneAndUpdate({cuid: acknowledgementFields.cuid, hash: acknowledgementFields.hash}, {'$set': acknowledgementFields}, {upsert: true, returnOriginal: false}, function(err, updateResult){
     if (err) {
       syncUtil.doLog(datasetId, 'error', ' Failed to doSaveUpdate due to error ' + util.inspect(err) + ' :: acknowledgementFields = ' + util.inspect(acknowledgementFields));
       return callback(err);
@@ -409,9 +414,39 @@ function doListUpdates(datasetId, criteria, callback) {
   });
 }
 
+/** Functions related to indexes */
+
+/**
+ * Create an index on the given collection
+ * @param {String} collectionName 
+ * @param {Object} indexField see mongodb indexes
+ * @param {Object} indexOpts see mongodb indexes options
+ */
+function createIndexForCollection(collectionName, indexField, indexOpts) {
+  var collection = mongoClient.collection(collectionName);
+  collection.createIndex(indexField, indexOpts, function(err){
+    if (err) {
+      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'warn', 'Failed to create index for collection. collection = ' + collectionName + ' :: index = ' + util.inspect(indexField) + ' :: error = ' + util.inspect(err));
+    } else {
+      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'Index created for collection. Collection = ' + collection + ' :: index = ' + util.inspect(indexField));
+    }
+  });
+}
+
+/**
+ * Create all the indexes on the collections for a given dataset
+ * @param {String} datasetId
+ */
+function ensureIndexesForDataset(datasetId) {
+  createIndexForCollection(getDatasetRecordsCollectionName(datasetId), {'uid': 1}, {});
+  createIndexForCollection(getDatasetUpdatesCollectionName(datasetId), {'cuid': 1, 'hash': 1}, {});
+}
+
 
 module.exports = function(mongoClientImpl) {
   mongoClient = mongoClientImpl;
+  createIndexForCollection(DATASETCLIENTS_COLLECTION, {'id': 1}, {});
+  createIndexForCollection(DATASETCLIENTS_COLLECTION, {'datasetId': 1}, {});
   return {
     /**
      * list the currently managed dataset clients
@@ -471,8 +506,7 @@ module.exports = function(mongoClientImpl) {
     },
 
     updateManyDatasetClients: function(query, fields, callback) {
-      doUpdateManyDatasetClients(query, fields, callback);
-      //return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doUpdateManyDatasetClients)(query, fields, callback);
+      return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doUpdateManyDatasetClients)(query, fields, callback);
     },
 
     /**


### PR DESCRIPTION
During the load test, we noticed that some mongodb operations are very slow. This PR will add indexes on some of the collections to see if it will improve the performance.

ping @david-martin @aidenkeating for review