### PR TITLE
Add `fh-mbaas-api:sync:error` debug level

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,6 @@
 var redis = require("redis");
 var Memcached = require('memcached');
-var debug = require('debug')('fh-mbaas-api:cache');
+var debugError = require('debug')('fh-mbaas-api:cache:error');
 var redisPort = 6379;
 var redisHost = '127.0.0.1';
 var redisPassword;
@@ -20,8 +20,8 @@ var getEnvVarValue = function(name, default_value, type) {
       return JSON.parse(value); // works for boolean, number, array & object;
     }
   } catch (e) {
-    debug('fh.cache excpetion parsing env var. Using default value');
-    debug('name=' + name + 'value=' + value + 'default_value=' + default_value + 'type=' + type + 'exception=' + e);
+    debugError('fh.cache excpetion parsing env var. Using default value');
+    debugError('name=' + name + 'value=' + value + 'default_value=' + default_value + 'type=' + type + 'exception=' + e);
     console.error(e);
     return default_value;
   }
@@ -147,7 +147,7 @@ var redisCache = function(opts, callback) {
       }
     });
     client.on("error", function(err) {
-      debug("fh.cache error: %s ", err);
+      debugError("fh.cache error: %s ", err);
       return callback(err);
     });
     client.on("ready", function(err) {
@@ -173,7 +173,7 @@ var redisCache = function(opts, callback) {
       }
     });
     client.on("error", function(err) {
-      debug("fh.cache error: %s", err);
+      debugError("fh.cache error: %s", err);
       callback(err);
       client.end();
     });
@@ -193,7 +193,7 @@ var redisCache = function(opts, callback) {
       }
     });
     client.on("error", function(err) {
-      debug("fh.cache error: %s", err);
+      debugError("fh.cache error: %s", err);
       return callback(err);
     });
     client.on("ready", function(err) {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,5 @@
 var redis = require("redis");
 var Memcached = require('memcached');
-var debugError = require('debug')('fh-mbaas-api:cache:error');
 var redisPort = 6379;
 var redisHost = '127.0.0.1';
 var redisPassword;
@@ -20,8 +19,8 @@ var getEnvVarValue = function(name, default_value, type) {
       return JSON.parse(value); // works for boolean, number, array & object;
     }
   } catch (e) {
-    debugError('fh.cache excpetion parsing env var. Using default value');
-    debugError('name=' + name + 'value=' + value + 'default_value=' + default_value + 'type=' + type + 'exception=' + e);
+    console.error('fh.cache excpetion parsing env var. Using default value');
+    console.error('name=' + name + 'value=' + value + 'default_value=' + default_value + 'type=' + type + 'exception=' + e);
     console.error(e);
     return default_value;
   }
@@ -147,7 +146,7 @@ var redisCache = function(opts, callback) {
       }
     });
     client.on("error", function(err) {
-      debugError("fh.cache error: %s ", err);
+      console.error("fh.cache error: %s ", err);
       return callback(err);
     });
     client.on("ready", function(err) {
@@ -173,7 +172,7 @@ var redisCache = function(opts, callback) {
       }
     });
     client.on("error", function(err) {
-      debugError("fh.cache error: %s", err);
+      console.error("fh.cache error: %s", err);
       callback(err);
       client.end();
     });
@@ -193,7 +192,7 @@ var redisCache = function(opts, callback) {
       }
     });
     client.on("error", function(err) {
-      debugError("fh.cache error: %s", err);
+      console.error("fh.cache error: %s", err);
       return callback(err);
     });
     client.on("ready", function(err) {

--- a/lib/call.js
+++ b/lib/call.js
@@ -1,5 +1,5 @@
 var config,
-  debug = require('debug')('fh-mbaas-api:call'),
+  debugError = require('debug')('fh-mbaas-api:call:error'),
   _ = require('underscore'),
   https = require('https'),
   futils = require('./fhutils'),
@@ -63,7 +63,7 @@ var call = function call(path, params, callback) {
   });
 
   req.on('error', function(e) {
-    debug('Problem invoking: %s', e.message);
+    debugError('Problem invoking: %s', e.message);
     callback(e);
   });
 

--- a/lib/call.js
+++ b/lib/call.js
@@ -1,5 +1,4 @@
 var config,
-  debugError = require('debug')('fh-mbaas-api:call:error'),
   _ = require('underscore'),
   https = require('https'),
   futils = require('./fhutils'),
@@ -63,7 +62,7 @@ var call = function call(path, params, callback) {
   });
 
   req.on('error', function(e) {
-    debugError('Problem invoking: %s', e.message);
+    console.error('Problem invoking: %s', e.message);
     callback(e);
   });
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -2,7 +2,6 @@ var request = require('request'),
   fs = require('fs'),
   util = require('util'),
   debug = require('debug')('fh-mbaas-api:db'),
-  debugError = require('debug')('fh-mbaas-api:db:error'),
   mongodbUri = require('mongodb-uri'),
   assert = require('assert'),
   futils = require('./fhutils'),
@@ -69,7 +68,7 @@ function getMongoConnectionUrl(cb) {
     process.env.FH_MONGODB_CONN_URL = 'mongodb://localhost:27017/FH_LOCAL';
     return cb(undefined, process.env.FH_MONGODB_CONN_URL);
   } else {
-    debugError('no way to determine mongo connection string');
+    console.error('no way to determine mongo connection string');
     return cb();
   }
 }
@@ -163,7 +162,7 @@ function net_db(params, callback) {
     // Only export requests get streamed - the rest use the normal callback mehcanism
     requestArgs.push(function(err, res, body) {
       if (err) {
-        debugError('Problem contacting DITCH server: ' + err.message + "\n" + util.inspect(err.stack));
+        console.error('Problem contacting DITCH server: ' + err.message + "\n" + util.inspect(err.stack));
         return callback(err);
       }
       return callback(null, body);
@@ -191,7 +190,7 @@ function net_db(params, callback) {
   if (params.act === 'export') {
     // Finish up a streaming request for exports
     req.on('error', function(err) {
-      debugError('Problem contacting DITCH server: %s \n %s', err.message, util.inspect(err.stack));
+      console.error('Problem contacting DITCH server: %s \n %s', err.message, util.inspect(err.stack));
       return callback(err);
     });
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -2,6 +2,7 @@ var request = require('request'),
   fs = require('fs'),
   util = require('util'),
   debug = require('debug')('fh-mbaas-api:db'),
+  debugError = require('debug')('fh-mbaas-api:db:error'),
   mongodbUri = require('mongodb-uri'),
   assert = require('assert'),
   futils = require('./fhutils'),
@@ -68,7 +69,7 @@ function getMongoConnectionUrl(cb) {
     process.env.FH_MONGODB_CONN_URL = 'mongodb://localhost:27017/FH_LOCAL';
     return cb(undefined, process.env.FH_MONGODB_CONN_URL);
   } else {
-    debug('no way to determine mongo connection string');
+    debugError('no way to determine mongo connection string');
     return cb();
   }
 }
@@ -162,7 +163,7 @@ function net_db(params, callback) {
     // Only export requests get streamed - the rest use the normal callback mehcanism
     requestArgs.push(function(err, res, body) {
       if (err) {
-        debug('Problem contacting DITCH server: ' + err.message + "\n" + util.inspect(err.stack));
+        debugError('Problem contacting DITCH server: ' + err.message + "\n" + util.inspect(err.stack));
         return callback(err);
       }
       return callback(null, body);
@@ -190,7 +191,7 @@ function net_db(params, callback) {
   if (params.act === 'export') {
     // Finish up a streaming request for exports
     req.on('error', function(err) {
-      debug('Problem contacting DITCH server: %s \n %s', err.message, util.inspect(err.stack));
+      debugError('Problem contacting DITCH server: %s \n %s', err.message, util.inspect(err.stack));
       return callback(err);
     });
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,14 +1,12 @@
 /**
  * Init script responsible for setting required parameters
  */
-var debugError = require('debug')('fh-mbaas-api:init:error');
-
 module.exports = function init() {
   var maxSocketCount = Infinity;
   if (process.env.NODE_MAX_SOCKETS_COUNT) {
     var count = process.env.NODE_MAX_SOCKETS_COUNT;
     if (isNaN(count)) {
-      debugError("Invalid NODE_MAX_SOCKETS_COUNT environment variable: " + count);
+      console.error("Invalid NODE_MAX_SOCKETS_COUNT environment variable: " + count);
     } else {
       maxSocketCount = Number(process.env.NODE_MAX_SOCKETS_COUNT);
     }

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,14 +1,14 @@
 /**
  * Init script responsible for setting required parameters
  */
-var debug = require('debug')("fh-mbaas-api:init");
+var debugError = require('debug')('fh-mbaas-api:init:error');
 
 module.exports = function init() {
   var maxSocketCount = Infinity;
   if (process.env.NODE_MAX_SOCKETS_COUNT) {
     var count = process.env.NODE_MAX_SOCKETS_COUNT;
     if (isNaN(count)) {
-      debug("Invalid NODE_MAX_SOCKETS_COUNT environment variable: " + count);
+      debugError("Invalid NODE_MAX_SOCKETS_COUNT environment variable: " + count);
     } else {
       maxSocketCount = Number(process.env.NODE_MAX_SOCKETS_COUNT);
     }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,6 +1,6 @@
 var fhs = require("fh-statsc"),
   assert = require('assert'),
-  debug = require('debug')('fh-mbaas-api:stats'),
+  debugError = require('debug')('fh-mbaas-api:stats:error'),
   config, appname,
   stats_host, stats_port, stats_enabled, fhStats;
 
@@ -35,7 +35,7 @@ var stats = function() {
     }
 
     fhStats.inc(formatStatsName(stat, apiStats), function(err) {
-      if (err) debug("Error %s", err);
+      if (err) debugError("Error %s", err);
       if (cb) cb(err);
     });
   }
@@ -47,7 +47,7 @@ var stats = function() {
     }
 
     fhStats.dec(formatStatsName(stat, apiStats), function(err) {
-      if (err) debug("Error %s", err);
+      if (err) debugError("Error %s", err);
       if (cb) cb(err);
     });
   }
@@ -59,7 +59,7 @@ var stats = function() {
     }
 
     fhStats.timing(formatStatsName(stat, apiStats), time, function(err) {
-      if (err) debug("Error %s", err);
+      if (err) debugError("Error %s", err);
       if (cb) cb(err);
     });
   }
@@ -71,7 +71,7 @@ var stats = function() {
     }
 
     fhStats.gauge(formatStatsName(stat, apiStats), value, function(err) {
-      if (err) debug("Error %s", err);
+      if (err) debugError("Error %s", err);
       if (cb) cb(err);
     });
   }

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,6 +1,5 @@
 var fhs = require("fh-statsc"),
   assert = require('assert'),
-  debugError = require('debug')('fh-mbaas-api:stats:error'),
   config, appname,
   stats_host, stats_port, stats_enabled, fhStats;
 
@@ -35,7 +34,7 @@ var stats = function() {
     }
 
     fhStats.inc(formatStatsName(stat, apiStats), function(err) {
-      if (err) debugError("Error %s", err);
+      if (err) console.error("Error %s", err);
       if (cb) cb(err);
     });
   }
@@ -47,7 +46,7 @@ var stats = function() {
     }
 
     fhStats.dec(formatStatsName(stat, apiStats), function(err) {
-      if (err) debugError("Error %s", err);
+      if (err) console.error("Error %s", err);
       if (cb) cb(err);
     });
   }
@@ -59,7 +58,7 @@ var stats = function() {
     }
 
     fhStats.timing(formatStatsName(stat, apiStats), time, function(err) {
-      if (err) debugError("Error %s", err);
+      if (err) console.error("Error %s", err);
       if (cb) cb(err);
     });
   }
@@ -71,7 +70,7 @@ var stats = function() {
     }
 
     fhStats.gauge(formatStatsName(stat, apiStats), value, function(err) {
-      if (err) debugError("Error %s", err);
+      if (err) console.error("Error %s", err);
       if (cb) cb(err);
     });
   }

--- a/lib/sync/ack-processor.js
+++ b/lib/sync/ack-processor.js
@@ -1,5 +1,6 @@
 var syncUtil = require('./util');
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 
 var syncStorage;
 
@@ -14,13 +15,13 @@ var syncStorage;
 function processAcknowledgement(acknowledgement, callback) {
   var datasetId = acknowledgement.datasetId;
   if (!datasetId || !acknowledgement.cuid || !acknowledgement.hash) {
-    debug("acknowledgement missing info %j", acknowledgement);
+    debugError("acknowledgement missing info %j", acknowledgement);
     return callback();
   }
   debug('processAcknowledge :: processing acknowledge %j', acknowledgement);
   syncStorage.findAndDeleteUpdate(datasetId, acknowledgement, function(err) {
     if (err) {
-      debug('END processAcknowledge - err=%j', err);
+      debugError('END processAcknowledge - err=%j', err);
       return callback(err);
     } else {
       debug('acknowledgement processed successfully. hash = %s', acknowledgement.hash);

--- a/lib/sync/api-sync.js
+++ b/lib/sync/api-sync.js
@@ -3,6 +3,7 @@ var async = require('async');
 var syncUtil = require('./util');
 var DatasetClient = require('./DatasetClient');
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 var interceptors, ackQueue, pendingQueue, syncStorage, syncConfig;
 
 var datasetClientsUpdateQueue;
@@ -93,7 +94,7 @@ function processSyncAPI(datasetId, params, readDatasetClient, cb) {
     }
   }, function(err, results) {
     if (err) {
-      debug('[%s] sync request error = %j %j', datasetId, err, params);
+      debugError('[%s] sync request error = %j %j', datasetId, err, params);
       return cb(err);
     } else {
       debug('[%s] syn API results %j', datasetId, results);
@@ -103,7 +104,7 @@ function processSyncAPI(datasetId, params, readDatasetClient, cb) {
       var response = {hash: globalHash, updates: formatUpdates(remainingUpdates)};
       interceptors.responseInterceptor(datasetId, queryParams, function(err) {
         if (err) {
-          debug('[%s] sync response interceptor returns error = %j %j', datasetId, err, params);
+          debugError('[%s] sync response interceptor returns error = %j %j', datasetId, err, params);
           return cb(err);
         }
         debug('[%s] sync API response %j', datasetId, response);
@@ -152,7 +153,7 @@ function sync(datasetId, params, cb) {
     }
   }, function(err, results) {
     if (err) {
-      debug('[%s] sync request returns error = %j %j', datasetId, err, params);
+      debugError('[%s] sync request returns error = %j %j', datasetId, err, params);
       return cb(err);
     }
     return processSyncAPI(datasetId, params, results.readDatasetClient, cb);

--- a/lib/sync/api-syncRecords.js
+++ b/lib/sync/api-syncRecords.js
@@ -7,6 +7,7 @@ var SYNC_UPDATE_TYPES = require('./pending-processor').SYNC_UPDATE_TYPES;
 var convertToObject = syncUtil.convertToObject;
 var syncStorage, pendingQueue;
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 
 /**
  * List the records for the given datasetClient
@@ -189,7 +190,7 @@ function syncRecords(datasetId, params, cb) {
         }
         if (!datasetClientJson) {
           var errMsg = "unknown dataset client datasetId = " + datasetId + " :: queryParams = " + util.inspect(queryParams);
-          debug("[%s] %s", datasetId, errMsg);
+          debugError("[%s] %s", datasetId, errMsg);
           return callback(errMsg);
         }
         if (datasetClientJson.stopped === true) {

--- a/lib/sync/datasetClientsCleaner.js
+++ b/lib/sync/datasetClientsCleaner.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 var DatasetClient = require('./DatasetClient');
 var syncUtil = require('./util');
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 
 var storage;
 
@@ -38,7 +39,7 @@ function cleanDatasetClients(retentionPeriod) {
     async.apply(storage.removeDatasetClients)
   ], function(err, deletedDatasetClients) {
     if (err) {
-      debug('Failed to cleanup dataset clients due to error %j', err);
+      debugError('Failed to cleanup dataset clients due to error %j', err);
     } else {
       debug('Removed %d dataset clients',_.size(deletedDatasetClients));
     }

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -8,6 +8,7 @@ var redis = require('redis');
 var async = require('async');
 var eventEmitter = new (require('events').EventEmitter)();
 var debug=syncUtil.debug;
+var debugError = syncUtil.debugError;
 
 function toJSON(dataset_id, returnData, cb) {
   debug('[%s] toJSON',dataset_id);
@@ -78,7 +79,7 @@ function invoke(dataset_id, params, callback) {
   // Verify that fn param has been passed
   if (!params || !params.fn) {
     var err = 'no fn parameter provided in params "' + util.inspect(params) + '"';
-    debug('[%s] warn %s $j', dataset_id, err, params);
+    debugError('[%s] warn %s $j', dataset_id, err, params);
     return callback(err, null);
   }
 

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -3,6 +3,7 @@ var metrics = require('./sync-metrics');
 var _ = require('underscore');
 var syncUtil = require('./util');
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 var parseDuration = require('parse-duration');
 
 /**
@@ -135,7 +136,7 @@ MongodbQueue.prototype.prune = function(cb) {
   collection.deleteMany(pruneQuery, function(err, result){
     self.metrics.gauge(metrics.KEYS.QUEUE_OPERATION_TIME, {method: 'prune', name: self.queueName}, timer.stop());
     if (err) {
-      debug('Failed to delete messages from queue %s due to error %j', self.queueName, err);
+      debugError('Failed to delete messages from queue %s due to error %j', self.queueName, err);
     } else {
       debug('Deleted %d messages from queue %s', result.deletedCount, self.queueName);
     }

--- a/lib/sync/pending-processor.js
+++ b/lib/sync/pending-processor.js
@@ -1,5 +1,6 @@
 var syncUtil = require('./util');
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 var metrics = require('./sync-metrics');
 var util = require('util');
 
@@ -39,7 +40,7 @@ function handleCollision(datasetId, metaData, pendingChange, dataHash, callback)
   var newCollisionCount = pendingChange.datasetClient.collisionCount + 1;
   syncStorage.updateDatasetClient(pendingChange.datasetClient.id, {collisionCount: newCollisionCount}, function(err) {
     if (err) {
-      debug('[%s] Updating dataset client collision count (%s) failed : err = %j', datasetId, pendingChange.datasetClient.id, err);
+      debugError('[%s] Updating dataset client collision count (%s) failed : err = %j', datasetId, pendingChange.datasetClient.id, err);
     }
   });
   dataHandlers.handleCollision(datasetId, collisionFields.hash, collisionFields.timestamp, collisionFields.uid, collisionFields.pre, collisionFields.post, metaData, callback);
@@ -65,7 +66,7 @@ function doCreate(datasetId, pendingChange, callback) {
   debug('[%s] CREATE Start data = %j', datasetId, record);
   dataHandlers.doCreate(datasetId, record, metaData, function(err, data) {
     if (err) {
-      debug('[%s] CREATE Failed - : err = %j', datasetId, err);
+      debugError('[%s] CREATE Failed - : err = %j', datasetId, err);
     } else {
       debug('[%s] CREATE Success - uid = %s', datasetId, data.uid);
       pendingChange.oldUid = pendingChange.uid;
@@ -97,7 +98,7 @@ function doUpdate(datasetId, pendingChange, callback) {
   var uid = pendingChange.uid;
   dataHandlers.doRead(datasetId, uid, metaData, function(err, data) {
     if (err) {
-      debug('[%s] READ for UPDATE Failed - uid = %s : err = %j', datasetId, uid, err);
+      debugError('[%s] READ for UPDATE Failed - uid = %s : err = %j', datasetId, uid, err);
       return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.FAILED, util.inspect(err), callback);
     }
     debug('[%s] READ for UPDATE Success', datasetId);
@@ -111,7 +112,7 @@ function doUpdate(datasetId, pendingChange, callback) {
     if (preHash === dataHash) {
       dataHandlers.doUpdate(datasetId, uid, pendingChange.post, metaData, function(err) {
         if (err) {
-          debug('[%s] UPDATE Failed - uid = %s : err = %j', datasetId, uid, err);
+          debugError('[%s] UPDATE Failed - uid = %s : err = %j', datasetId, uid, err);
         } else {
           debug('[%s] UPDATE Success - uid = %s : hash = %s', datasetId, uid, dataHash);
         }
@@ -128,7 +129,7 @@ function doUpdate(datasetId, pendingChange, callback) {
         debug('[%s] UPDATE COLLISION \n Pre record from client:\n%j\nCurrent record from data store:\n%j', datasetId, syncUtil.sortObject(pendingChange.pre), syncUtil.sortObject(data));
         handleCollision(datasetId, metaData, pendingChange, dataHash, function(err) {
           if (err) {
-            debug('[%s] Failed to save collision uid = %s : err = %j', datasetId, uid, err);
+            debugError('[%s] Failed to save collision uid = %s : err = %j', datasetId, uid, err);
           }
           return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.COLLISION, null, callback);
         });
@@ -158,7 +159,7 @@ function doDelete(datasetId, pendingChange, callback) {
   var uid = pendingChange.uid;
   dataHandlers.doRead(datasetId, uid, metaData, function(err, data) {
     if (err) {
-      debug('READ for DELETE Failed - uid = %s : err = %j', datasetId, uid, err);
+      debugError('READ for DELETE Failed - uid = %s : err = %j', datasetId, uid, err);
       return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.FAILED, util.inspect(err), callback);
     }
     debug('[%s] READ for DELETE Success', datasetId);
@@ -178,7 +179,7 @@ function doDelete(datasetId, pendingChange, callback) {
       if (preHash === dataHash) {
         dataHandlers.doDelete(datasetId, uid, metaData, function(err) {
           if (err) {
-            debug('[%s] DELETE Failed - uid=%s : err = %j', datasetId, err);
+            debugError('[%s] DELETE Failed - uid=%s : err = %j', datasetId, err);
           } else {
             debug('[%s] DELETE Success - uid=%s : hash = %s', datasetId, dataHash);
           }
@@ -188,7 +189,7 @@ function doDelete(datasetId, pendingChange, callback) {
         debug('[%s] DELETE COLLISION \n Pre record from client:\n%j\nCurrent record from data store:\n%j', datasetId, syncUtil.sortObject(pendingChange.pre), syncUtil.sortObject(data));
         handleCollision(datasetId, metaData, pendingChange, dataHash, function(err) {
           if (err) {
-            debug('[%s] Failed to save collision uid = %s : err = %j', datasetId, err);
+            debugError('[%s] Failed to save collision uid = %s : err = %j', datasetId, err);
           }
           return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.COLLISION, null, callback);
         });
@@ -215,13 +216,13 @@ function doDelete(datasetId, pendingChange, callback) {
 function applyPendingChange(pendingChange, tries, callback) {
   var datasetId = pendingChange.datasetId;
   if (!datasetId || !pendingChange.action || !pendingChange.uid || !pendingChange.cuid || !pendingChange.hash) {
-    debug("[%s] invalid pendingChange request dropped :: item = %j", datasetId, pendingChange);
+    debugError("[%s] invalid pendingChange request dropped :: item = %j", datasetId, pendingChange);
     return callback();
   }
   debug('[%s] processPending :: item = %j', datasetId, pendingChange);
   if (tries > 1) {
     //the pendingChange has been processed before but it didn't complete, most likely the process crashedd. Mark it as failed
-    debug('[%s] processPending failed :: tries = %d  :: item = %j', datasetId, tries, pendingChange);
+    debugError('[%s] processPending failed :: tries = %d  :: item = %j', datasetId, tries, pendingChange);
     return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.FAILED, "crashed", callback);
   }
   var action = pendingChange.action.toLowerCase();
@@ -244,7 +245,7 @@ function applyPendingChange(pendingChange, tries, callback) {
       doDelete(datasetId, pendingChange, onComplete);
       break;
     default:
-      debug("[%s] invalid pendingChange request dropped :: item = %j", datasetId, pendingChange);
+      debugError("[%s] invalid pendingChange request dropped :: item = %j", datasetId, pendingChange);
       return onComplete();
   }
 }

--- a/lib/sync/storage/dataset-clients.js
+++ b/lib/sync/storage/dataset-clients.js
@@ -3,6 +3,7 @@ var syncUtil = require('../util');
 var async = require('async');
 var _ = require('underscore');
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 var DATASETCLIENTS_COLLECTION = "fhsync_datasetClients";
 var RECORDS_UPDATE_CONCURRENCY = 10;
 var mongoClient;
@@ -39,7 +40,7 @@ function doListDatasetClients(filter, cb) {
   var col = mongoClient.collection(DATASETCLIENTS_COLLECTION);
   col.find(filter).toArray(function(err, datasetClients) {
     if (err) {
-      debug('Failed to list datasetClients due to error %j', err);
+      debugError('Failed to list datasetClients due to error %j', err);
     }
     return cb(err, datasetClients);
   });
@@ -163,7 +164,7 @@ function upsertOrDeleteDatasetRecords(datasetId, datasetClientId, records, cb) {
     });
   }, function(err, updates) {
     if (err) {
-      debug('Failed to upsertOrDeleteDatasetRecords due to error %j :: datasetId = %s', err, datasetId);
+      debugError('Failed to upsertOrDeleteDatasetRecords due to error %j :: datasetId = %s', err, datasetId);
       return cb(err);
     }
     var returned = _.compact(updates);
@@ -217,7 +218,7 @@ function doReadDatasetClientWithRecords(datasetClientId, callback) {
     }
   ], function(err, datasetClientJson, localRecords) {
     if (err) {
-      debug('Failed to doReadDatasetClientWithRecords due to error %j :: datasetClientId = %s', err, datasetClientId);
+      debugError('Failed to doReadDatasetClientWithRecords due to error %j :: datasetClientId = %s', err, datasetClientId);
       return callback(err);
     }
     if (datasetClientJson) {
@@ -242,7 +243,7 @@ function doReadDatasetClientWithRecordsUseCache(datasetClientId, callback) {
   var cacheKey = buildDatasetClientRecordsCachkey(datasetClientId);
   cacheClient.get(cacheKey, function(err, cachedData){
     if (err) {
-      debug('Failed to read cache from redis with key %s due to error %j', cacheKey, err);
+      debugError('Failed to read cache from redis with key %s due to error %j', cacheKey, err);
     }
     if (cachedData) {
       return callback(null, JSON.parse(cachedData));
@@ -268,7 +269,7 @@ function doReadDatasetClient(datasetClientId, cb) {
   var col = mongoClient.collection(DATASETCLIENTS_COLLECTION);
   col.findOne({id: datasetClientId}, function(err, datasetClient) {
     if (err) {
-      debug('Failed to read datasetClient due to error %j :: datasetClientId = %s', err, datasetClientId);
+      debugError('Failed to read datasetClient due to error %j :: datasetClientId = %s', err, datasetClientId);
     }
     return cb(err, datasetClient);
   });
@@ -306,7 +307,7 @@ function doUpdateDatasetClient(datasetClientId, fields, upsert, cb) {
   delete fields._id;
   col.findOneAndUpdate({id: datasetClientId}, {'$set': fields}, {upsert: upsert, returnOriginal: false}, function(err, result) {
     if (err) {
-      debug('Failed to update datasetClients due to error %j :: datasetClientId = %s :: fields = %j',err,datasetClientId,fields);
+      debugError('Failed to update datasetClients due to error %j :: datasetClientId = %s :: fields = %j',err,datasetClientId,fields);
       return cb(err);
     }
 
@@ -330,7 +331,7 @@ function createIndexForCollection(collectionName, indexField, indexOpts) {
   var collection = mongoClient.collection(collectionName);
   collection.createIndex(indexField, indexOpts, function(err) {
     if (err) {
-      debug('Failed to create index for collection. collection = %s :: index = %j :: error = %j',collectionName,indexField,err);
+      debugError('Failed to create index for collection. collection = %s :: index = %j :: error = %j',collectionName,indexField,err);
     } else {
       debug('Index created for collection. Collection = %s  :: index = %j',collectionName,indexField);
     }
@@ -418,7 +419,7 @@ function doUpdateDatasetClientWithRecords(datasetClientId, fields, records, call
     }
   ], function(err, updatedDatasetClient) {
     if (err) {
-      debug('Failed to doUpdateDatasetClientWithRecords due to error %j :: datasetClientId = %s :: fields = %j', err, datasetClientId, fields);
+      debugError('Failed to doUpdateDatasetClientWithRecords due to error %j :: datasetClientId = %s :: fields = %j', err, datasetClientId, fields);
     }
     return callback(err, updatedDatasetClient);
   });
@@ -429,7 +430,7 @@ function doUpdateManyDatasetClients(query, fields, callback) {
   var datasetClientsCollection = mongoClient.collection(DATASETCLIENTS_COLLECTION);
   datasetClientsCollection.updateMany(query, {$set: fields}, function(err, result) {
     if (err) {
-      debug('Failed to doUpdateManyDatasetClients due to error %j :: fields = %j', err, fields);
+      debugError('Failed to doUpdateManyDatasetClients due to error %j :: fields = %j', err, fields);
       return callback(err);
     }
     return callback(null, result);

--- a/lib/sync/storage/sync-updates.js
+++ b/lib/sync/storage/sync-updates.js
@@ -1,6 +1,7 @@
 var syncUtil = require('../util');
 var metrics = require('../sync-metrics');
 var debug=syncUtil.debug;
+var debugError = syncUtil.debugError;
 var mongoClient;
 
 /**
@@ -26,7 +27,7 @@ function doFindAndDeleteUpdate(datasetId, acknowledgement, callback) {
   var updatesCollection = mongoClient.collection(getDatasetUpdatesCollectionName(datasetId));
   updatesCollection.findOneAndDelete({cuid: acknowledgement.cuid, hash: acknowledgement.hash}, function(err, result) {
     if (err) {
-      debug('[%s] Failed to doFindAndDeleteUpdate due to error %j :: acknowledgement = %j',datasetId,err,acknowledgement);
+      debugError('[%s] Failed to doFindAndDeleteUpdate due to error %j :: acknowledgement = %j',datasetId,err,acknowledgement);
       return callback(err);
     }
     return callback(null, result.value);
@@ -45,7 +46,7 @@ function doSaveUpdate(datasetId, acknowledgementFields, callback) {
   var updatesCollection = mongoClient.collection(getDatasetUpdatesCollectionName(datasetId));
   updatesCollection.findOneAndUpdate({cuid: acknowledgementFields.cuid, hash: acknowledgementFields.hash}, {'$set': acknowledgementFields}, {upsert: true, returnOriginal: false}, function(err, updateResult) {
     if (err) {
-      debug('[%s] Failed to doSaveUpdate due to error %j :: acknowledgementFields = %j' ,datasetId,err,acknowledgementFields);
+      debugError('[%s] Failed to doSaveUpdate due to error %j :: acknowledgementFields = %j' ,datasetId,err,acknowledgementFields);
       return callback(err);
     }
     return callback(null, updateResult.value);
@@ -64,7 +65,7 @@ function doListUpdates(datasetId, criteria, callback) {
   var updatesCollection = mongoClient.collection(getDatasetUpdatesCollectionName(datasetId));
   updatesCollection.find(criteria).toArray(function(err, updates) {
     if (err) {
-      debug('[%s] Failed to doListUpdates due to error %j :: criteria = %j' + criteria,datasetId,err,criteria);
+      debugError('[%s] Failed to doListUpdates due to error %j :: criteria = %j' + criteria,datasetId,err,criteria);
       return callback(err);
     }
     return callback(null, updates);

--- a/lib/sync/sync-metrics.js
+++ b/lib/sync/sync-metrics.js
@@ -29,6 +29,7 @@ var metricsTitle = (process.env.FH_TITLE || 'fhsync') + '_stats';
 
 var redisClient;
 var debug = syncUtils.debug;
+var debugError = syncUtils.debugError;
 
 var Timer = function() {
   this.start = Date.now();
@@ -43,7 +44,7 @@ var timeAsyncFunc = function(metricKey, targetFn) {
   return function() {
     var args = [].slice.call(arguments);
     if (typeof args[args.length - 1] !== 'function') {
-      debug('can not time the target function %s as last argument is not a function', targetFn.name);
+      debugError('can not time the target function %s as last argument is not a function', targetFn.name);
     } else {
       var callback = args.pop();
       var timer = new Timer();
@@ -152,7 +153,7 @@ var getStats = function(cb) {
     var metricName = metric.metricName;
     redisClient.lrange([statsNamespace, metricName].join(':'), 0, MAX_NUMBER, function(err, data) {
       if (err) {
-        debug('Failed to get values from redis for key %s  with error : %j', metricName, err);
+        debugError('Failed to get values from redis for key %s  with error : %j', metricName, err);
         return callback();
       }
       var stats = aggregateData(metric, data);

--- a/lib/sync/sync-metrics.js
+++ b/lib/sync/sync-metrics.js
@@ -28,7 +28,6 @@ var statsNamespace = 'fhsyncstats';
 var metricsTitle = (process.env.FH_TITLE || 'fhsync') + '_stats';
 
 var redisClient;
-var debug = syncUtils.debug;
 var debugError = syncUtils.debugError;
 
 var Timer = function() {

--- a/lib/sync/sync-processor.js
+++ b/lib/sync/sync-processor.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var async = require('async');
 var syncUtil = require('./util');
 var debug=syncUtil.debug;
+var debugError = syncUtil.debugError;
 var metrics = require('./sync-metrics');
 var datasets = require('./datasets');
 
@@ -52,7 +53,7 @@ function recordProcessTime(startTime, success) {
 function markDatasetClientAsCompleted(datasetClientId, startTime, callback) {
   syncStorage.updateDatasetClient(datasetClientId, {syncLoopEnd: Date.now(), syncCompleted: true, syncScheduled: null}, function(err){
     if (err) {
-      debug("Error when update dataset client with id %s. error = %j",datasetClientId,err);
+      debugError("Error when update dataset client with id %s. error = %j",datasetClientId,err);
     }
     recordProcessTime(startTime, !err);
     return callback();
@@ -77,7 +78,7 @@ function syncWithBackend(payload, tries, callback) {
 
   if (!datasetClientId || !datasetId) {
     recordProcessTime(startTime, false);
-    debug("no datasetId value found in sync request payload %j" ,payload);
+    debugError("no datasetId value found in sync request payload %j" ,payload);
     return callback();
   }
 
@@ -112,7 +113,7 @@ function syncWithBackend(payload, tries, callback) {
     }
   ], function(err){
     if (err) {
-      debug("[%s] Error when sync data with backend. error = %j",datasetId,err);
+      debugError("[%s] Error when sync data with backend. error = %j",datasetId,err);
     }
 
     markDatasetClientAsCompleted(datasetClientId, startTime, callback);

--- a/lib/sync/sync-processor.js
+++ b/lib/sync/sync-processor.js
@@ -1,7 +1,6 @@
 var _ = require('underscore');
 var async = require('async');
 var syncUtil = require('./util');
-var debug=syncUtil.debug;
 var debugError = syncUtil.debugError;
 var metrics = require('./sync-metrics');
 var datasets = require('./datasets');

--- a/lib/sync/sync-scheduler.js
+++ b/lib/sync/sync-scheduler.js
@@ -4,6 +4,7 @@ var syncUtil = require('./util');
 var DatasetClient = require('./DatasetClient');
 var metrics = require('./sync-metrics');
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 var metricsClient;
 var syncStorage;
 var syncLock;
@@ -76,7 +77,7 @@ SyncScheduler.prototype.checkDatasetsForSyncing = function(cb) {
             // if there's a problem, log it and continue.
             // There's nothing we can or should do as it may be an intermittent problem
             if (err) {
-              debug('Error adding datasetClients to sync queue (%j)', err);
+              debugError('Error adding datasetClients to sync queue (%j)', err);
             }
             return wcb();
           });
@@ -97,7 +98,7 @@ function tryNext(target, lockCode) {
         syncLock.release(target.syncSchedulerLockName, lockCode, function(err) {
           if (err) {
             //if failed, log the error. The lock will be release evetually when `timeBeforeCrashAssumed` is reached.
-            debug('Failed to release lock due to error (%j)', err);
+            debugError('Failed to release lock due to error (%j)', err);
           }
           target.start();
         });
@@ -116,7 +117,7 @@ SyncScheduler.prototype.start = function() {
   //we only want one of the workers can become a scheduler
   syncLock.acquire(self.syncSchedulerLockName, self.timeBeforeCrashAssumed, function(err, lockCode) {
     if (err) {
-      debug('Failed to accquire lock for key %s error = %j', self.syncSchedulerLockName, err);
+      debugError('Failed to accquire lock for key %s error = %j', self.syncSchedulerLockName, err);
       tryNext(self);
     } else if (lockCode) {
       debug('Got lock for %s :: lock = %s', self.syncSchedulerLockName, lockCode);

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -17,6 +17,7 @@ var cacheClientModule = require('./sync-cache');
 var syncUtil = require('./util');
 var datasetClientCleanerModule = require('./datasetClientsCleaner');
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 var Worker = require('./worker');
 var _ = require('underscore');
 var redisClient = null;
@@ -292,7 +293,7 @@ function stopAll(cb) {
     async.apply(syncScheduler.stop.bind(syncScheduler))
   ], function(err) {
     if (err) {
-      debug('Failed to stop sync due to error : %j', err);
+      debugError('Failed to stop sync due to error : %j', err);
       return cb(err);
     }
     setConfig();

--- a/lib/sync/util.js
+++ b/lib/sync/util.js
@@ -41,7 +41,7 @@ var sortedStringify = function(obj) {
       str = JSON.stringify(sortObject(obj));
     }
   } catch (e) {
-    debug('Error stringifying sorted object: %s', e);
+    debugError('Error stringifying sorted object: %s', e);
     throw e;
   }
 

--- a/lib/sync/util.js
+++ b/lib/sync/util.js
@@ -2,6 +2,7 @@ var crypto = require('crypto');
 var assert = require('assert');
 var _ = require('underscore');
 var debug = require('debug')('fh-mbaas-api:sync');
+var debugError = require('debug')('fh-mbaas-api:sync:error');
 
 var generateHash = function(plainText) {
   var hash;
@@ -82,3 +83,4 @@ module.exports.sortedStringify = sortedStringify;
 module.exports.getCuid = getCuid;
 module.exports.convertToObject = convertToObject;
 module.exports.debug = debug;
+module.exports.debugError = debugError;

--- a/lib/sync/util.js
+++ b/lib/sync/util.js
@@ -2,7 +2,13 @@ var crypto = require('crypto');
 var assert = require('assert');
 var _ = require('underscore');
 var debug = require('debug')('fh-mbaas-api:sync');
-var debugError = require('debug')('fh-mbaas-api:sync:error');
+
+/**
+ * Wrap around `console.error`.
+ */
+var debugError = function() {
+  console.error.apply(this, arguments);
+}
 
 var generateHash = function(plainText) {
   var hash;

--- a/lib/sync/worker.js
+++ b/lib/sync/worker.js
@@ -1,5 +1,6 @@
 var syncUtil = require('./util');
 var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 var metrics = require('./sync-metrics');
 var backoff = require('backoff');
 
@@ -74,7 +75,7 @@ QueueWorker.prototype.work = function() {
   self.queue.get(function(err, job) {
     if (err) {
       self.metrics.inc(metrics.KEYS.WORKER_JOB_ERROR_COUNT, {name: self.name});
-      debug('Error occured when try to get the job from the queue. Error = %j', err);
+      debugError('Error occured when try to get the job from the queue. Error = %j', err);
       return next(self);
     }
     if (job) {
@@ -91,13 +92,13 @@ QueueWorker.prototype.work = function() {
           //This will allow the processor to get the job again and decide if the job should be retried (using the `tries` value).
           //If the processor doesn't allow retry, it can call `done` with no error, and that will remove the job.
           //Otherwise the processor can try it again.
-          debug('Error occured processing job. Job = %j Error = %j', job, err);
+          debugError('Error occured processing job. Job = %j Error = %j', job, err);
           return next(self);
         } else {
           self.metrics.inc(metrics.KEYS.WORKER_JOB_SUCCESS_COUNT, {name: self.name});
           self.queue.ack(job.ack, function(err) {
             if (err) {
-              debug('Error occured acking job. Job = %j Error = ', job, err);
+              debugError('Error occured acking job. Job = %j Error = ', job, err);
             }
             return next(self);
           });
@@ -128,7 +129,7 @@ QueueWorker.prototype.collectStats = function() {
     self.statsCollector = setInterval(function(){
       self.queue.size(function(err, size) {
         if (err) {
-          debug('Error occured when try to get queue size. Error = %j', err);
+          debugError('Error occured when try to get queue size. Error = %j', err);
           return;
         }
         self.metrics.gauge(metrics.KEYS.WORKER_QUEUE_SIZE, {name: self.name}, size);


### PR DESCRIPTION
Currently we have one log level for sync. This causes a lot of logs to be
generated when the app is running. This adds an extra `error` level to the
debug logs so only error messages will be output. This should result in logs
in the studio not rotating so often, making issues easier to debug when you
are only concerned with errors.

This reduces the overall amount of logs considerably.
This also adds the same `:error` level for all other debug logs (e.g. stats).

To log all errors in `fh-mbaas-api` you can use `DEBUG=fh-mbaas-api:*:error`