### PR TITLE
 🐛 set a max wait time for the syncScheduled field

### DIFF
--- a/lib/sync/DatasetClient.js
+++ b/lib/sync/DatasetClient.js
@@ -1,5 +1,6 @@
 var syncUtil = require('./util');
 var datasets = require('./datasets');
+var debug = syncUtil.debug;
 
 function generateDatasetClientId(datasetClient) {
   return [datasetClient.datasetId, syncUtil.generateHash(datasetClient.queryParams)].join("_");
@@ -66,6 +67,7 @@ DatasetClient.prototype.shouldSync = function() {
     var sinceLastScheduled = Date.now() - self.syncScheduled;
     var maxWaitTIme = (self.config.maxScheduleWaitTime || (self.config.syncFrequency + self.config.backendListTimeout)) * 1000;
     if (sinceLastScheduled < maxWaitTIme) {
+      debug('skip scheduling for datasetClient %s as it is scheduled already', self.id);
       return false;
     }
   }

--- a/lib/sync/DatasetClient.js
+++ b/lib/sync/DatasetClient.js
@@ -55,8 +55,19 @@ DatasetClient.prototype.toJSON = function() {
  */
 DatasetClient.prototype.shouldSync = function() {
   var self = this;
-  if (self.stopped === true || self.syncScheduled) {
+  if (self.stopped === true) {
     return false;
+  }
+
+  //this will make sure the syncScheduled field won't cause the dataset client not to be synced anymore.
+  //This could happen if the syncScheduled is set on the datasetClient, but then the process is crashed before the sync requests are put on the queue (see checkDatasetsForSyncing in sync-scheduler.js). 
+  //The syncScheduled field will only take into consideration if it's within reasonable past.
+  if (self.syncScheduled) {
+    var sinceLastScheduled = Date.now() - self.syncScheduled;
+    var maxWaitTIme = (self.config.maxScheduleWaitTime || (self.config.syncFrequency + self.config.backendListTimeout)) * 1000;
+    if (sinceLastScheduled < maxWaitTIme) {
+      return false;
+    }
   }
 
   if (!self.syncLoopStart) {

--- a/lib/sync/datasets.js
+++ b/lib/sync/datasets.js
@@ -8,7 +8,11 @@ var DEFAULT_CONFIG = {
   //the dataset client is deemed to be inactive.
   clientSyncTimeout: 60*60,
   //a value that determins how long it should wait for the backend list operation to complete
-  backendListTimeout: 60*5
+  backendListTimeout: 60*5,
+  //Specify the max wait time the dataset can be scheduled to sync again after its previous schedule, in seconds.
+  //This is only used in some edge cases where the dataset is not synced as scheduled.
+  //By default it will be the syncFrequency + backendListTimeout (because in most cases, the sync requests should be executed immediately once put on the queue, and that is the maximum time it will take to execute.)
+  maxScheduleWaitTime: null
 };
 
 function Dataset(datasetId, opts) {

--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -59,6 +59,11 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
     });
 
     async.series([
+        //make sure each dataset client is marked to be scheduled
+        function updateDatasetClients(wcb) {
+          var datasetClientIds = _.pluck(datasetClientsToSync, 'id');
+          syncStorage.updateManyDatasetClients({id: {$in: datasetClientIds}}, {syncScheduled: Date.now()}, wcb);
+        },
         function addDatasetClientsToSyncQueue(wcb) {
           self.syncQueue.addMany(datasetClientsToSync, function(err) {
             // if there's a problem, log it and continue.
@@ -68,12 +73,6 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
             }
             return wcb();
           });
-        },
-        //make sure each dataset client is marked to be scheduled
-        function updateDatasetClients(wcb) {
-          async.each(datasetClientsToSync, function(datasetClient, cb) {
-            syncStorage.updateDatasetClient(datasetClient.id, {syncScheduled: Date.now()}, cb);
-          }, wcb);
         }
       ],
       function() {


### PR DESCRIPTION
This PR fixes a bug where the dataset client may not be synced anymore because the `syncScheduled` field is set.

ping @david-martin @aidenkeating for review.