### PR TITLE
Fh 3412 add caching

### DIFF
--- a/integration/sync/test_dataHandler_overrides.js
+++ b/integration/sync/test_dataHandler_overrides.js
@@ -12,7 +12,7 @@ var TESTCUID = 'syncDataHandlerOverridesTestCuid';
 module.exports = {
   'test dataHandler overrides': {
     'beforeEach': function(done) {
-      sync.api.setConfig({workerInterval: 100, schedulerInterval: 100, schedulerLockName: 'test:datahandler:lock'});
+      sync.api.setConfig({pendingWorkerInterval: 100, ackWorkerInterval: 100, syncWorkerInterval: 100, schedulerInterval: 100, schedulerLockName: 'test:datahandler:lock'});
       async.series([
         async.apply(helper.resetDb, MONGODB_URL, DATASETID),
         async.apply(sync.api.connect, MONGODB_URL, null, null)

--- a/integration/sync/test_index.js
+++ b/integration/sync/test_index.js
@@ -5,6 +5,7 @@ var util = require('util');
 var async = require('async');
 
 var mongoDBUrl = 'mongodb://127.0.0.1:27017/test_index';
+var redisUrl = 'redis://127.0.0.1:6379';
 var DATASETID = 'testSyncInitStop';
 
 module.exports = {
@@ -21,12 +22,13 @@ module.exports = {
         readyEmitted = true;
       });
       // assume redis & mongodb on localhost with default ports
-      sync.api.connect(mongoDBUrl, {}, null, function(err, mongoDbClient, redisClient) {
+      sync.api.connect(mongoDBUrl, {}, redisUrl, function(err, mongoDbClient, redisClient) {
         assert.ok(!err, util.inspect(err));
         assert.ok(readyEmitted, 'Expected sync:ready event to be emitted');
         var mClient = mongoDbClient;
         var rClient = redisClient;
         assert.ok(mongoDbClient);
+        assert.ok(rClient);
 
         async.series([function testMongoDBConnection(cb) {
           var testValue = 'test value ' + Date.now();

--- a/integration/sync/test_storage.js
+++ b/integration/sync/test_storage.js
@@ -1,4 +1,5 @@
 var storageModule = require('../../lib/sync/storage');
+var cacheClientModule = require('../../lib/sync/sync-cache');
 var MongoClient = require('mongodb').MongoClient;
 var async = require('async');
 var assert = require('assert');
@@ -64,12 +65,13 @@ function recordMatch(expect, actual) {
 module.exports = {
   'test storage functions': {
     'before': function(done) {
+      var cacheClient = cacheClientModule();
       helper.resetDb(MONGODB_URL, DATASETID, function(err, db){
         if (err) {
           return done(err);
         }
         mongodb = db;
-        storage = storageModule(mongodb);
+        storage = storageModule(mongodb, cacheClient);
         done();
       });
     },

--- a/integration/sync/test_sync_apis.js
+++ b/integration/sync/test_sync_apis.js
@@ -20,8 +20,6 @@ module.exports = {
   'test sync & syncRecords apis': {
     'before': function(done) {
       sync.api.setConfig({syncWorkerInterval: 100, pendingWorkerInterval: 100, ackWorkerInterval: 100, schedulerInterval: 100, schedulerLockName: 'test:syncApi:lock', useCache: true});
-      sync.api.setLogLevel(DATASETID, {logLevel: 'debug'});
-      sync.api.setLogLevel(syncUtil.SYNC_LOGGER, {logLevel: 'debug'});
       async.series([
         async.apply(sync.api.connect, mongoDBUrl, null, redisUrl),
         async.apply(sync.api.init, DATASETID, {syncFrequency: 1}),

--- a/integration/sync/test_sync_apis.js
+++ b/integration/sync/test_sync_apis.js
@@ -8,6 +8,7 @@ var storageModule = require('../../lib/sync/storage');
 var _ = require('underscore');
 
 var mongoDBUrl = 'mongodb://127.0.0.1:27017/test_sync_api';
+var redisUrl = 'redis://127.0.0.1:6379';
 var DATASETID = 'syncIntegrationTest';
 var TESTCUID = 'syncIntegrationTestCuid';
 
@@ -18,9 +19,9 @@ var recordCUid;
 module.exports = {
   'test sync & syncRecords apis': {
     'before': function(done) {
-      sync.api.setConfig({workerInterval: 100, schedulerInterval: 100, schedulerLockName: 'test:syncApi:lock'});
+      sync.api.setConfig({workerInterval: 100, schedulerInterval: 100, schedulerLockName: 'test:syncApi:lock', useCache: true});
       async.series([
-        async.apply(sync.api.connect, mongoDBUrl, null, null),
+        async.apply(sync.api.connect, mongoDBUrl, null, redisUrl),
         async.apply(sync.api.init, DATASETID, {syncFrequency: 1}),
         function resetdb(callback) {
           helper.resetDb(mongoDBUrl, DATASETID, function(err, db){

--- a/integration/sync/test_sync_apis.js
+++ b/integration/sync/test_sync_apis.js
@@ -19,7 +19,9 @@ var recordCUid;
 module.exports = {
   'test sync & syncRecords apis': {
     'before': function(done) {
-      sync.api.setConfig({workerInterval: 100, schedulerInterval: 100, schedulerLockName: 'test:syncApi:lock', useCache: true});
+      sync.api.setConfig({syncWorkerInterval: 100, pendingWorkerInterval: 100, ackWorkerInterval: 100, schedulerInterval: 100, schedulerLockName: 'test:syncApi:lock', useCache: true});
+      sync.api.setLogLevel(DATASETID, {logLevel: 'debug'});
+      sync.api.setLogLevel(syncUtil.SYNC_LOGGER, {logLevel: 'debug'});
       async.series([
         async.apply(sync.api.connect, mongoDBUrl, null, redisUrl),
         async.apply(sync.api.init, DATASETID, {syncFrequency: 1}),

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -108,7 +108,9 @@ MongodbQueue.prototype.search = function(searchFields, cb) {
     deleted: {$exists: false},
     payload: searchFields
   };
-  collection.find(query).toArray(function(err, docs) {
+  var timer = metrics.startTimer();
+  collection.find(query).toArray(function(err, docs){
+    self.metrics.gauge(metrics.KEYS.QUEUE_OPERATION_TIME, {method: 'search', name: self.queueName}, timer.stop());
     if (err) {
       return cb(err);
     }
@@ -129,7 +131,9 @@ MongodbQueue.prototype.prune = function(cb) {
     var since = new Date(Date.now() - parseDuration(self.messagesToKeep.time));
     pruneQuery.visible = {$lt: since.toISOString()};
   }
-  collection.deleteMany(pruneQuery, function(err, result) {
+  var timer = metrics.startTimer();
+  collection.deleteMany(pruneQuery, function(err, result){
+    self.metrics.gauge(metrics.KEYS.QUEUE_OPERATION_TIME, {method: 'prune', name: self.queueName}, timer.stop());
     if (err) {
       debug('Failed to delete messages from queue %s due to error %j', self.queueName, err);
     } else {

--- a/lib/sync/storage/dataset-clients.js
+++ b/lib/sync/storage/dataset-clients.js
@@ -6,6 +6,7 @@ var debug = syncUtil.debug;
 var DATASETCLIENTS_COLLECTION = "fhsync_datasetClients";
 var RECORDS_UPDATE_CONCURRENCY = 10;
 var mongoClient;
+var cacheClient;
 
 
 /**
@@ -203,6 +204,37 @@ function doReadDatasetClientWithRecords(datasetClientId, callback) {
   });
 }
 
+function buildDatasetClientRecordsCachkey(datasetClientId) {
+  return ['fhsync', datasetClientId, "records"].join(':');
+}
+
+function doReadDatasetClientWithRecordsUseCache(datasetClientId, callback) {
+  //we are only cache the dataset records per dataset client here. 
+  //This will not work very well if there are a lot of records are shared between different datasetClients as some of them will get stalled data.
+  //That's why the caching is turned off by default. If can be enabled if there are no records shared between different datasetClients.
+  //However, if in the future we need to add caching properly, we can implement different cache strategies.
+  //For example, `perdatasetclient` = save the records in cache for each dataset client (current implementation), or
+  // 'perdataset' = save the records per dataset. If any one of the datasetClient is updated, all the those datasetClients's caches should be invalidated as well.
+  //Developers can then choose which cache strategy to use based on their requirements.
+  var cacheKey = buildDatasetClientRecordsCachkey(datasetClientId);
+  cacheClient.get(cacheKey, function(err, cachedData){
+    if (err) {
+      syncUtil.doLog(syncUtil.SYNC_LOGGER, ' error', ' Failed to read cache from redis with key ' + cacheKey + ' due to error ' + util.inspect(err));
+    }
+    if (cachedData) {
+      return callback(null, JSON.parse(cachedData));
+    } else {
+      doReadDatasetClientWithRecords(datasetClientId, function(err, results){
+        if (err) {
+          return callback(err);
+        }
+        cacheClient.set(cacheKey, JSON.stringify(results));
+        return callback(null, results);
+      });
+    }
+  });
+}
+
 /**
  * Read the dataset client from db
  * @param {String} datasetClientId the id of the datasetClient
@@ -352,6 +384,11 @@ function doUpdateDatasetClientWithRecords(datasetClientId, fields, records, call
       var recordUids = _.pluck(records, 'uid');
       fields.recordUids = recordUids;
       doUpdateDatasetClient(datasetClientId, fields, false, next);
+    },
+    function invalidateCache(updatedDatasetClient, next) {
+      var cacheKey = buildDatasetClientRecordsCachkey(datasetClientId);
+      cacheClient.del(cacheKey);
+      return next(null, updatedDatasetClient);
     }
   ], function(err, updatedDatasetClient) {
     if (err) {
@@ -373,8 +410,9 @@ function doUpdateManyDatasetClients(query, fields, callback) {
   });
 }
 
-module.exports = function(mongoClientImpl) {
+module.exports = function(mongoClientImpl, cacheClientImpl) {
   mongoClient = mongoClientImpl;
+  cacheClient = cacheClientImpl;
   createIndexForCollection(DATASETCLIENTS_COLLECTION, {'id': 1}, {});
   createIndexForCollection(DATASETCLIENTS_COLLECTION, {'datasetId': 1}, {});
 
@@ -446,7 +484,7 @@ module.exports = function(mongoClientImpl) {
      * @param {Function} callback
      */
     readDatasetClientWithRecords: function(datasetClientId, callback) {
-      return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doReadDatasetClientWithRecords)(datasetClientId, callback);
+      return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doReadDatasetClientWithRecordsUseCache)(datasetClientId, callback);
     }
   };
 };

--- a/lib/sync/storage/dataset-clients.js
+++ b/lib/sync/storage/dataset-clients.js
@@ -219,7 +219,7 @@ function doReadDatasetClientWithRecordsUseCache(datasetClientId, callback) {
   var cacheKey = buildDatasetClientRecordsCachkey(datasetClientId);
   cacheClient.get(cacheKey, function(err, cachedData){
     if (err) {
-      syncUtil.doLog(syncUtil.SYNC_LOGGER, ' error', ' Failed to read cache from redis with key ' + cacheKey + ' due to error ' + util.inspect(err));
+      debug('Failed to read cache from redis with key %s due to error %j', cacheKey, err);
     }
     if (cachedData) {
       return callback(null, JSON.parse(cachedData));

--- a/lib/sync/storage/index.js
+++ b/lib/sync/storage/index.js
@@ -2,10 +2,10 @@ var _ = require('underscore');
 var datasetClients = require('./dataset-clients');
 var datasetUpdates = require('./sync-updates');
 
-module.exports = function(mongoClientImpl) {
+module.exports = function(mongoClientImpl, cacheClientImpl) {
   var api = {};
   _.extend(api,
-    datasetClients(mongoClientImpl),
+    datasetClients(mongoClientImpl, cacheClientImpl),
     datasetUpdates(mongoClientImpl)
   );
   return api;

--- a/lib/sync/sync-cache.js
+++ b/lib/sync/sync-cache.js
@@ -1,0 +1,49 @@
+var redisClient;
+var syncConfig;
+
+/**
+ * Save data to the cache
+ * @param {String} key 
+ * @param {String} value 
+ * @param {Function} cb
+ */
+function set(key, value, cb) {
+  if (!syncConfig.useCache || !redisClient) {
+    return cb && cb();
+  }
+  return redisClient.set(key, value, cb);
+}
+
+/**
+ * Read data from cache
+ * @param {String} key 
+ * @param {Function} cb 
+ */
+function get(key, cb) {
+  if (!syncConfig.useCache || !redisClient) {
+    return cb && cb();
+  }
+  return redisClient.get(key, cb);
+}
+
+/**
+ * Delete data from cache
+ * @param {String} key 
+ * @param {Function} cb
+ */
+function del(key, cb) {
+  if (!syncConfig.useCache || !redisClient) {
+    return cb && cb();
+  }
+  return redisClient.del(key, cb);
+}
+
+module.exports = function(syncConfigInst, redisClientImpl) {
+  syncConfig = syncConfigInst || {};
+  redisClient = redisClientImpl;
+  return {
+    set: set,
+    get: get,
+    del: del
+  };
+};

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -43,8 +43,12 @@ var syncWorker;
 
 /** @type {Object} default global configuration options for the sync server */
 var DEFAULT_SYNC_CONF = {
-  /** @type {Number} how often workers should check for the next job, in ms. Default: 1000 */
-  workerInterval: 1000,
+  /** @type {Number} how often pending workers should check for the next job, in ms. Default: 500 */
+  pendingWorkerInterval: 500,
+  /** @type {Number} how often ack workers should check for the next job, in ms. Default: 500 */
+  ackWorkerInterval: 500,
+  /** @type {Number} how often sync workers should check for the next job, in ms. Default: 500 */
+  syncWorkerInterval: 500,
   /** @type {Number} how often the scheduler should check the datasetClients, in ms. Default: 500 */
   schedulerInterval: 500,
   /** @type {Number} the max time a scheduler can hold the lock for, in ms. Default: 20000 */
@@ -67,6 +71,10 @@ var DEFAULT_SYNC_CONF = {
    * Can be turned on if there are no records are shared between many different dataset clients. Default is false.
   */
   useCache: false,
+  /**@type {Object} specify how many messages to keep for the queues. By default it will keep the messages in the last 24 hours */
+  queueMessagesToKeep: {time: '24h'},
+  /**@type {Number} specify how often the queues should be checked to prune old message. By default it will run every hour. */
+  queuePruneFrequency: 1*60*60*1000
 };
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
 var syncStarted = false;
@@ -119,9 +127,9 @@ function start(cb) {
 
   async.series([
     function createQueues(callback) {
-      ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, {mongodb: mongoDbClient});
-      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, {mongodb: mongoDbClient});
-      syncQueue = new MongodbQueue('fhsync_queue', metricsClient, {mongodb: mongoDbClient});
+      ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, {mongodb: mongoDbClient, messagesToKeep: syncConfig.queueMessagesToKeep, pruneFrequency: syncConfig.queuePruneFrequency});
+      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, {mongodb: mongoDbClient, messagesToKeep: syncConfig.queueMessagesToKeep, pruneFrequency: syncConfig.queuePruneFrequency});
+      syncQueue = new MongodbQueue('fhsync_queue', metricsClient, {mongodb: mongoDbClient, messagesToKeep: syncConfig.queueMessagesToKeep, pruneFrequency: syncConfig.queuePruneFrequency});
 
       async.parallel([
         async.apply(ackQueue.create.bind(ackQueue)),
@@ -139,13 +147,13 @@ function start(cb) {
     },
     function createWorkers(callback) {
       var syncProcessorImpl = syncProcessor(syncStorage, dataHandlers, metricsClient, hashProvider);
-      syncWorker = new Worker(syncQueue, syncProcessorImpl, metricsClient, {name: 'sync_worker', interval: syncConfig.workerInterval});
+      syncWorker = new Worker(syncQueue, syncProcessorImpl, metricsClient, {name: 'sync_worker', interval: syncConfig.syncWorkerInterval});
 
       var ackProcessorImpl = ackProcessor(syncStorage);
-      ackWorker = new Worker(ackQueue, ackProcessorImpl, metricsClient, {name: 'ack_worker', interval: syncConfig.workerInterval});
+      ackWorker = new Worker(ackQueue, ackProcessorImpl, metricsClient, {name: 'ack_worker', interval: syncConfig.ackWorkerInterval});
 
       var pendingProcessorImpl = pendingProcessor(syncStorage, dataHandlers, hashProvider, metricsClient);
-      pendingWorker = new Worker(pendingQueue, pendingProcessorImpl, metricsClient, {name: 'pending_worker', interval: syncConfig.workerInterval});
+      pendingWorker = new Worker(pendingQueue, pendingProcessorImpl, metricsClient, {name: 'pending_worker', interval: syncConfig.pendingWorkerInterval});
 
       ackWorker.work();
       pendingWorker.work();

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -14,6 +14,7 @@ var syncLockModule = require('./lock');
 var syncProcessor = require('./sync-processor');
 var syncRecordsApiModule = require('./api-syncRecords');
 var syncSchedulerModule = require('./sync-scheduler');
+var cacheClientModule = require('./sync-cache');
 var syncUtil = require('./util');
 var debug = syncUtil.debug;
 var Worker = require('./worker');
@@ -31,6 +32,7 @@ var interceptors = null;
 var apiSync = null;
 var apiSyncRecords = null;
 var dataHandlers = null;
+var cacheClient = null;
 
 var ackQueue;
 var pendingQueue;
@@ -60,7 +62,11 @@ var DEFAULT_SYNC_CONF = {
   /**@type {String} the host of the influxdb server. If set, the metrics data will be sent to the influxdb server. */
   metricsInfluxdbHost: null,
   /**@type {Number} the port of the influxdb server. It should be a UDP port. */
-  metricsInfluxdbPort: null
+  metricsInfluxdbPort: null,
+  /**@type {Boolean} if cache the dataset client records using redis. This can help improve performance for the syncRecords API.
+   * Can be turned on if there are no records are shared between many different dataset clients. Default is false.
+  */
+  useCache: false,
 };
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
 var syncStarted = false;
@@ -83,7 +89,8 @@ function setClients(mongo, redis) {
   dataHandlers = dataHandlersModule({
     defaultHandlers: defaultDataHandlersModule(mongoDbClient)
   });
-  syncStorage = storageModule(mongoDbClient);
+  cacheClient = cacheClientModule(syncConfig, redisClient);
+  syncStorage = storageModule(mongoDbClient, cacheClient);
   // TODO: follow same pattern as other modules for this hashProviderModule
   hashProvider = hashProviderModule;
   syncLock = syncLockModule(mongoDbClient, 'fhsync_locks');
@@ -176,7 +183,9 @@ function stop(dataset_id, cb) {
 }
 
 function setConfig(conf) {
-  syncConfig = _.extend({}, DEFAULT_SYNC_CONF, conf);
+  //make sure extend the existing syncConfig object so that we don't have to update other modules which might have references to it.
+  //if we use new object here then we have to manually update those modules to reflect the change.
+  syncConfig = _.extend(syncConfig || {}, DEFAULT_SYNC_CONF, conf);
 }
 
 /**


### PR DESCRIPTION
This PR adds 2 changes:

1. Introduces a new caching layer & configuration to allow developers to control if they want to cache the records of the a given dataset client in redis. Load testing shows there are some performance gains if caching is enabled. However, there is a side effect of it (see the comments in the code), it's turned off by default.
2. Rename some of the configuration options to allow developers to control more behaviours of queues and workers.

ping @david-martin @aidenkeating for review.