### PR TITLE
[FH 3228] split index js

### DIFF
--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -14,18 +14,6 @@ function toJSON(dataset_id, returnData, cb) {
   return cb(null, {});
 }
 
-function listCollisions(dataset_id, params, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'listCollisions');
-  return server.api.listCollisions(dataset_id, params.meta_data, cb);
-}
-
-// Defines a handler function for deleting a collision from the collisions list.
-// Should be called after the dataset is initialised.
-function removeCollision(dataset_id, params, cb) {
-  syncUtil.doLog(dataset_id, 'info', 'removeCollision');
-  return server.api.removeCollision(dataset_id, params.hash, params.meta_data, cb);
-}
-
 /**
  * Connect to mongodb & redis with the given connection urls.
  * This should be called before `start()` is called
@@ -113,8 +101,8 @@ module.exports = _.extend({}, server, {
   connect: connect,
   sync: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.sync),
   syncRecords: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.syncRecords),
-  listCollisions: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, listCollisions),
-  removeCollision: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, removeCollision),
+  listCollisions: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.api.listCollisions),
+  removeCollision: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.api.removeCollision),
   setLogLevel: setLogLevel,
   api: _.extend({}, server.api, {
     invoke: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, invoke),

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -3,6 +3,8 @@ var metricsModule = require('./sync-metrics');
 var _ = require('underscore');
 var server = require('./sync-server');
 var util = require('util');
+var MongoClient = require('mongodb').MongoClient;
+var redis = require('redis');
 
 function toJSON(dataset_id, returnData, cb) {
   syncUtil.doLog(dataset_id, 'debug', 'toJSON');
@@ -22,6 +24,45 @@ function listCollisions(dataset_id, params, cb) {
 function removeCollision(dataset_id, params, cb) {
   syncUtil.doLog(dataset_id, 'info', 'removeCollision');
   return server.api.removeCollision(dataset_id, params.hash, params.meta_data, cb);
+}
+
+/**
+ * Connect to mongodb & redis with the given connection urls.
+ * This should be called before `start()` is called
+ *
+ * @param {string} mongoDBConnectionUrl A MongoDB connection uril in a format supported by the `mongodb` module
+ * @param {string} redisUrl A redis connection url in a format supported by the `redis` module
+ * @param {Object} metricsConf Metrics configuration
+ * @param {function} cb
+ */
+function connect(mongoDBConnectionUrl, redisUrl, metricsConf, cb) {
+  if (arguments.length < 4) throw new Error('connect requires 4 arguments');
+
+  async.series([
+    function connectToMongoDB(callback) {
+      MongoClient.connect(mongoDBConnectionUrl, callback);
+    },
+    function connectToRedis(callback) {
+      if (redisUrl) {
+        var redisOpts = {
+          url: redisUrl
+        };
+        var client = redis.createClient(redisOpts);
+        return callback(null, client);
+      } else {
+        return callback();
+      }
+    }
+  ], function(err, results) {
+    if (err) return cb(err);
+    var mongoDbClient = results[0];
+    var redisClient = results[1];
+    var metricsClient = metricsModule.init(metricsConf);
+
+    server.setClients(mongoDbClient, redisClient, metricsClient);
+
+    return cb(null, mongoDbClient, redisClient, metricsClient);
+  });
 }
 
 function setLogLevel(dataset_id, params, cb) {
@@ -69,6 +110,7 @@ function invoke(dataset_id, params, callback) {
 
 // extend from empty object to force copy, and because last source overrides the previous ones
 module.exports = _.extend({}, server, {
+  connect: connect,
   sync: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.sync),
   syncRecords: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.syncRecords),
   listCollisions: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, listCollisions),

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -102,7 +102,7 @@ function setConfig(conf) {
 function init(dataset_id, options, cb) {
   syncUtil.doLog(dataset_id, 'debug', 'init sync for dataset ' + dataset_id + ' with options ' + util.inspect(options));
   datasets.init(dataset_id, options);
-  start(function(err){
+  start(function(err) {
     if (err) {
       return cb(err);
     }
@@ -140,7 +140,7 @@ function stopAll(cb) {
     async.apply(pendingWorker.stop.bind(pendingWorker)),
     async.apply(syncScheduler.stop.bind(syncScheduler)),
     async.apply(datasetClientsCleaner.stop.bind(datasetClientsCleaner))
-  ], function(err){
+  ], function(err) {
     if (err) {
       syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Failed to stop sync due to error : ' + util.inspect(err));
       return cb(err);
@@ -185,8 +185,7 @@ function setLogLevel(dataset_id, params, cb) {
     syncUtil.doLog(dataset_id, 'debug', 'Setting logLevel to "' + params.logLevel + '"');
     syncUtil.setLogger(dataset_id, params);
     cb && cb(null, {"status": "ok"});
-  }
-  else {
+  } else {
     cb && cb('logLevel parameter required');
   }
 }
@@ -232,7 +231,7 @@ function connect(mongoDBConnectionUrl, redisUrl, metricsConf, cb) {
     mongoDbClient = results[0];
     redisClient = results[1];
     metricsClient = metricsModule.init(metricsConf);
-    dataHandlers = dataHandlersModule(options = {
+    dataHandlers = dataHandlersModule({
       defaultHandlers: defaultDataHandlersModule(mongoDbClient)
     });
     syncStorage = storageModule(mongoDbClient);
@@ -366,5 +365,5 @@ var handlerOverrides = {
 _.each(handlerOverrides, function(target, methodName) {
   module.exports.api[methodName] = function() {
     dataHandlers[target].apply(null, arguments);
-  }
+  };
 });

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -1,58 +1,8 @@
 var syncUtil = require('./util');
-var async = require('async');
-var util = require('util');
-var MongoClient = require('mongodb').MongoClient;
-var redis = require('redis');
-var _ = require('underscore');
 var metricsModule = require('./sync-metrics');
-var MongodbQueue = require('./mongodbQueue');
-var Worker = require('./worker');
-var dataHandlersModule = require('./dataHandlers');
-var defaultDataHandlersModule = require('./default-dataHandlers');
-var storageModule = require('./storage');
-var hashProviderModule = require('./hashProvider');
-var ackProcessor = require('./ack-processor');
-var pendingProcessor = require('./pending-processor');
-var syncProcessor = require('./sync-processor');
-var syncSchedulerModule = require('./sync-scheduler');
-var syncLockModule = require('./lock');
-var interceptorsModule = require('./interceptors');
-var syncApiModule = require('./api-sync');
-var syncRecordsApiModule = require('./api-syncRecords');
-var datasets = require('./datasets');
-var datasetClientsCleanerModule = require('./datasetClientsCleaner');
-
-//default global configuration options for the sync server
-var DEFAULT_SYNC_CONF = {
-  //how often workers should check for the next job. Default: 1s
-  workerInterval: 1000,
-  //how often the scheduler should check the datasetClients. Default: 500ms
-  schedulerInterval: 500,
-  //the max time a scheduler can hold the lock for. Default: 20s
-  schedulerLockMaxTime: 20000,
-  //the default lock name for the sync scheduler
-  schedulerLockName: 'locks:sync:SyncScheduler',
-  datasetClientRetentionPeriod: '24h',
-  datasetClientCleanerCheckFrequency: '1h'
-};
-
-var ackQueue, pendingQueue, syncQueue, ackWorker, pendingWorker, syncWorker, datasetClientsCleaner;
-
-//TODO: remove redisClient. We probably don't need it anymore
-var redisClient = null;
-var mongoDbClient = null;
-var metricsClient = null;
-var dataHandlers = null;
-var syncStorage = null;
-var hashProvider = null;
-var syncLock = null;
-var interceptors = null;
-var apiSync = null;
-var apiSyncRecords = null;
-var syncScheduler = null;
-
-var syncStarted = false;
-var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
+var _ = require('underscore');
+var server = require('./sync-server');
+var util = require('util');
 
 function toJSON(dataset_id, returnData, cb) {
   syncUtil.doLog(dataset_id, 'debug', 'toJSON');
@@ -62,121 +12,16 @@ function toJSON(dataset_id, returnData, cb) {
   return cb(null, {});
 }
 
-// Functions that are allowed to be invoked
-var invokeFunctions = ['sync', 'syncRecords', 'listCollisions', 'removeCollision', 'setLogLevel'];
-
-// Invoke the Sync Server.
-function invoke(dataset_id, params, callback) {
-  syncUtil.doLog(dataset_id, 'debug', 'invoke');
-
-  if (arguments.length < 3) throw new Error('invoke requires 3 arguments');
-
-  // Verify that fn param has been passed
-  if (!params || !params.fn) {
-    var err = 'no fn parameter provided in params "' + util.inspect(params) + '"';
-    syncUtil.doLog(dataset_id, 'debug', err, params);
-    return callback(err, null);
-  }
-
-  var fn = params.fn;
-
-  // Verify that fn param is valid
-  if (invokeFunctions.indexOf(fn) < 0) {
-    return callback('invalid fn parameter provided in params "' + fn + '"', null);
-  }
-  var fnHandler = module.exports[fn];
-
-  start(function(err) {
-    if (err) {
-      return callback(err);
-    }
-    return fnHandler(dataset_id, params, callback);
-  });
-}
-
-function setConfig(conf) {
-  syncConfig = _.extend({}, DEFAULT_SYNC_CONF, conf);
-}
-
-// Initialise cloud data sync service for specified dataset.
-function init(dataset_id, options, cb) {
-  syncUtil.doLog(dataset_id, 'debug', 'init sync for dataset ' + dataset_id + ' with options ' + util.inspect(options));
-  datasets.init(dataset_id, options);
-  start(function(err) {
-    if (err) {
-      return cb(err);
-    }
-    syncStorage.updateManyDatasetClients({datasetId: dataset_id}, {stopped: false}, cb);
-  });
-}
-
-// Stop cloud data sync for the specified dataset_id.
-function stop(dataset_id, cb) {
-  if (!syncStarted) {
-    return cb();
-  }
-  syncUtil.doLog(dataset_id, 'debug', 'stop sync for dataset');
-  syncStorage.updateManyDatasetClients({datasetId: dataset_id}, {stopped: true}, cb);
-}
-
-// Stop cloud data sync service for ALL datasets and reset.
-// This should really only used by tests.
-function stopAll(cb) {
-  //sync is not started yet, but connect could be called already. In this case, just reset a few things
-  if (!syncStarted) {
-    mongoDbClient = null;
-    redisClient = null;
-    metricsClient = null;
-    return cb();
-  }
-  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'stopAll syncs');
-  ackQueue.stopPruneJob();
-  pendingQueue.stopPruneJob();
-  syncQueue.stopPruneJob();
-  async.parallel([
-    async.apply(syncStorage.updateManyDatasetClients, {}, {stopped: true}),
-    async.apply(syncWorker.stop.bind(syncWorker)),
-    async.apply(ackWorker.stop.bind(ackWorker)),
-    async.apply(pendingWorker.stop.bind(pendingWorker)),
-    async.apply(syncScheduler.stop.bind(syncScheduler)),
-    async.apply(datasetClientsCleaner.stop.bind(datasetClientsCleaner))
-  ], function(err) {
-    if (err) {
-      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Failed to stop sync due to error : ' + util.inspect(err));
-      return cb(err);
-    }
-    setConfig();
-    dataHandlers.restore();
-    interceptors.restore();
-    mongoDbClient = null;
-    redisClient = null;
-    metricsClient = null;
-    ackQueue = null;
-    pendingQueue = null;
-    syncQueue = null;
-    ackWorker = null;
-    pendingWorker = null;
-    syncWorker = null;
-    syncStarted = false;
-    dataHandlers = null;
-    interceptors = null;
-    hashProvider = null;
-    syncLock = null;
-    datasetClientsCleaner = null;
-    return cb();
-  });
-}
-
 function listCollisions(dataset_id, params, cb) {
-  syncUtil.doLog(dataset_id, 'debug', 'listCollisions');
-  return dataHandlers.listCollisions(dataset_id, params.meta_data, cb);
+  syncUtil.doLog(dataset_id, 'info', 'listCollisions');
+  return server.api.listCollisions(dataset_id, params.meta_data, cb);
 }
 
 // Defines a handler function for deleting a collision from the collisions list.
 // Should be called after the dataset is initialised.
 function removeCollision(dataset_id, params, cb) {
-  syncUtil.doLog(dataset_id, 'debug', 'removeCollision');
-  return dataHandlers.removeCollision(dataset_id, params.hash, params.meta_data, cb);
+  syncUtil.doLog(dataset_id, 'info', 'removeCollision');
+  return server.api.removeCollision(dataset_id, params.hash, params.meta_data, cb);
 }
 
 function setLogLevel(dataset_id, params, cb) {
@@ -190,157 +35,51 @@ function setLogLevel(dataset_id, params, cb) {
   }
 }
 
-function sync(datasetId, params, cb) {
-  apiSync(datasetId, params, cb);
-}
+// Functions that are allowed to be invoked
+var invokeFunctions = ['sync', 'syncRecords', 'listCollisions', 'removeCollision', 'setLogLevel'];
 
-// Synchronise the individual records for a dataset
-function syncRecords(datasetId, params, cb) {
-  apiSyncRecords(datasetId, params, cb);
-}
+// Invoke the Sync Server.
+function invoke(dataset_id, params, callback) {
+  syncUtil.doLog(dataset_id, 'info', 'invoke');
 
-/**
- * Connect to mongodb & redis with the given connection urls.
- * This should be called before `start()` is called
- *
- * @param {string} mongoDBConnectionUrl A MongoDB connection uril in a format supported by the `mongodb` module
- * @param {string} redisUrl A redis connection url in a format supported by the `redis` module
- * @param {Object} metricsConf Metrics configuration
- * @param {function} cb
- */
-function connect(mongoDBConnectionUrl, redisUrl, metricsConf, cb) {
-  if (arguments.length < 4) throw new Error('connect requires 4 arguments');
+  if (arguments.length < 3) throw new Error('invoke requires 3 arguments');
 
-  async.series([
-    function connectToMongoDB(callback) {
-      MongoClient.connect(mongoDBConnectionUrl, callback);
-    },
-    function connectToRedis(callback) {
-      if (redisUrl) {
-        var redisOpts = {
-          url: redisUrl
-        };
-        var client = redis.createClient(redisOpts);
-        return callback(null, client);
-      } else {
-        return callback();
-      }
-    }
-  ], function(err, results) {
-    if (err) return cb(err);
-    mongoDbClient = results[0];
-    redisClient = results[1];
-    metricsClient = metricsModule.init(metricsConf);
-    dataHandlers = dataHandlersModule({
-      defaultHandlers: defaultDataHandlersModule(mongoDbClient)
-    });
-    syncStorage = storageModule(mongoDbClient);
-    // TODO: follow same pattern as other modules for this hashProviderModule
-    hashProvider = hashProviderModule;
-    syncLock = syncLockModule(mongoDbClient, 'fhsync_locks');
-    interceptors = interceptorsModule();
-    return cb(null, mongoDbClient, redisClient, metricsClient);
-  });
-}
-
-/**
- * Starts all sync queues, workers & the sync scheduler.
- * This should only be called after `connect()`.
- * If this is not explicitly called before clients send sync requests,
- * it will be called when a client sends a sync request.
- * It is OK for this to be called multiple times.
- *
- * @param {function} cb
- */
-function start(cb) {
-  if (arguments.length < 1) throw new Error('start requires 1 argument');
-
-  if (syncStarted) return cb();
-
-  if (mongoDbClient === null || redisClient === null) {
-    return cb('MongoDB Client & Redis Client are not connected. Ensure connect() is called before calling start');
+  // Verify that fn param has been passed
+  if (!params || !params.fn) {
+    var err = 'no fn parameter provided in params "' + util.inspect(params) + '"';
+    syncUtil.doLog(dataset_id, 'warn', err, params);
+    return callback(err, null);
   }
 
-  async.series([
-    function createQueues(callback) {
-      ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, {mongodb: mongoDbClient});
-      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, {mongodb: mongoDbClient});
-      syncQueue = new MongodbQueue('fhsync_queue', metricsClient, {mongodb: mongoDbClient});
+  var fn = params.fn;
 
-      async.parallel([
-        async.apply(ackQueue.create.bind(ackQueue)),
-        async.apply(ackQueue.startPruneJob.bind(ackQueue), true),
-        async.apply(pendingQueue.create.bind(pendingQueue)),
-        async.apply(pendingQueue.startPruneJob.bind(ackQueue), true),
-        async.apply(syncQueue.create.bind(syncQueue)),
-        async.apply(syncQueue.startPruneJob.bind(ackQueue), true),
-      ], callback);
-    },
-    function initApis(callback) {
-      apiSync = syncApiModule(interceptors, ackQueue, pendingQueue, syncStorage);
-      apiSyncRecords = syncRecordsApiModule(syncStorage, pendingQueue);
-      return callback();
-    },
-    function createWorkers(callback) {
-      var syncProcessorImpl = syncProcessor(syncStorage, dataHandlers, metricsClient, hashProvider);
-      syncWorker = new Worker(syncQueue, syncProcessorImpl, metricsClient, {name: 'sync_worker', interval: syncConfig.workerInterval});
+  // Verify that fn param is valid
+  if (invokeFunctions.indexOf(fn) < 0) {
+    return callback('invalid fn parameter provided in params "' + fn + '"', null);
+  }
+  var fnHandler =  module.exports[fn] || server[fn] || server.api[fn];
 
-      var ackProcessorImpl = ackProcessor(syncStorage);
-      ackWorker = new Worker(ackQueue, ackProcessorImpl, metricsClient, {name: 'ack_worker', interval: syncConfig.workerInterval});
-
-      var pendingProcessorImpl = pendingProcessor(syncStorage, dataHandlers, hashProvider, metricsClient);
-      pendingWorker = new Worker(pendingQueue, pendingProcessorImpl, metricsClient, {name: 'pending_worker', interval: syncConfig.workerInterval});
-
-      ackWorker.work();
-      pendingWorker.work();
-      syncWorker.work();
-      return callback();
-    },
-    function startSyncScheduler(callback) {
-      var SyncScheduler = syncSchedulerModule(syncLock, syncStorage, metricsClient).SyncScheduler;
-      syncScheduler = new SyncScheduler(syncQueue, {timeBetweenChecks: syncConfig.schedulerInterval, timeBeforeCrashAssumed: syncConfig.schedulerLockMaxTime, syncSchedulerLockName: syncConfig.schedulerLockName});
-      syncScheduler.start();
-      return callback();
-    },
-    function startDatasetClientCleaner(callback) {
-      datasetClientsCleaner = datasetClientsCleanerModule(syncStorage)({retentionPeriod: syncConfig.datasetClientRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
-      datasetClientsCleaner.start.bind(datasetClientsCleaner)(true, callback);
+  server.api.start(function(err) {
+    if (err) {
+      return callback(err);
     }
-  ], function(err) {
-    if (err) return cb(err);
-    syncStarted = true;
-    return cb();
+    return fnHandler(dataset_id, params, callback);
   });
 }
 
-module.exports = {
-  sync: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, sync),
-  syncRecords: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, syncRecords),
+// extend from empty object to force copy, and because last source overrides the previous ones
+module.exports = _.extend({}, server, {
+  sync: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.sync),
+  syncRecords: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.syncRecords),
   listCollisions: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, listCollisions),
   removeCollision: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, removeCollision),
-  api: {
-    init: init,
+  setLogLevel: setLogLevel,
+  api: _.extend({}, server.api, {
     invoke: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, invoke),
-    stop: stop,
-    stopAll: stopAll,
-    connect: connect,
     toJSON: toJSON,
     setLogLevel: setLogLevel,
-    setConfig: setConfig,
-    globalInterceptRequest: function(fn) {
-      interceptors.setDefaultRequestInterceptor(fn);
-    },
-    globalInterceptResponse: function(fn) {
-      interceptors.setDefaultResponseInterceptor(fn);
-    },
-    interceptRequest: function(datasetId, fn) {
-      interceptors.setRequestInterceptor(datasetId, fn);
-    },
-    interceptResponse: function(datasetId, fn) {
-      interceptors.setResponseInterceptor(datasetId, fn);
-    }
-  }
-};
+  })
+});
 
 //Expose the handler overrides as part of the API. Each key is the name of the public interface, and the value is the name of function in dataHandlers
 var handlerOverrides = {
@@ -364,6 +103,6 @@ var handlerOverrides = {
 
 _.each(handlerOverrides, function(target, methodName) {
   module.exports.api[methodName] = function() {
-    dataHandlers[target].apply(null, arguments);
+    server.api.callHandler(target, arguments);
   };
 });

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -5,6 +5,7 @@ var server = require('./sync-server');
 var util = require('util');
 var MongoClient = require('mongodb').MongoClient;
 var redis = require('redis');
+var async = require('async');
 
 function toJSON(dataset_id, returnData, cb) {
   syncUtil.doLog(dataset_id, 'debug', 'toJSON');
@@ -64,10 +65,10 @@ function setLogLevel(dataset_id, params, cb) {
   }
 }
 
-// Functions that are allowed to be invoked
+/** @type {Array} Functions that are allowed to be invoked */
 var invokeFunctions = ['sync', 'syncRecords', 'listCollisions', 'removeCollision', 'setLogLevel'];
 
-// Invoke the Sync Server.
+/** Invoke the Sync Server. */
 function invoke(dataset_id, params, callback) {
   syncUtil.doLog(dataset_id, 'info', 'invoke');
 
@@ -86,6 +87,7 @@ function invoke(dataset_id, params, callback) {
   if (invokeFunctions.indexOf(fn) < 0) {
     return callback('invalid fn parameter provided in params "' + fn + '"', null);
   }
+
   var fnHandler =  module.exports[fn] || server[fn] || server.api[fn];
 
   server.api.start(function(err) {
@@ -98,14 +100,14 @@ function invoke(dataset_id, params, callback) {
 
 // extend from empty object to force copy, and because last source overrides the previous ones
 module.exports = _.extend({}, server, {
-  connect: connect,
   sync: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.sync),
   syncRecords: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.syncRecords),
   listCollisions: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.api.listCollisions),
   removeCollision: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, server.api.removeCollision),
   setLogLevel: setLogLevel,
   api: _.extend({}, server.api, {
-    invoke: metricsModule.timeAsyncFunc(metricsModule.KEYS.SYNC_API_PROCESS_TIME, invoke),
+    connect: connect,
+    invoke: invoke,
     toJSON: toJSON,
     setLogLevel: setLogLevel,
   })

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -5,11 +5,8 @@ var datasets = require('./datasets');
 var defaultDataHandlersModule = require('./default-dataHandlers');
 var hashProviderModule = require('./hashProvider');
 var interceptorsModule = require('./interceptors');
-var metricsModule = require('./sync-metrics');
-var MongoClient = require('mongodb').MongoClient;
 var MongodbQueue = require('./mongodbQueue');
 var pendingProcessor = require('./pending-processor');
-var redis = require('redis');
 var storageModule = require('./storage');
 var syncApiModule = require('./api-sync');
 var syncLockModule = require('./lock');
@@ -67,50 +64,19 @@ function init(dataset_id, options, cb) {
   });
 }
 
-/**
- * Connect to mongodb & redis with the given connection urls.
- * This should be called before `start()` is called
- *
- * @param {string} mongoDBConnectionUrl A MongoDB connection uril in a format supported by the `mongodb` module
- * @param {string} redisUrl A redis connection url in a format supported by the `redis` module
- * @param {Object} metricsConf Metrics configuration
- * @param {function} cb
- */
-function connect(mongoDBConnectionUrl, redisUrl, metricsConf, cb) {
-  if (arguments.length < 4) throw new Error('connect requires 4 arguments');
-
-  async.series([
-    function connectToMongoDB(callback) {
-      MongoClient.connect(mongoDBConnectionUrl, callback);
-    },
-    function connectToRedis(callback) {
-      if (redisUrl) {
-        var redisOpts = {
-          url: redisUrl
-        };
-        var client = redis.createClient(redisOpts);
-        return callback(null, client);
-      } else {
-        return callback();
-      }
-    }
-  ], function(err, results) {
-    if (err) return cb(err);
-    mongoDbClient = results[0];
-    redisClient = results[1];
-    metricsClient = metricsModule.init(metricsConf);
-    dataHandlers = dataHandlersModule({
-      defaultHandlers: defaultDataHandlersModule(mongoDbClient)
-    });
-    syncStorage = storageModule(mongoDbClient);
-    // TODO: follow same pattern as other modules for this hashProviderModule
-    hashProvider = hashProviderModule;
-    syncLock = syncLockModule(mongoDbClient, 'fhsync_locks');
-    interceptors = interceptorsModule();
-    return cb(null, mongoDbClient, redisClient, metricsClient);
+function setClients(mongo, redis, metrics) {
+  mongoDbClient = mongo;
+  redisClient = redis;
+  metricsClient = metrics;
+  dataHandlers = dataHandlersModule({
+    defaultHandlers: defaultDataHandlersModule(mongoDbClient)
   });
+  syncStorage = storageModule(mongoDbClient);
+  // TODO: follow same pattern as other modules for this hashProviderModule
+  hashProvider = hashProviderModule;
+  syncLock = syncLockModule(mongoDbClient, 'fhsync_locks');
+  interceptors = interceptorsModule();
 }
-
 
 /**
  * Starts all sync queues, workers & the sync scheduler.
@@ -273,8 +239,8 @@ function callHandler(handlerName, args) {
 module.exports = {
   sync: sync,
   syncRecords: syncRecords,
+  setClients: setClients,
   api: {
-    connect: connect,
     init: init,
     start: start,
     stop: stop,

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -237,7 +237,7 @@ function listCollisions(datasetId, params, cb) {
  */
 function removeCollision(datasetId, params, cb) {
   syncUtil.doLog(datasetId, 'info', 'removeCollision');
-  dataHandlers.removeCollision(datasetId, params.meta_data, cb);
+  dataHandlers.removeCollision(datasetId, params.hash, params.meta_data, cb);
 }
 
 function callHandler(handlerName, args) {

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -225,11 +225,15 @@ function interceptResponse(datasetId, fn) {
 }
 
 function listCollisions(datasetId, params, cb) {
-  dataHandlers.listCollisions(datasetId, params, cb);
+  syncUtil.doLog(datasetId, 'info', 'listCollisions');
+  dataHandlers.listCollisions(datasetId, params.meta_data, cb);
 }
 
+// Defines a handler function for deleting a collision from the collisions list.
+// Should be called after the dataset is initialised.
 function removeCollision(datasetId, params, cb) {
-  dataHandlers.removeCollision(datasetId, params, cb);
+  syncUtil.doLog(datasetId, 'info', 'removeCollision');
+  dataHandlers.removeCollision(datasetId, params.meta_data, cb);
 }
 
 function callHandler(handlerName, args) {

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -1,0 +1,291 @@
+var ackProcessor = require('./ack-processor');
+var async = require('async');
+var dataHandlersModule = require('./dataHandlers');
+var datasets = require('./datasets');
+var defaultDataHandlersModule = require('./default-dataHandlers');
+var hashProviderModule = require('./hashProvider');
+var interceptorsModule = require('./interceptors');
+var metricsModule = require('./sync-metrics');
+var MongoClient = require('mongodb').MongoClient;
+var MongodbQueue = require('./mongodbQueue');
+var pendingProcessor = require('./pending-processor');
+var redis = require('redis');
+var storageModule = require('./storage');
+var syncApiModule = require('./api-sync');
+var syncLockModule = require('./lock');
+var syncProcessor = require('./sync-processor');
+var syncRecordsApiModule = require('./api-syncRecords');
+var syncSchedulerModule = require('./sync-scheduler');
+var syncUtil = require('./util');
+var util = require('util');
+var Worker = require('./worker');
+var _ = require('underscore');
+
+//TODO: remove redisClient. We probably don't need it anymore
+var redisClient = null;
+var mongoDbClient = null;
+var metricsClient = null;
+var hashProvider = null;
+var syncLock = null;
+var syncScheduler = null;
+var syncStorage = null;
+var interceptors = null;
+var apiSync = null;
+var apiSyncRecords = null;
+var dataHandlers = null;
+
+var ackQueue;
+var pendingQueue;
+var syncQueue;
+var ackWorker;
+var pendingWorker;
+var syncWorker;
+
+//default global configuration options for the sync server
+var DEFAULT_SYNC_CONF = {
+  //how often workers should check for the next job. Default: 1s
+  workerInterval: 1000,
+  //how often the scheduler should check the datasetClients. Default: 500ms
+  schedulerInterval: 500,
+  //the max time a scheduler can hold the lock for. Default: 20s
+  schedulerLockMaxTime: 20000,
+  //the default lock name for the sync scheduler
+  schedulerLockName: 'locks:sync:SyncScheduler'
+};
+var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
+var syncStarted = false;
+
+// Initialise cloud data sync service for specified dataset.
+function init(dataset_id, options, cb) {
+  syncUtil.doLog(dataset_id, 'info', 'init sync for dataset ' + dataset_id + ' with options ' + util.inspect(options));
+  datasets.init(dataset_id, options);
+  start(function(err) {
+    if (err) {
+      return cb(err);
+    }
+    syncStorage.updateManyDatasetClients({datasetId: dataset_id}, {stopped: false}, cb);
+  });
+}
+
+/**
+ * Connect to mongodb & redis with the given connection urls.
+ * This should be called before `start()` is called
+ *
+ * @param {string} mongoDBConnectionUrl A MongoDB connection uril in a format supported by the `mongodb` module
+ * @param {string} redisUrl A redis connection url in a format supported by the `redis` module
+ * @param {Object} metricsConf Metrics configuration
+ * @param {function} cb
+ */
+function connect(mongoDBConnectionUrl, redisUrl, metricsConf, cb) {
+  if (arguments.length < 4) throw new Error('connect requires 4 arguments');
+
+  async.series([
+    function connectToMongoDB(callback) {
+      MongoClient.connect(mongoDBConnectionUrl, callback);
+    },
+    function connectToRedis(callback) {
+      if (redisUrl) {
+        var redisOpts = {
+          url: redisUrl
+        };
+        var client = redis.createClient(redisOpts);
+        return callback(null, client);
+      } else {
+        return callback();
+      }
+    }
+  ], function(err, results) {
+    if (err) return cb(err);
+    mongoDbClient = results[0];
+    redisClient = results[1];
+    metricsClient = metricsModule.init(metricsConf);
+    dataHandlers = dataHandlersModule({
+      defaultHandlers: defaultDataHandlersModule(mongoDbClient)
+    });
+    syncStorage = storageModule(mongoDbClient);
+    // TODO: follow same pattern as other modules for this hashProviderModule
+    hashProvider = hashProviderModule;
+    syncLock = syncLockModule(mongoDbClient, 'fhsync_locks');
+    interceptors = interceptorsModule();
+    return cb(null, mongoDbClient, redisClient, metricsClient);
+  });
+}
+
+
+/**
+ * Starts all sync queues, workers & the sync scheduler.
+ * This should only be called after `connect()`.
+ * If this is not explicitly called before clients send sync requests,
+ * it will be called when a client sends a sync request.
+ * It is OK for this to be called multiple times.
+ *
+ * @param {function} cb
+ */
+function start(cb) {
+  if (arguments.length < 1) throw new Error('start requires 1 argument');
+
+  if (syncStarted) return cb();
+
+  if (mongoDbClient === null || redisClient === null) {
+    return cb('MongoDB Client & Redis Client are not connected. Ensure connect() is called before calling start');
+  }
+
+  async.series([
+    function createQueues(callback) {
+      ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, {mongodb: mongoDbClient});
+      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, {mongodb: mongoDbClient});
+      syncQueue = new MongodbQueue('fhsync_queue', metricsClient, {mongodb: mongoDbClient});
+
+      async.parallel([
+        async.apply(ackQueue.create.bind(ackQueue)),
+        async.apply(ackQueue.startPruneJob.bind(ackQueue), true),
+        async.apply(pendingQueue.create.bind(pendingQueue)),
+        async.apply(pendingQueue.startPruneJob.bind(ackQueue), true),
+        async.apply(syncQueue.create.bind(syncQueue)),
+        async.apply(syncQueue.startPruneJob.bind(ackQueue), true),
+      ], callback);
+    },
+    function initApis(callback) {
+      apiSync = syncApiModule(interceptors, ackQueue, pendingQueue, syncStorage);
+      apiSyncRecords = syncRecordsApiModule(syncStorage, pendingQueue);
+      return callback();
+    },
+    function createWorkers(callback) {
+      var syncProcessorImpl = syncProcessor(syncStorage, dataHandlers, metricsClient, hashProvider);
+      syncWorker = new Worker(syncQueue, syncProcessorImpl, metricsClient, {name: 'sync_worker', interval: syncConfig.workerInterval});
+
+      var ackProcessorImpl = ackProcessor(syncStorage);
+      ackWorker = new Worker(ackQueue, ackProcessorImpl, metricsClient, {name: 'ack_worker', interval: syncConfig.workerInterval});
+
+      var pendingProcessorImpl = pendingProcessor(syncStorage, dataHandlers, hashProvider, metricsClient);
+      pendingWorker = new Worker(pendingQueue, pendingProcessorImpl, metricsClient, {name: 'pending_worker', interval: syncConfig.workerInterval});
+
+      ackWorker.work();
+      pendingWorker.work();
+      syncWorker.work();
+      return callback();
+    },
+    function startSyncScheduler(callback) {
+      var SyncScheduler = syncSchedulerModule(syncLock, syncStorage, metricsClient).SyncScheduler;
+      syncScheduler = new SyncScheduler(syncQueue, {timeBetweenChecks: syncConfig.schedulerInterval, timeBeforeCrashAssumed: syncConfig.schedulerLockMaxTime, syncSchedulerLockName: syncConfig.schedulerLockName});
+      syncScheduler.start();
+      return callback();
+    }
+  ], function(err) {
+    if (err) return cb(err);
+    syncStarted = true;
+    return cb();
+  });
+}
+
+function sync(datasetId, params, cb) {
+  apiSync(datasetId, params, cb);
+}
+
+function syncRecords(datasetId, params, cb) {
+  apiSyncRecords(datasetId, params, cb);
+}
+
+// Stop cloud data sync for the specified dataset_id.
+function stop(dataset_id, cb) {
+  if (!syncStarted) {
+    return cb();
+  }
+  syncUtil.doLog(dataset_id, 'info', 'stop sync for dataset');
+  syncStorage.updateManyDatasetClients({datasetId: dataset_id}, {stopped: true}, cb);
+}
+
+function setConfig(conf) {
+  syncConfig = _.extend({}, DEFAULT_SYNC_CONF, conf);
+}
+
+// Stop cloud data sync service for ALL datasets and reset.
+// This should really only used by tests.
+function stopAll(cb) {
+  //sync is not started yet, but connect could be called already. In this case, just reset a few things
+  if (!syncStarted) {
+    mongoDbClient = null;
+    redisClient = null;
+    metricsClient = null;
+    return cb();
+  }
+  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'info', 'stopAll syncs');
+  ackQueue.stopPruneJob();
+  pendingQueue.stopPruneJob();
+  syncQueue.stopPruneJob();
+  async.parallel([
+    async.apply(syncStorage.updateManyDatasetClients, {}, {stopped: true}),
+    async.apply(syncWorker.stop.bind(syncWorker)),
+    async.apply(ackWorker.stop.bind(ackWorker)),
+    async.apply(pendingWorker.stop.bind(pendingWorker)),
+    async.apply(syncScheduler.stop.bind(syncScheduler))
+  ], function(err) {
+    if (err) {
+      syncUtil.doLog(syncUtil.SYNC_LOGGER, 'error', 'Failed to stop sync due to error : ' + util.inspect(err));
+      return cb(err);
+    }
+    setConfig();
+    dataHandlers.restore();
+    interceptors.restore();
+    mongoDbClient = null;
+    redisClient = null;
+    metricsClient = null;
+    ackQueue = null;
+    pendingQueue = null;
+    syncQueue = null;
+    ackWorker = null;
+    pendingWorker = null;
+    syncWorker = null;
+    syncStarted = false;
+    dataHandlers = null;
+    interceptors = null;
+    hashProvider = null;
+    syncLock = null;
+    return cb();
+  });
+}
+
+function globalInterceptRequest(fn) {
+  interceptors.setDefaultRequestInterceptor(fn);
+}
+function globalInterceptResponse(fn) {
+  interceptors.setDefaultResponseInterceptor(fn);
+}
+function interceptRequest(datasetId, fn) {
+  interceptors.setRequestInterceptor(datasetId, fn);
+}
+function interceptResponse(datasetId, fn) {
+  interceptors.setResponseInterceptor(datasetId, fn);
+}
+
+function listCollisions(datasetId, params, cb) {
+  dataHandlers.listCollisions(datasetId, params, cb);
+}
+
+function removeCollision(datasetId, params, cb) {
+  dataHandlers.removeCollision(datasetId, params, cb);
+}
+
+function callHandler(handlerName, args) {
+  dataHandlers[handlerName].apply(null, args);
+}
+
+module.exports = {
+  sync: sync,
+  syncRecords: syncRecords,
+  api: {
+    connect: connect,
+    init: init,
+    start: start,
+    stop: stop,
+    stopAll: stopAll,
+    setConfig: setConfig,
+    globalInterceptRequest: globalInterceptRequest,
+    globalInterceptResponse: globalInterceptResponse,
+    interceptRequest: interceptRequest,
+    interceptResponse: interceptResponse,
+    listCollisions: listCollisions,
+    removeCollision: removeCollision,
+    callHandler: callHandler
+  }
+};

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -38,21 +38,21 @@ var ackWorker;
 var pendingWorker;
 var syncWorker;
 
-//default global configuration options for the sync server
+/** @type {Object} default global configuration options for the sync server */
 var DEFAULT_SYNC_CONF = {
-  //how often workers should check for the next job. Default: 1s
+  /** @type {Number} how often workers should check for the next job, in ms. Default: 1000 */
   workerInterval: 1000,
-  //how often the scheduler should check the datasetClients. Default: 500ms
+  /** @type {Number} how often the scheduler should check the datasetClients, in ms. Default: 500 */
   schedulerInterval: 500,
-  //the max time a scheduler can hold the lock for. Default: 20s
+  /** @type {Number} the max time a scheduler can hold the lock for, in ms. Default: 20000 */
   schedulerLockMaxTime: 20000,
-  //the default lock name for the sync scheduler
+  /** @type {String} the default lock name for the sync scheduler */
   schedulerLockName: 'locks:sync:SyncScheduler'
 };
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
 var syncStarted = false;
 
-// Initialise cloud data sync service for specified dataset.
+/** Initialise cloud data sync service for specified dataset. */
 function init(dataset_id, options, cb) {
   syncUtil.doLog(dataset_id, 'info', 'init sync for dataset ' + dataset_id + ' with options ' + util.inspect(options));
   datasets.init(dataset_id, options);
@@ -152,7 +152,7 @@ function syncRecords(datasetId, params, cb) {
   apiSyncRecords(datasetId, params, cb);
 }
 
-// Stop cloud data sync for the specified dataset_id.
+/** Stop cloud data sync for the specified dataset_id */
 function stop(dataset_id, cb) {
   if (!syncStarted) {
     return cb();
@@ -165,8 +165,10 @@ function setConfig(conf) {
   syncConfig = _.extend({}, DEFAULT_SYNC_CONF, conf);
 }
 
-// Stop cloud data sync service for ALL datasets and reset.
-// This should really only used by tests.
+/**
+ * Stop cloud data sync service for ALL datasets and reset.
+ * This should really only used by tests.
+ */
 function stopAll(cb) {
   //sync is not started yet, but connect could be called already. In this case, just reset a few things
   if (!syncStarted) {
@@ -229,8 +231,10 @@ function listCollisions(datasetId, params, cb) {
   dataHandlers.listCollisions(datasetId, params.meta_data, cb);
 }
 
-// Defines a handler function for deleting a collision from the collisions list.
-// Should be called after the dataset is initialised.
+/**
+ * Defines a handler function for deleting a collision from the collisions list.
+ * Should be called after the dataset is initialised.
+ */
 function removeCollision(datasetId, params, cb) {
   syncUtil.doLog(datasetId, 'info', 'removeCollision');
   dataHandlers.removeCollision(datasetId, params.meta_data, cb);


### PR DESCRIPTION
Moving a lot of setup and api implementation out of `lib/sync/index.js` into `lib/sync/sync-server.js`.
`index` is left with setting up metrics and the module's public API.

Currently pending a rebase on newer changes to the scaling branch and figuring out why some of the tests are still failing.

Putting up this WIP PR for preliminary review.