### PR TITLE
add an isLocal method

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -69,6 +69,9 @@ function FHapi(cfg, logr) {
     api.sync.stopAll(cb);
   };
 
+
+  api.isLocal = require('./fhutils').isLocal;
+
   api.bootstrap = function(cb) {
     api.db({'act': 'connectionString'}, cb);
   };

--- a/lib/fhutils.js
+++ b/lib/fhutils.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var process = require('process');
 
 module.exports = function (cfg) {
   assert.ok(cfg, 'cfg is undefined');
@@ -15,6 +16,20 @@ module.exports = function (cfg) {
     if (cfg.fhapi && cfg.fhapi.appapikey && cfg.fhapi.appapikey.length > 0) {
       headers[cfg.APP_API_KEY_HEADER] = value || cfg.fhapi.appapikey;
     }
+  };
+
+  /**
+   * Returns a boolean that indicates if we're running locally
+   * @return {Boolean}
+   */
+  this.isLocal = function () {
+    var useLocalDb = process.env.FH_USE_LOCAL_DB;
+    var stats = process.env.FH_STATS_PORT;
+    var title = process.env.FH_TITLE;
+
+    // if use local db is true then we know we're for sure running locally
+    // else, if FH sepcific vars are not set then we're also local
+    return useLocalDb === 'true' || !(stats && title);
   };
 
   this.getMillicoreProps = function () {

--- a/test/test_fhutils.js
+++ b/test/test_fhutils.js
@@ -2,8 +2,50 @@ var assert = require('assert');
 var futils = require('../lib/fhutils');
 var fhutils = new futils({});
 var expect = require('chai').expect;
+var clearRequire = require('clear-require');
+var proxyquire = require('proxyquire');
 
 module.exports = {
+  'beforeEach': function () {
+    clearRequire('../lib/fhutils');
+  },
+
+
+  'isLocal - return false': function () {
+    futils = proxyquire('../lib/fhutils', {
+      process: {
+        env: {
+          FH_STATS_PORT: 'value',
+          FH_TITLE: 'value'
+        }
+      }
+    });
+
+    assert.equal(new futils({}).isLocal(), false);
+  },
+
+  'isLocal - return true if FH_USE_LOCAL_DB is "true"': function () {
+    futils = proxyquire('../lib/fhutils', {
+      process: {
+        env: {
+          FH_USE_LOCAL_DB: 'true'
+        }
+      }
+    })
+
+    assert.equal(new futils({}).isLocal(), true);
+  },
+
+  'isLocal - return true if expected platform vars are not set': function () {
+    futils = proxyquire('../lib/fhutils', {
+      process: {
+        env: {}
+      }
+    })
+
+    assert.equal(new futils({}).isLocal(), true);
+  },
+
   'test addAppApiKeyHeader - without override': function () {
     var fhutils = new futils({
       APP_API_KEY_HEADER: 'x-fh-api-key',
@@ -45,7 +87,7 @@ module.exports = {
       'x-fh-api-key': customApiKey
     });
   },
-  
+
   'test urlPathJoin': function(finish) {
 
     assert.equal(fhutils.urlPathJoin('/p1', '/p2'),              "/p1/p2");


### PR DESCRIPTION
Open to opinions on whether this belongs here or not. Thought it would be useful vs. having people check for different env vars in their code.

Sample use case:

```js
var mbaasApi = require('fh-mbaas-api');
var createLocalData = require('fixtures/create');

if (mbaasApi.isLocal()) {
  createLocalData.then(startApp);
} else {
  startApp()
}
```