### PR TITLE
✨ FH-3366 Add sync:ready event to the fh api

### DIFF
--- a/integration/sync/test_index.js
+++ b/integration/sync/test_index.js
@@ -16,9 +16,14 @@ module.exports = {
       sync.api.stopAll(done);
     },
     'should connect ok': function(finish) {
+      var readyEmitted = false;
+      sync.api.getEventEmitter().on('sync:ready', function onSyncReady() {
+        readyEmitted = true;
+      });
       // assume redis & mongodb on localhost with default ports
       sync.api.connect(mongoDBUrl, null, {}, function(err, mongoDbClient, redisClient) {
         assert.ok(!err, util.inspect(err));
+        assert.ok(readyEmitted, 'Expected sync:ready event to be emitted');
         var mClient = mongoDbClient;
         var rClient = redisClient;
         assert.ok(mongoDbClient);

--- a/lib/api.js
+++ b/lib/api.js
@@ -8,6 +8,7 @@ var sec = require('fh-security'),
 var url = require('url');
 var packageJSON = require('../package.json');
 var initScript = require('./init.js');
+var EventEmitter = require('events').EventEmitter;
 
 var mbaasClient = require('fh-mbaas-client');
 
@@ -29,6 +30,7 @@ function FHapi(cfg, logr) {
     },
     cache: require('./cache')(cfg),
     db: require('./db')(cfg),
+    events: new EventEmitter(),
     forms: require('./forms')(cfg),
     log: false,
     stringify: false,
@@ -56,6 +58,8 @@ function FHapi(cfg, logr) {
     },
     web: require('./web')(cfg)
   };
+
+  api.sync.setEventEmitter(api.events);
 
   var redisUrl = 'redis://' + api.redisHost + ':' + api.redisPort;
 
@@ -87,16 +91,6 @@ function FHapi(cfg, logr) {
     // Call stopAll to ensure Sync exits clenaly.
     api.sync.stopAll(cb);
   };
-
-  api.bootstrap = function(cb) {
-    api.db({'act': 'connectionString'}, cb);
-  };
-
-  api.bootstrap(function(err) {
-    if (err) {
-      logr.error(err);
-    }
-  });
 
   api.setLogLevel = function(level) {
     logr.setLogLevel(level);
@@ -220,5 +214,5 @@ module.exports = (function () {
 
   var logger = new consolelogger.ConsoleLogger(logLevel);
   initScript(logger);
-  return new FHapi(cfg, logger);
+  return FHapi(cfg, logger);
 })();

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -6,7 +6,7 @@ var util = require('util');
 var MongoClient = require('mongodb').MongoClient;
 var redis = require('redis');
 var async = require('async');
-
+var eventEmitter = new (require('events').EventEmitter)();
 function toJSON(dataset_id, returnData, cb) {
   syncUtil.doLog(dataset_id, 'debug', 'toJSON');
 
@@ -50,6 +50,7 @@ function connect(mongoDBConnectionUrl, redisUrl, metricsConf, cb) {
 
     server.setClients(mongoDbClient, redisClient, metricsClient);
 
+    eventEmitter.emit('sync:ready');
     return cb(null, mongoDbClient, redisClient, metricsClient);
   });
 }
@@ -63,6 +64,16 @@ function setLogLevel(dataset_id, params, cb) {
   } else {
     cb && cb('logLevel parameter required');
   }
+}
+
+function getEventEmitter() {
+  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'getEventEmitter');
+  return eventEmitter;
+}
+
+function setEventEmitter(emitter) {
+  syncUtil.doLog(syncUtil.SYNC_LOGGER, 'debug', 'setEventEmitter');
+  eventEmitter = emitter;
 }
 
 /** @type {Array} Functions that are allowed to be invoked */
@@ -110,6 +121,8 @@ module.exports = _.extend({}, server, {
     invoke: invoke,
     toJSON: toJSON,
     setLogLevel: setLogLevel,
+    getEventEmitter: getEventEmitter,
+    setEventEmitter: setEventEmitter,
   })
 });
 

--- a/test/test_fhdb.js
+++ b/test/test_fhdb.js
@@ -23,7 +23,8 @@ module.exports = {
     var syncMock = {
       api: {
         connect: sinon.stub().yieldsAsync(),
-        stopAll: sinon.stub().yieldsAsync()
+        stopAll: sinon.stub().yieldsAsync(),
+        setEventEmitter: sinon.stub()
       }
     };
 
@@ -59,7 +60,7 @@ module.exports = {
       // - for sync connection
       // - when calling fh.db
       // - in fh.bootstrap
-      sinon.assert.calledThrice(databaseConnectionStringStub);
+      sinon.assert.calledTwice(databaseConnectionStringStub);
       finish();
     });
   },
@@ -75,7 +76,8 @@ module.exports = {
     var syncMock = {
       api: {
         connect: sinon.stub().yieldsAsync(),
-        stopAll: sinon.stub().yieldsAsync()
+        stopAll: sinon.stub().yieldsAsync(),
+        setEventEmitter: sinon.stub()
       }
     };
 


### PR DESCRIPTION
FH-3366 Add sync_ready event to the fh api
This change required & incorporated a few things:
* adding a new `events` EventEmitter object to the fh API i.e. `fh.events`
* passing this into the sync server
* emitting a `sync:ready` event when sync is connected OK to mongo &
redis
* removing an uneccessary 'bootstrap' call for db string (& fix fhdb
test)