### PR TITLE
 🐛  do not delete the datasetclients if they are inactive

### DIFF
--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -49,9 +49,9 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
       var datasetId = datasetClient.getDatasetId();
       if (datasetClient.shouldDeactiveSync()) {
         //if the a datasetclient is not active, we don't need to sync it
-        syncUtil.doLog(datasetId, 'info', 'Deactivating sync for client ' + datasetId + '. No client instances have accessed in ' + datasetClient.getConfig().clientSyncTimeout * 1000 + 'ms');
+        syncUtil.doLog(datasetId, 'debug', 'Deactivating sync for client ' + datasetId + '. No client instances have accessed in ' + datasetClient.getConfig().clientSyncTimeout * 1000 + 'ms');
       } else if (datasetClient.shouldSync()) {
-        syncUtil.doLog(datasetId, 'info', 'schedule sync run for datasetClient ' + datasetClient.id);
+        syncUtil.doLog(datasetId, 'debug', 'schedule sync run for datasetClient ' + datasetClient.id);
         var syncRequest = datasetClient.toJSON();
         //record the start time to allow us measure the overall time it takes to process a sync request
         syncRequest.startTime = Date.now();
@@ -88,7 +88,7 @@ function tryNext(target, lockCode) {
   setTimeout(function(){
     if (!target.stopped) {
       if (lockCode) {
-        syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'release lock ' + target.syncSchedulerLockName);
+        syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'release lock ' + target.syncSchedulerLockName);
         syncLock.release(target.syncSchedulerLockName, lockCode, function(err){
           if (err) {
             //if failed, log the error. The lock will be release evetually when `timeBeforeCrashAssumed` is reached.
@@ -111,10 +111,10 @@ SyncScheduler.prototype.start = function() {
   //we only want one of the workers can become a scheduler
   syncLock.acquire(self.syncSchedulerLockName, self.timeBeforeCrashAssumed, function(err, lockCode){
     if (err) {
-      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'Failed to accquire lock for key ' + self.syncSchedulerLockName + ' error = ' + util.inspect(err));
+      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'Failed to accquire lock for key ' + self.syncSchedulerLockName + ' error = ' + util.inspect(err));
       tryNext(self);
     } else if (lockCode) {
-      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'Got lock for ' + self.syncSchedulerLockName+ ' :: lock = ' + lockCode);
+      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'Got lock for ' + self.syncSchedulerLockName+ ' :: lock = ' + lockCode);
       self.checkDatasetsForSyncing(function(err) {
         if (err) {
           // Any error may be intermittent, so log it and continue as normal
@@ -123,7 +123,7 @@ SyncScheduler.prototype.start = function() {
         tryNext(self, lockCode);
       });
     } else {
-      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'no lock acquired ' + self.syncSchedulerLockName);
+      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'no lock acquired ' + self.syncSchedulerLockName);
       //no lock, try again
       tryNext(self);
     }

--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -43,20 +43,19 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
     }
 
     var datasetClientsToSync = [];
-    var datasetClientsToRemove = [];
 
     _.each(datasetClients, function(datasetClientJson){
       var datasetClient = DatasetClient.fromJSON(datasetClientJson);
       var datasetId = datasetClient.getDatasetId();
-      if (datasetClient.shouldSync()) {
+      if (datasetClient.shouldDeactiveSync()) {
+        //if the a datasetclient is not active, we don't need to sync it
+        syncUtil.doLog(datasetId, 'info', 'Deactivating sync for client ' + datasetId + '. No client instances have accessed in ' + datasetClient.getConfig().clientSyncTimeout * 1000 + 'ms');
+      } else if (datasetClient.shouldSync()) {
         syncUtil.doLog(datasetId, 'info', 'schedule sync run for datasetClient ' + datasetClient.id);
         var syncRequest = datasetClient.toJSON();
         //record the start time to allow us measure the overall time it takes to process a sync request
         syncRequest.startTime = Date.now();
         datasetClientsToSync.push(syncRequest);
-      } else if (datasetClient.shouldDeactiveSync()) {
-        syncUtil.doLog(datasetId, 'info', 'Deactivating sync for client ' + datasetId + '. No client instances have accessed in ' + datasetClient.getConfig().clientSyncTimeout * 1000 + 'ms');
-        datasetClientsToRemove.push(datasetClient.toJSON());
       }
     });
 
@@ -76,14 +75,6 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
         async.each(datasetClientsToSync, function(datasetClient, cb){
           syncStorage.updateDatasetClient(datasetClient.id, {syncScheduled: Date.now()}, cb);
         }, wcb);
-      },
-      function removeDatasetClientsFromSyncList(wcb) {
-        syncStorage.removeDatasetClients(datasetClientsToRemove, function(err){
-          if (err) {
-            syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Error removing datasetClients from storage (' + util.inspect(err) + ')');
-          }
-        });
-        return wcb();
       }
     ],
     function(){

--- a/test/sync/test_sync-scheduler.js
+++ b/test/sync/test_sync-scheduler.js
@@ -12,7 +12,6 @@ var lock = {
 
 var syncStorage = {
   listDatasetClients: sinon.stub(),
-  removeDatasetClients: sinon.stub(),
   updateDatasetClient: sinon.stub()
 };
 
@@ -91,7 +90,6 @@ module.exports = {
 
     syncStorage.listDatasetClients.yieldsAsync(null, datasetClients);
     syncQueue.addMany.yieldsAsync();
-    syncStorage.removeDatasetClients.yieldsAsync();
     syncStorage.updateDatasetClient.yieldsAsync();
 
     var scheduler = new SyncScheduler(syncQueue, {timeBetweenChecks: 2000}); //only run the sync loop once
@@ -106,11 +104,6 @@ module.exports = {
       assert.equal(datasetClientsToSync[0].queryParams.user, "user1");
 
       assert.ok(syncStorage.updateDatasetClient.calledOnce);
-
-      assert.ok(syncStorage.removeDatasetClients.calledOnce);
-      var datasetClientsToRemove = syncStorage.removeDatasetClients.args[0][0];
-      assert.equal(datasetClientsToRemove.length, 1);
-      assert.equal(datasetClientsToRemove[0].queryParams.user, "user2");
 
       done();
     }, 1500);
@@ -128,7 +121,6 @@ module.exports = {
     syncStorage.listDatasetClients.yieldsAsync(null, datasetClients);
     syncStorage.updateDatasetClient.yieldsAsync();
     syncQueue.addMany.yieldsAsync();
-    syncStorage.removeDatasetClients.yieldsAsync();
     var scheduler = new SyncScheduler(syncQueue, {timeBetweenChecks: 100});
     scheduler.start();
     setTimeout(function(){


### PR DESCRIPTION
This PR will not remove the dataset clients immediately if they are inactive. We will not sync them but leave them in the db.

There will be another PR to add the job that will clean then up.

ping @david-martin @aidenkeating for review