### PR TITLE
FH-3461 Change inactive dataset client log

### DIFF
--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -48,7 +48,7 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
       var datasetId = datasetClient.getDatasetId();
       if (datasetClient.shouldDeactiveSync()) {
         //if the a datasetclient is not active, we don't need to sync it
-        debug('[%s] Deactivating sync. No client instances have accessed in %d ms', datasetId, datasetClient.getConfig().clientSyncTimeout * 1000);
+        debug('[%s] Ignoring inactive dataset client. No client instances have accessed in over %d ms', datasetId, datasetClient.getConfig().clientSyncTimeout * 1000);
       } else if (datasetClient.shouldSync()) {
         debug('[%s] schedule sync run for datasetClient %s', datasetId, datasetClient.id);
         var syncRequest = datasetClient.toJSON();


### PR DESCRIPTION
The log that would appear when dataset clients are inactive can be
confusing. This updates the log to something more descriptive.

@david-martin Could you take a mega-quick look?