### PR TITLE
Fix memory issue

### DIFF
--- a/integration/sync/test_storage.js
+++ b/integration/sync/test_storage.js
@@ -82,7 +82,7 @@ module.exports = {
       ], function(err){
         assert.ok(!err);
         
-        storage.listDatasetClients(function(err, savedDatasetClients){
+        storage.listDatasetClients({}, function(err, savedDatasetClients){
           assert.ok(!err);
           assert.equal(savedDatasetClients.length, 2);
           done();
@@ -131,7 +131,7 @@ module.exports = {
         async.apply(storage.removeDatasetClients, [datasetClient1])
       ], function(err){
         assert.ok(!err);
-        storage.listDatasetClients(function(err, savedDatasetClients){
+        storage.listDatasetClients({}, function(err, savedDatasetClients){
           assert.ok(!err);
           assert.equal(savedDatasetClients.length, 1);
           done();
@@ -235,7 +235,7 @@ module.exports = {
         async.apply(storage.updateManyDatasetClients, {}, {stopped: true}),
       ], function(err){
         assert.ok(!err);
-        storage.listDatasetClients(function(err, savedDatasetClients){
+        storage.listDatasetClients({}, function(err, savedDatasetClients){
           assert.ok(!err);
           assert.equal(savedDatasetClients[0].stopped, true);
           assert.equal(savedDatasetClients[1].stopped, true);

--- a/lib/sync/DatasetClient.js
+++ b/lib/sync/DatasetClient.js
@@ -109,7 +109,7 @@ DatasetClient.prototype.shouldDeactiveSync = function() {
 DatasetClient.prototype.shouldBeRemoved = function(retentionTime) {
   if (this.lastAccessed) {
     //only inactive datasetClients can be removed
-    return (this.lastAccessed + self.config.clientSyncTimeout * 1000 + retentionTime) < Date.now();
+    return (this.lastAccessed + this.config.clientSyncTimeout * 1000 + retentionTime) < Date.now();
   } else {
     return false;
   }

--- a/lib/sync/DatasetClient.js
+++ b/lib/sync/DatasetClient.js
@@ -108,7 +108,8 @@ DatasetClient.prototype.shouldDeactiveSync = function() {
  */
 DatasetClient.prototype.shouldBeRemoved = function(retentionTime) {
   if (this.lastAccessed) {
-    return (this.lastAccessed + retentionTime) < Date.now();
+    //only inactive datasetClients can be removed
+    return (this.lastAccessed + self.config.clientSyncTimeout * 1000 + retentionTime) < Date.now();
   } else {
     return false;
   }

--- a/lib/sync/api-sync.js
+++ b/lib/sync/api-sync.js
@@ -69,7 +69,8 @@ function processSyncAPI(datasetId, params, readDatasetClient, cb) {
     collisionCount: collisionCount,
     queryParams: queryParams,
     metaData: metaData,
-    lastAccessed: Date.now()
+    lastAccessed: Date.now(),
+    active: true
   };
   async.parallel({
     pushDatasetClient: function(callback) {

--- a/lib/sync/datasetClientsCleaner.js
+++ b/lib/sync/datasetClientsCleaner.js
@@ -27,7 +27,7 @@ function DatasetClientsCleaner(opts) {
 function cleanDatasetClients(retentionPeriod) {
   var parsedTime = parseDuration(retentionPeriod);
   async.waterfall([
-    async.apply(storage.listDatasetClients),
+    async.apply(storage.listDatasetClients, {active: false}),
     function filterDatasetClients(datasetClients, callback) {
       var datasetClientsToRemove = _.filter(datasetClients, function(datasetClientJson) {
         var datasetClient = DatasetClient.fromJSON(datasetClientJson);

--- a/lib/sync/storage/dataset-clients.js
+++ b/lib/sync/storage/dataset-clients.js
@@ -31,14 +31,15 @@ var cacheClient;
 
 /**
  * List all the dataset clients docs.
+ * @param {Object} filter
  * @param {Function} cb
  */
-function doListDatasetClients(cb) {
+function doListDatasetClients(filter, cb) {
   debug('doListDatasetClients');
   var col = mongoClient.collection(DATASETCLIENTS_COLLECTION);
-  col.find({}).toArray(function(err, datasetClients) {
+  col.find(filter).project({recordUids: 0}).toArray(function(err, datasetClients) {
     if (err) {
-      debug('Failed to list datasetClients due to error %j', err);
+      debug('Failed to list doListDatasetClients due to error %j', err);
     }
     return cb(err, datasetClients);
   });
@@ -421,8 +422,8 @@ module.exports = function(mongoClientImpl, cacheClientImpl) {
      * list the currently managed dataset clients
      * @param {Function} callback
      */
-    listDatasetClients: function(callback) {
-      metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doListDatasetClients)(callback);
+    listDatasetClients: function(filter, callback) {
+      metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doListDatasetClients)(filter, callback);
     },
 
     /**

--- a/lib/sync/storage/dataset-clients.js
+++ b/lib/sync/storage/dataset-clients.js
@@ -39,7 +39,7 @@ function doListDatasetClients(filter, cb) {
   var col = mongoClient.collection(DATASETCLIENTS_COLLECTION);
   col.find(filter).project({recordUids: 0}).toArray(function(err, datasetClients) {
     if (err) {
-      debug('Failed to list doListDatasetClients due to error %j', err);
+      debug('Failed to list datasetClients due to error %j', err);
     }
     return cb(err, datasetClients);
   });

--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -35,13 +35,16 @@ function SyncScheduler(syncQueueImpl, options) {
 SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
   var self = this;
   var timer = metrics.startTimer();
-  syncStorage.listDatasetClients(function(err, datasetClients) {
+  syncStorage.listDatasetClients({active: true}, function(err, datasetClients) {
     if (err) {
       metricsClient.gauge(metrics.KEYS.SYNC_SCHEDULER_CHECK_TIME, {success: false}, timer.stop());
       return cb(err);
     }
 
+    debug('[%s] sync scheduler checking %d active datasetClients', datasetClients.length);
+
     var datasetClientsToSync = [];
+    var inactiveDatasetClientIds = [];
 
     _.each(datasetClients, function(datasetClientJson) {
       var datasetClient = DatasetClient.fromJSON(datasetClientJson);
@@ -49,6 +52,7 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
       if (datasetClient.shouldDeactiveSync()) {
         //if the a datasetclient is not active, we don't need to sync it
         debug('[%s] Ignoring inactive dataset client. No client instances have accessed in over %d ms', datasetId, datasetClient.getConfig().clientSyncTimeout * 1000);
+        inactiveDatasetClientIds.push(datasetClient.getId());
       } else if (datasetClient.shouldSync()) {
         debug('[%s] schedule sync run for datasetClient %s', datasetId, datasetClient.id);
         var syncRequest = datasetClient.toJSON();
@@ -63,6 +67,9 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
         function updateDatasetClients(wcb) {
           var datasetClientIds = _.pluck(datasetClientsToSync, 'id');
           syncStorage.updateManyDatasetClients({id: {$in: datasetClientIds}}, {syncScheduled: Date.now()}, wcb);
+        },
+        function deactiveDatasetClients(wcb) {
+          syncStorage.updateManyDatasetClients({id: {$in: inactiveDatasetClientIds}}, {active: false}, wcb);
         },
         function addDatasetClientsToSyncQueue(wcb) {
           self.syncQueue.addMany(datasetClientsToSync, function(err) {

--- a/lib/sync/worker.js
+++ b/lib/sync/worker.js
@@ -11,7 +11,7 @@ function initBackoff(backOffOpts) {
     bo = new backoff.FibonacciStrategy({initialDelay: backOffOpts.min, maxDelay: backOffOpts.max});
   } else {
     //if no valid value is given, just return the default minimum delay. Can be used to turn off backoff.
-    console.log('[warning] no valid sync strategy found in the backoff options %o. Turning off backoff', backOffOpts);
+    console.log('[info] no valid sync strategy found in the backoff options. Turning off backoff', backOffOpts);
     bo = {
       next: function() {
         return backOffOpts.min;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "dependencies": {
     "async": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=7.0.1
+sonar.projectVersion=7.0.2
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/sync/test_datasetClientsCleaner.js
+++ b/test/sync/test_datasetClientsCleaner.js
@@ -30,10 +30,12 @@ module.exports = {
       var datasetClients = [{
         'datasetId': DATASETID,
         'queryParams': {user: '1'},
+        'config': {clientSyncTimeout: 1},
         'lastAccessed': Date.now() - 1.5*60*1000
       }, {
         'datasetId': DATASETID,
         'queryParams': {user: '2'},
+        'config': {clientSyncTimeout: 1},
         'lastAccessed': Date.now()
       }];
       syncStorage.listDatasetClients.yieldsAsync(null, datasetClients);

--- a/test/sync/test_sync-scheduler.js
+++ b/test/sync/test_sync-scheduler.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var sinon = require('sinon');
 var syncSchedulerModule = require('../../lib/sync/sync-scheduler');
+var DatasetClient = require('../../lib/sync/DatasetClient');
 
 var lockProvider = {
   acquire: sinon.stub(),
@@ -120,7 +121,9 @@ module.exports = {
       assert.equal(datasetClientsToSync[0].queryParams.user, "user1");
       assert.equal(datasetClientsToSync[1].queryParams.user, "user4");
 
-      assert.ok(syncStorage.updateManyDatasetClients.calledOnce);
+      assert.ok(syncStorage.updateManyDatasetClients.calledTwice);
+      var deactiveDatasetClients = syncStorage.updateManyDatasetClients.args[1][0];
+      assert.equal(deactiveDatasetClients.id.$in[0], DatasetClient.fromJSON(datasetClients[1]).getId());
 
       done();
     }, 1500);


### PR DESCRIPTION
## Why

During  load testing, we discovered that the app is using too much memory and CPU. After investigation, it turns out there the load test generate about 1700 datasetClients in the db, and some of those datasetClients have a lot of records associated with it.

In the syncScheduler, to check if a datasetClient should be synced, we do a `collection.list({})` operation. This operation lists ALL the data records and ALL the data fields in to memory and then process them. Since the collection data is relatively large, this has caused memory issue and CPU issue (to parse all the data).

To make things worse, there is a datasetClientCleaner that will run at the start of the app. It tries to identify the datasetClients that haven't been active for too long and remove them. It is listing all the datasetClients as well.
 
## What

To fix the issue, we add list filters to only get the datasetClients we need, and don't list the fields we don't need:

1. when list datasetClients in the syncScheduler, we only list `active` datasetClients. When those datasetClients are being checked, some of them will have the `active` field set to false if they are not active. The `active` field will be set to `true` again once they are accessed again from clients.
2. when cleanup datasetClients, we only need to list the ones that are not active.

Also this PR fixed an issue when a datasetClient could be removed before it's being marked as "inactive".

ping @david-martin  @aidenkeating for review
