### PR TITLE
 🐛 make sure the right queue are bound when start the queue prune job

### DIFF
--- a/lib/sync/datasets.js
+++ b/lib/sync/datasets.js
@@ -6,7 +6,7 @@ var DEFAULT_CONFIG = {
   //a value that will be used to decide if the dataset client is not active anymore.
   //if the gap between the current time and the last access time of the dataset client is bigger than this value, 
   //the dataset client is deemed to be inactive.
-  clientSyncTimeout: 15,
+  clientSyncTimeout: 60*60,
   //a value that determins how long it should wait for the backend list operation to complete
   backendListTimeout: 60*5
 };

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -167,9 +167,9 @@ function start(cb) {
         async.apply(ackQueue.create.bind(ackQueue)),
         async.apply(ackQueue.startPruneJob.bind(ackQueue), true),
         async.apply(pendingQueue.create.bind(pendingQueue)),
-        async.apply(pendingQueue.startPruneJob.bind(ackQueue), true),
+        async.apply(pendingQueue.startPruneJob.bind(pendingQueue), true),
         async.apply(syncQueue.create.bind(syncQueue)),
-        async.apply(syncQueue.startPruneJob.bind(ackQueue), true),
+        async.apply(syncQueue.startPruneJob.bind(syncQueue), true),
       ], callback);
     },
     function initApis(callback) {


### PR DESCRIPTION
I noticed that the queues are not pruned as expected in zeta. Turns out when start the prune jobs on the queues, the wrong context are used.

This PR will fix the issue.

Also we decided to change the default client timeout value to 1 hour.

ping @david-martin  @aidenkeating for review