### PR TITLE
FH-3460 Handle client records not being in syncRecords request

### DIFF
--- a/lib/sync/api-syncRecords.js
+++ b/lib/sync/api-syncRecords.js
@@ -180,7 +180,7 @@ function syncRecords(datasetId, params, cb) {
   var metaData = params.meta_data || {}; //NOTE: the client doesn't send in this value for syncRecords ATM
   var cuid = syncUtil.getCuid(params);
   var datasetClient = new DatasetClient(datasetId, {queryParams: queryParams, metaData: metaData});
-  var clientRecords = params.clientRecs;
+  var clientRecords = params.clientRecs || {};
   async.waterfall([
     function checkDatasetclientStopped(callback) {
       syncStorage.readDatasetClient(datasetClient.getId(), function(err, datasetClientJson) {


### PR DESCRIPTION
Currently if `clientRecs` is not provided in the body of a
syncRecords request the server will crash as it tries to access
it in the syncRecords logic.

This adds a small fix where if the `clientRecs` property is not
provided an empty object will be used instead.

@grdryn Could you take a look please? I haven't actually tested it yet.