### PR TITLE
 🐛 Only call Object.freeze once to fix memory leak

### DIFF
--- a/lib/sync/DatasetClient.js
+++ b/lib/sync/DatasetClient.js
@@ -20,7 +20,7 @@ function DatasetClient(datasetId, opts){
   this.queryParams = opts.queryParams || {};
   this.metaData = opts.metaData || {};
   this.id = generateDatasetClientId(this);
-  this.config = opts.config || datasets.getDatasetConfig(datasetId);
+  this.config = Object.freeze(opts.config || datasets.getDatasetConfig(datasetId));
   this.collisionCount = opts.collisionCount || 0;
   this.stopped = opts.stopped;
   this.syncScheduled = opts.syncScheduled;
@@ -132,7 +132,7 @@ DatasetClient.prototype.getId = function() {
  * Get the current configuration object. Return an immutable object
  */
 DatasetClient.prototype.getConfig = function() {
-  return Object.freeze(this.config);
+  return this.config;
 };
 
 /**

--- a/lib/sync/DatasetClient.js
+++ b/lib/sync/DatasetClient.js
@@ -20,7 +20,7 @@ function DatasetClient(datasetId, opts){
   this.queryParams = opts.queryParams || {};
   this.metaData = opts.metaData || {};
   this.id = generateDatasetClientId(this);
-  this.config = Object.freeze(opts.config || datasets.getDatasetConfig(datasetId));
+  this.config = opts.config || datasets.getDatasetConfig(datasetId);
   this.collisionCount = opts.collisionCount || 0;
   this.stopped = opts.stopped;
   this.syncScheduled = opts.syncScheduled;

--- a/lib/sync/datasets.js
+++ b/lib/sync/datasets.js
@@ -17,7 +17,7 @@ var DEFAULT_CONFIG = {
 
 function Dataset(datasetId, opts) {
   this.id = datasetId;
-  this.config = Object.freeze(_.extend({}, DEFAULT_CONFIG, opts || {}));
+  this.config = _.extend({}, DEFAULT_CONFIG, opts || {});
 }
 
 Dataset.prototype.getConfig = function() {

--- a/lib/sync/datasets.js
+++ b/lib/sync/datasets.js
@@ -17,11 +17,11 @@ var DEFAULT_CONFIG = {
 
 function Dataset(datasetId, opts) {
   this.id = datasetId;
-  this.config = _.extend({}, DEFAULT_CONFIG, opts || {});
+  this.config = Object.freeze(_.extend({}, DEFAULT_CONFIG, opts || {}));
 }
 
 Dataset.prototype.getConfig = function() {
-  return Object.freeze(this.config);
+  return this.config;
 };
 
 var datasets = {};


### PR DESCRIPTION
Both the Raincatcher app and Simense app discovered memory leak. After investigation, it turns out too many objects are being created from Object.freeze calls.

This PR only calls Object.freeze at initialisation time to fix the memory leak