### PR TITLE
🐛 FH-3254 Add a null check for dataset client before processing

### DIFF
--- a/integration/sync/test_storage.js
+++ b/integration/sync/test_storage.js
@@ -109,6 +109,19 @@ module.exports = {
         });
       });
     },
+    'test dataset client update when null': function(done) {
+      var datasetClientUpdateFields = {
+        props: {syncRunning: true},
+        metaData: {token: 'testToken'}
+      };
+      async.series([
+        async.apply(storage.updateDatasetClient, 'invalid_id', datasetClientUpdateFields),
+      ], function(err){
+        assert.ok(err);
+        assert.equal(err.message, 'DatasetClient not found for id invalid_id');
+        done();
+      });
+    },
     'test dataset client remove': function(done) {
       async.series([
         async.apply(storage.upsertDatasetClient, datasetClient1.id, datasetClient1),

--- a/lib/sync/storage.js
+++ b/lib/sync/storage.js
@@ -136,6 +136,11 @@ function doUpdateDatasetClient(datasetClientId, fields, upsert, cb) {
       syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Failed to update datasetClients due to error ' + util.inspect(err) + ' :: datasetClientId = ' + datasetClientId + ' :: fields = ' + util.inspect(fields));
       return cb(err);
     }
+
+    if (result.value === null) {
+      return cb(new Error('DatasetClient not found for id ' + datasetClientId));
+    }
+
     //ensure the indexes are create for a given dataset
     ensureIndexesForDataset(result.value.datasetId);
     return cb(null, result.value);


### PR DESCRIPTION
This change prevents a scenario where a datasetclient has been removed
from the db (via a cleanup task for inactive clients) yet there are
still pending items in the queue for that datasetclient.
In that scenario, it is best to mark the pending update as failed as we
don't have enough info to process it correctly.
The update failed notification will be triggered on the client whenever
they become active again and do a sync with the server