### PR TITLE
do not lock the datasetclient collection on sync api call

### DIFF
--- a/lib/sync/api-sync.js
+++ b/lib/sync/api-sync.js
@@ -157,6 +157,10 @@ module.exports = function(interceptorsImpl, ackQueueImpl, pendingQueueImpl, sync
   pendingQueue = pendingQueueImpl;
   syncStorage = syncStorageImpl;
   syncConfig = syncConfigInst;
+  //we just use an in-memory queue here to update the dataset clients, the main purpose of the update here is:
+  //1. make sure a new dataset client will be created if it's never created before. 2. update the `lastAccessed` field of an existing dataset client to determine when a dataset client should be set to "inactive".
+  //So even if the app crashes, and some of those records are lost, it means some of the datasetclients may not be synced. 
+  //But as soon as the clients makes another request, it will be synced again. If the clients doesn't sent the request, then the dataset client should not be synced anyway.
   datasetClientsUpdateQueue = async.queue(function(datasetClientJson, cb){
     syncStorage.upsertDatasetClient(datasetClientJson.id, datasetClientJson, cb);
   }, syncConfig.datasetClientUpdateConcurrency || 10);

--- a/lib/sync/api-sync.js
+++ b/lib/sync/api-sync.js
@@ -4,8 +4,9 @@ var syncUtil = require('./util');
 var DatasetClient = require('./DatasetClient');
 var util = require('util');
 
-var interceptors, ackQueue, pendingQueue, syncStorage;
+var interceptors, ackQueue, pendingQueue, syncStorage, syncConfig;
 
+var datasetClientsUpdateQueue;
 /**
  * Add the given items to the given queue. For each item, also add the given extraParams.
  * @param {Array} items the items to add to the queue
@@ -57,16 +58,18 @@ function removeUpdatesInRequest(updatesInDb, updatesInRequest) {
   return updatesNotInRequest;
 }
 
-function processSyncAPI(datasetId, params, cb) {
+function processSyncAPI(datasetId, params, readDatasetClient, cb) {
   var queryParams = params.query_params || {};
   var metaData = params.meta_data || {};
   var cuid = syncUtil.getCuid(params);
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
+  var datasetClientFields = {id: datasetClient.getId(), datasetId: datasetId,  queryParams: queryParams, metaData: metaData, lastAccessed: Date.now()};
   async.parallel({
-    upsertDatasetClient: function(callback) {
-      syncUtil.doLog(datasetId, 'debug', 'upsert datasetClient id = ' + datasetClient.getId());
-      var datasetClientFields = {id: datasetClient.getId(), datasetId: datasetId,  queryParams: queryParams, metaData: metaData, lastAccessed: Date.now()};
-      syncStorage.upsertDatasetClient(datasetClient.getId(), datasetClientFields, callback);
+    pushDatasetClient: function(callback) {
+      //after some loading testing, we noticed that upsertDatasetClient is an atomic operation and requires a lock. If there are  a lot operations on the same document (collection?) those operations will queued up in mongo, which blocks the request.
+      //To avoid that, we push the updates into a queue and call upsertDatasetClient with a reasonable concurrency value to void the locking issue.
+      datasetClientsUpdateQueue.push(datasetClientFields);
+      return callback();
     },
     addAcks: function(callback) {
       syncUtil.doLog(datasetId, 'debug', 'adding acks to queue. size = ' + (params.acknowledgements && params.acknowledgements.length || 0));
@@ -86,7 +89,7 @@ function processSyncAPI(datasetId, params, cb) {
       return cb(err);
     } else {
       syncUtil.doLog(datasetId, 'debug', 'syn API results ' + util.inspect(results));
-      var globalHash = results.upsertDatasetClient.globalHash;
+      var globalHash = readDatasetClient? readDatasetClient.globalHash: undefined;
       //the acknowledgements in the current request will be put on the queue and take some time to process, so don't return them if they are still in the db
       var remainingUpdates = removeUpdatesInRequest(results.processedUpdates, params.acknowledgements);
       var response = {hash: globalHash, updates: formatUpdates(remainingUpdates)};
@@ -125,9 +128,9 @@ function sync(datasetId, params, cb) {
   var metaData = params.meta_data || {};
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
   syncUtil.doLog(datasetId, 'debug', 'processing sync API request :: query_params = ' + util.inspect(queryParams) + ' :: meta_data = ' + util.inspect(metaData));
-  async.series([
-    async.apply(interceptors.requestInterceptor, datasetId, params),
-    function checkDatasetclientStopped(callback) {
+  async.series({
+    requestInterceptor: async.apply(interceptors.requestInterceptor, datasetId, params),
+    readDatasetClient: function checkDatasetclientStopped(callback) {
       syncStorage.readDatasetClient(datasetClient.getId(), function(err, datasetClientJson){
         if (err) {
           return callback(err);
@@ -135,23 +138,27 @@ function sync(datasetId, params, cb) {
         if (datasetClientJson && datasetClientJson.stopped === true) {
           return callback(new Error('sync stopped for dataset ' + datasetId));
         } else {
-          return callback();
+          return callback(null, datasetClientJson);
         }
       });
     }
-  ], function(err){
+  }, function(err, results){
     if (err) {
       syncUtil.doLog(datasetId, 'debug', 'sync request returns error = ' + util.inspect(err), params);
       return cb(err);
     }
-    return processSyncAPI(datasetId, params, cb);
+    return processSyncAPI(datasetId, params, results.readDatasetClient, cb);
   });
 }
 
-module.exports = function(interceptorsImpl, ackQueueImpl, pendingQueueImpl, syncStorageImpl){
+module.exports = function(interceptorsImpl, ackQueueImpl, pendingQueueImpl, syncStorageImpl, syncConfigInst){
   interceptors = interceptorsImpl;
   ackQueue = ackQueueImpl;
   pendingQueue = pendingQueueImpl;
   syncStorage = syncStorageImpl;
+  syncConfig = syncConfigInst;
+  datasetClientsUpdateQueue = async.queue(function(datasetClientJson, cb){
+    syncStorage.upsertDatasetClient(datasetClientJson.id, datasetClientJson, cb);
+  }, syncConfig.datasetClientUpdateConcurrency || 10);
   return sync;
 }

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -29,7 +29,8 @@ function connect(mongoDBConnectionUrl, redisUrl, metricsConf, cb) {
 
   async.series([
     function connectToMongoDB(callback) {
-      MongoClient.connect(mongoDBConnectionUrl, callback);
+      var poolSize = parseInt(process.env.SYNC_MONGO_POOLSIZE) || 50;
+      MongoClient.connect(mongoDBConnectionUrl, {poolSize: poolSize}, callback);
     },
     function connectToRedis(callback) {
       if (redisUrl) {

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -47,7 +47,9 @@ var DEFAULT_SYNC_CONF = {
   /** @type {Number} the max time a scheduler can hold the lock for, in ms. Default: 20000 */
   schedulerLockMaxTime: 20000,
   /** @type {String} the default lock name for the sync scheduler */
-  schedulerLockName: 'locks:sync:SyncScheduler'
+  schedulerLockName: 'locks:sync:SyncScheduler',
+  /**@type {Number} the default concurrency value when update dataset clients in the sync API. Default is 10. In most case this value should not need to be changed */
+  datasetClientUpdateConcurrency: 10
 };
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
 var syncStarted = false;
@@ -112,7 +114,7 @@ function start(cb) {
       ], callback);
     },
     function initApis(callback) {
-      apiSync = syncApiModule(interceptors, ackQueue, pendingQueue, syncStorage);
+      apiSync = syncApiModule(interceptors, ackQueue, pendingQueue, syncStorage, syncConfig);
       apiSyncRecords = syncRecordsApiModule(syncStorage, pendingQueue);
       return callback();
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -30,26 +30,14 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
     },
     "fh-component-metrics": {
-      "version": "2.4.0",
+      "version": "2.5.1",
       "from": "fh-component-metrics@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.5.1.tgz",
       "dependencies": {
-        "async": {
-          "version": "2.0.1",
-          "from": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
-          "dependencies": {
-            "lodash": {
-              "version": "4.15.0",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz"
-            }
-          }
-        },
         "lodash": {
-          "version": "4.3.0",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz"
+          "version": "4.17.4",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
         }
       }
     },
@@ -1241,7 +1229,7 @@
     },
     "mongodb-lock": {
       "version": "0.4.0",
-      "from": "https://registry.npmjs.org/mongodb-lock/-/mongodb-lock-0.4.0.tgz",
+      "from": "mongodb-lock@0.4.0",
       "resolved": "https://registry.npmjs.org/mongodb-lock/-/mongodb-lock-0.4.0.tgz"
     },
     "mongodb-queue": {
@@ -1261,7 +1249,7 @@
     },
     "parse-duration": {
       "version": "0.1.1",
-      "from": "parse-duration@latest",
+      "from": "parse-duration@0.1.1",
       "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.1.1.tgz"
     },
     "pkginfo": {
@@ -1270,24 +1258,24 @@
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
     },
     "redis": {
-      "version": "2.6.5",
-      "from": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.5.tgz",
+      "version": "2.7.1",
+      "from": "redis@>=2.6.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.7.1.tgz",
       "dependencies": {
         "double-ended-queue": {
           "version": "2.1.0-0",
-          "from": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+          "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
           "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
         },
         "redis-commands": {
           "version": "1.3.1",
-          "from": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
+          "from": "redis-commands@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
         },
         "redis-parser": {
-          "version": "2.4.0",
-          "from": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.4.0.tgz"
+          "version": "2.5.0",
+          "from": "redis-parser@>=2.5.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.5.0.tgz"
         }
       }
     },
@@ -1446,9 +1434,9 @@
               }
             },
             "is-my-json-valid": {
-              "version": "2.15.0",
+              "version": "2.16.0",
               "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
@@ -1526,10 +1514,15 @@
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
-              "version": "1.3.1",
+              "version": "1.4.0",
               "from": "jsprim@>=1.2.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
               "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@1.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                },
                 "extsprintf": {
                   "version": "1.0.2",
                   "from": "extsprintf@1.0.2",
@@ -1548,9 +1541,9 @@
               }
             },
             "sshpk": {
-              "version": "1.10.2",
+              "version": "1.11.0",
               "from": "sshpk@>=1.7.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
@@ -1629,9 +1622,9 @@
           }
         },
         "node-uuid": {
-          "version": "1.4.7",
+          "version": "1.4.8",
           "from": "node-uuid@>=1.4.7 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -1639,9 +1632,9 @@
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
-          "version": "6.2.2",
+          "version": "6.2.3",
           "from": "qs@>=6.2.0 <6.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz"
         },
         "stringstream": {
           "version": "0.0.5",

--- a/test/sync/test_api-sync.js
+++ b/test/sync/test_api-sync.js
@@ -46,7 +46,7 @@ module.exports = {
   },
 
   'test api sync success': function(done) {
-    var apiSync = apiSyncModule(interceptors, ackQueue, pendingQueue, syncStorage);
+    var apiSync = apiSyncModule(interceptors, ackQueue, pendingQueue, syncStorage, {});
     var acknowledgements = [{
       type: 'action',
       hash: 'ackhash',
@@ -84,7 +84,7 @@ module.exports = {
 
     interceptors.requestInterceptor.yieldsAsync();
     interceptors.responseInterceptor.yieldsAsync();
-    syncStorage.readDatasetClient.yieldsAsync();
+    syncStorage.readDatasetClient.yieldsAsync(null, {globalHash: globalHash});
     syncStorage.upsertDatasetClient.yieldsAsync(null, {globalHash: globalHash});
     syncStorage.listUpdates.yieldsAsync(null, updates);
     ackQueue.addMany.yieldsAsync();
@@ -93,7 +93,6 @@ module.exports = {
       assert.ok(!err);
       assert.ok(interceptors.requestInterceptor.calledOnce);
       assert.ok(interceptors.requestInterceptor.calledWith(DATASETID, params));
-      assert.ok(syncStorage.upsertDatasetClient.calledOnce);
 
       assert.ok(ackQueue.addMany.calledOnce);
       var ackItems = ackQueue.addMany.args[0][0];


### PR DESCRIPTION
This PR introduces 2 changes that will improve the performance significantly:

1. Do not call `upsertDatasetClient` inside each `sync` API call. The reason is to avoid mongodb locking.
2. Allow developers to override the `poolSize` mongodb connection option. It can help improve the performance as well.

ping @david-martin @aidenkeating for review