### PR TITLE
Fix timeout errors

### DIFF
--- a/lib/sync-DataSetModel.js
+++ b/lib/sync-DataSetModel.js
@@ -41,7 +41,6 @@ var self = {
   },
 
   datasets: {},
-  datasetClientRecords: {},
   deletedDatasets: {},
   createDatasetOnDemand: true,
 
@@ -361,20 +360,6 @@ var self = {
     }
   },
 
-  getDatasetClientRecords: function (datasetClient, cb) {
-    var datasetClientId = datasetClient.id;
-    if (typeof self.datasetClientRecords[datasetClientId] !== "undefined") {
-      return cb(null, self.datasetClientRecords[datasetClientId]);
-    } else {
-      var datasetId = datasetClient.datasetId;
-      syncUtil.doLog(datasetId, 'silly', 'no data records found for datasetClient ' + datasetClientId + '. Do backend list.');
-      self.syncDatasetClient(datasetClient, function (err) {
-        if (err) return cb(err);
-        return cb(null, self.datasetClientRecords[datasetClientId]);
-      });
-    }
-  },
-
   createDatasetClient: function (dataset_id, query_params, meta_data, cb) {
     self.getDataset(dataset_id, function (err, dataset) {
       if (err) return err;
@@ -444,7 +429,6 @@ var self = {
           syncUtil.doLog(dataset.id, 'verbose', 'doSyncList cb ' + ( cb !== undefined) + ' - Global Hash (prev :: cur) = ' + previousHash + ' ::  ' + globalHash);
 
           datasetClient.dataHash = globalHash;
-          self.datasetClientRecords[datasetClient.id] = hashes.records;
 
           datasetClient.syncRunning = false;
           datasetClient.syncLoopEnd = new Date().getTime();
@@ -523,7 +507,6 @@ var self = {
                 if (lastAccessed + syncClientTimeout < now) {
                   syncUtil.doLog(dataset_id, 'info', 'Deactivating sync for client ' + datasetClient.id + '. No client instances have accessed in ' + syncClientTimeout + 'ms');
                   datasetClient.syncActive = false;
-                  delete self.datasetClientRecords[datasetClient.id];
                 }
                 else {
                   var syncFrequency = dataset.config.syncFrequency * 1000;
@@ -561,35 +544,14 @@ var self = {
   toJSON: function (dataset_id, returnData, cb) {
     var res = {};
 
-    var addData = function (dataset) {
-      for (var i in dataset.clients) {
-        if (dataset.clients.hasOwnProperty(i)) {
-          var dsc = dataset.clients[i];
-          dsc.dataRecords = self.datasetClientRecords[dsc.id];
-        }
-      }
-    }
-
     if (!dataset_id) {
       // return entire sync object
       res = JSON.parse(JSON.stringify(self.datasets));
-      if (returnData) {
-        for (var i in res) {
-          if (res.hasOwnProperty(i)) {
-            var dataset = res[i];
-            addData(dataset);
-          }
-        }
-      }
       return cb(null, res);
     }
     else {
       self.getDataset(dataset_id, function (err) {
         if (err) return cb(err);
-
-        if (returnData) {
-          addData(res);
-        }
         return cb(null, res);
       });
     }
@@ -651,7 +613,6 @@ module.exports = {
   createDataset: self.createDataset,
   removeDataset: self.removeDataset,
   getDatasetClient: self.getDatasetClient,
-  getDatasetClientRecords: self.getDatasetClientRecords,
   createDatasetClient: self.createDatasetClient,
   removeDatasetClient: self.removeDatasetClient,
   syncDatasetClient: self.syncDatasetClient,

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -165,16 +165,22 @@ function doClientSync(dataset_id, params, callback) {
         if (params.pending && params.pending.length > 0) {
           syncUtil.doLog(dataset_id, 'info', 'Found ' + params.pending.length + ' pending records. processing', params);
 
-          // Process Pending Params then re-sync data
-          processPending(dataset_id, dataset, params, function () {
-            syncUtil.doLog(dataset_id, 'verbose', 'back from processPending', params);
-            // Changes have been submitted from client, redo the list operation on back end system.
-            DataSetModel.syncDatasetClient(datasetClient, function (err, res) {
-              if (err) return callback(err);
-              var resOut = {"hash": res.hash};
-              return returnUpdates(dataset_id, params, resOut, callback);
+          var resOut = {"hash": datasetClient.dataHash};
+          process.nextTick(function(){
+            // Process Pending Params then re-sync data
+            processPending(dataset_id, dataset, params, function () {
+              syncUtil.doLog(dataset_id, 'verbose', 'back from processPending', params);
+              // Changes have been submitted from client, redo the list operation on back end system.
+              DataSetModel.syncDatasetClient(datasetClient, function (err) {
+                if (err) {
+                  syncUtil.doLog(dataset_id, 'error', 'failed to sync datasetClient ' + util.inspect(err));
+                } else {
+                  syncUtil.doLog(dataset_id, 'verbose', 'datasetClient synced. Id = ' + datasetClient.id);
+                }
+              });
             });
           });
+          return returnUpdates(dataset_id, params, resOut, callback);
         }
         else {
           if (datasetClient.dataHash) {
@@ -183,7 +189,7 @@ function doClientSync(dataset_id, params, callback) {
             var res;
             if (datasetClient.dataHash === params.dataset_hash) {
               syncUtil.doLog(dataset_id, 'verbose', 'doClientSync - No pending - Hashes match. Just return hash', params);
-              res = {"hash": datasetClient.hash};
+              res = {"hash": datasetClient.dataHash};
               return returnUpdates(dataset_id, params, res, callback);
             }
             else {

--- a/lib/sync-srv.js
+++ b/lib/sync-srv.js
@@ -168,10 +168,14 @@ function doClientSync(dataset_id, params, callback) {
           var resOut = {"hash": datasetClient.dataHash};
           process.nextTick(function(){
             // Process Pending Params then re-sync data
+            var processStartTime = Date.now();
             processPending(dataset_id, dataset, params, function () {
+              syncUtil.doLog(dataset_id, 'info', "pending changes processed. Time taken = " + (Date.now() - processStartTime) + 'ms');
               syncUtil.doLog(dataset_id, 'verbose', 'back from processPending', params);
               // Changes have been submitted from client, redo the list operation on back end system.
+              var syncStartTime = Date.now();
               DataSetModel.syncDatasetClient(datasetClient, function (err) {
+                syncUtil.doLog(dataset_id, 'info', "sync loop completed. Time taken = " + (Date.now() - syncStartTime) + 'ms');
                 if (err) {
                   syncUtil.doLog(dataset_id, 'error', 'failed to sync datasetClient ' + util.inspect(err));
                 } else {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.8",
+  "version": "6.1.9",
   "dependencies": {
     "async": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "6.1.8",
+  "version": "6.1.9",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=6.1.8
+sonar.projectVersion=6.1.9
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
This PR:

1. Do not wait for the pending changes to be processed before returning response for sync API call. Instead return data ASAP, and process pending changes in `process.nextTick`.
2. Remove references to `datasetClientRecords`, it's not used and could use a lot of memory.

@david-martin can you please review the change?