### PR TITLE
 🎨 start the datasetClient cleaner job to remove the inactive dataset…

### DIFF
--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -129,7 +129,6 @@ function setClients(mongo, redis) {
   hashProvider = hashProviderModule;
   syncLock = syncLockModule(mongoDbClient, 'fhsync_locks');
   interceptors = interceptorsModule();
-  datasetClientCleaner = datasetClientCleanerModule(syncStorage);
 }
 
 function startAllWorkers(workers) {
@@ -234,7 +233,8 @@ function start(cb) {
       return callback();
     },
     function startDatasetClientCleaner(callback) {
-      datasetClientCleaner = datasetClientCleaner({retentionPeriod: syncConfig.datasetClientCleanerRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
+      var datasetClientCleanerBuilder = datasetClientCleanerModule(syncStorage);
+      datasetClientCleaner = datasetClientCleanerBuilder({retentionPeriod: syncConfig.datasetClientCleanerRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
       datasetClientCleaner.start(true, callback);
     }
   ], function(err) {

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -16,6 +16,7 @@ var syncRecordsApiModule = require('./api-syncRecords');
 var syncSchedulerModule = require('./sync-scheduler');
 var cacheClientModule = require('./sync-cache');
 var syncUtil = require('./util');
+var datasetClientCleanerModule = require('./datasetClientsCleaner');
 var debug = syncUtil.debug;
 var Worker = require('./worker');
 var _ = require('underscore');
@@ -32,6 +33,7 @@ var apiSync = null;
 var apiSyncRecords = null;
 var dataHandlers = null;
 var cacheClient = null;
+var datasetClientCleaner = null;
 
 var ackQueue;
 var pendingQueue;
@@ -94,7 +96,11 @@ var DEFAULT_SYNC_CONF = {
   /**@type {Object} specify how many messages to keep for the queues. By default it will keep the messages in the last 24 hours */
   queueMessagesToKeep: {time: '24h'},
   /**@type {Number} specify how often the queues should be checked to prune old message. By default it will run every hour. */
-  queuePruneFrequency: 1*60*60*1000
+  queuePruneFrequency: 1*60*60*1000,
+  /**@type {String} specify the maximum retention time of an inactive datasetClient. Any inactive datasetClient that is older than this period of time will be removed.*/
+  datasetClientCleanerRetentionPeriod: '24h',
+  /** @type {String} specify the frequency the datasetClient cleaner should run. Default every hour.*/
+  datasetClientCleanerCheckFrequency: '1h'
 };
 var syncConfig = _.extend({}, DEFAULT_SYNC_CONF);
 var syncStarted = false;
@@ -123,6 +129,7 @@ function setClients(mongo, redis) {
   hashProvider = hashProviderModule;
   syncLock = syncLockModule(mongoDbClient, 'fhsync_locks');
   interceptors = interceptorsModule();
+  datasetClientCleaner = datasetClientCleanerModule(syncStorage);
 }
 
 function startAllWorkers(workers) {
@@ -225,6 +232,10 @@ function start(cb) {
       syncScheduler = new SyncScheduler(syncQueue, {timeBetweenChecks: syncConfig.schedulerInterval, timeBeforeCrashAssumed: syncConfig.schedulerLockMaxTime, syncSchedulerLockName: syncConfig.schedulerLockName});
       syncScheduler.start();
       return callback();
+    },
+    function startDatasetClientCleaner(callback) {
+      datasetClientCleaner = datasetClientCleaner({retentionPeriod: syncConfig.datasetClientCleanerRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
+      datasetClientCleaner.start(true, callback);
     }
   ], function(err) {
     if (err) return cb(err);
@@ -272,6 +283,7 @@ function stopAll(cb) {
   ackQueue.stopPruneJob();
   pendingQueue.stopPruneJob();
   syncQueue.stopPruneJob();
+  datasetClientCleaner.stop();
   async.parallel([
     async.apply(syncStorage.updateManyDatasetClients, {}, {stopped: true}),
     async.apply(stopAllWorkers, syncWorkers),
@@ -300,6 +312,7 @@ function stopAll(cb) {
     interceptors = null;
     hashProvider = null;
     syncLock = null;
+    datasetClientCleaner = null;
     return cb();
   });
 }


### PR DESCRIPTION
…Clients

This PR will make sure the datasetClient cleaner will be started and stopped when the sync server is started or stopped.

A datasetClientCleaner will delete all the inactive datasetClients that are older than then given time threshold.