### PR TITLE
Rhmap 15214 - improve performance when delete datasetClients

### DIFF
--- a/integration/sync/test_storage.js
+++ b/integration/sync/test_storage.js
@@ -173,7 +173,6 @@ module.exports = {
             assert.ok(!err);
             assert.equal(datasetClient.props.syncCompleted, true);
             assert.equal(datasetClient.records.length, 2);
-            assert.equal(datasetClient.recordUids.length, 2);
             var record1 = _.findWhere(datasetClient.records, {uid: '1'});
             var record2 = _.findWhere(datasetClient.records, {uid: '2'});
             recordMatch(record1, records[0]);
@@ -188,7 +187,6 @@ module.exports = {
             assert.ok(!err);
             assert.equal(datasetClient.props.syncCompleted, true);
             assert.equal(datasetClient.records.length, 2);
-            assert.equal(datasetClient.recordUids.length, 2);
             var record1 = _.findWhere(datasetClient.records, {uid: '1'});
             var record2 = _.findWhere(datasetClient.records, {uid: '2'});
             recordMatch(record1, records[0]);
@@ -201,7 +199,6 @@ module.exports = {
           storage.readDatasetClientWithRecords(datasetClient1.id, function(err, datasetClient){
             assert.ok(!err);
             assert.equal(datasetClient.records.length, 1);
-            assert.equal(datasetClient.recordUids.length, 1);
             var updateRecord = _.findWhere(datasetClient.records, {uid: '1'});
             recordMatch(updateRecord, updateRecords[0]);
             callback();

--- a/lib/sync/storage/dataset-clients.js
+++ b/lib/sync/storage/dataset-clients.js
@@ -37,7 +37,7 @@ var cacheClient;
 function doListDatasetClients(filter, cb) {
   debug('doListDatasetClients');
   var col = mongoClient.collection(DATASETCLIENTS_COLLECTION);
-  col.find(filter).project({recordUids: 0}).toArray(function(err, datasetClients) {
+  col.find(filter).toArray(function(err, datasetClients) {
     if (err) {
       debug('Failed to list datasetClients due to error %j', err);
     }
@@ -52,12 +52,31 @@ function doListDatasetClients(filter, cb) {
  */
 function doRemoveDatasetClients(datasetClientsToRemove, cb) {
   var removeIds = _.pluck(datasetClientsToRemove, 'id');
-  debug('doRemoveDatasetClients removeIds = %j', removeIds);
-  async.map(removeIds, doRemoveDatasetClientWithRecords, function(err, deleteResult) {
-    if (err) {
-      debug('Failed to delete datasetClients due to error %j', err);
+  var datasetIds = _.uniq(_.pluck(datasetClientsToRemove, 'datasetId'));
+  debug('doRemoveDatasetClients: removed datasetClients = %d, datasets = %d', removeIds.length, datasetIds.length);
+  async.series([
+    function deleteDatasetClientAndRefs(callback) {
+      async.map(removeIds, doRemoveDatasetClientWithRecords, function(err, deleteResult) {
+        if (err) {
+          debug('Failed to delete datasetClients due to error %j', err);
+        }
+        return callback(err, deleteResult);
+      });
+    },
+    function removeUnusedRecords(callback) {
+      async.map(datasetIds, removeRecordsForDataset, function(err, deletedCount) {
+        if (err) {
+          debug('Error occured when delete records for dataset due to error %j', err);
+        }
+        return callback(err, deletedCount);
+      });
     }
-    return cb(err, deleteResult);
+  ], function(err, results){
+    if (err) {
+      return cb(err);
+    } else {
+      return cb(null, results[0]);
+    }
   });
 }
 
@@ -67,35 +86,47 @@ function doRemoveDatasetClients(datasetClientsToRemove, cb) {
  * @param {Function} cb
  */
 function doRemoveDatasetClientWithRecords(datasetClientId, cb) {
-  debug('doRemoveDatasetClientWithRecords datasetClientId = ' + datasetClientId);
+  debug('doRemoveDatasetClientWithRecords datasetClientId = %s',  datasetClientId);
   async.waterfall([
-    async.apply(doReadDatasetClientWithRecords, datasetClientId),
-    function removeRecords(datasetClientWithRecords, callback) {
-      var records = datasetClientWithRecords.records;
-      if (records.length > 0) {
-        records = syncUtil.convertToObject(records);
-        _.each(records, function(record) {
-          record.op = "delete";
-          delete record._id;
-        });
-        upsertOrDeleteDatasetRecords(datasetClientWithRecords.datasetId, datasetClientId, records, function(err) {
-          return callback(err, datasetClientWithRecords);
-        });
-      } else {
-        return callback(null, datasetClientWithRecords);
-      }
-    },
-    function deleteDatasetClient(datasetClientWithRecords, callback) {
-      var col = mongoClient.collection(DATASETCLIENTS_COLLECTION);
-      col.findOneAndDelete({'id': datasetClientId}, function(err, deleted) {
-        return callback(err, deleted);
+    async.apply(doReadDatasetClient, datasetClientId),
+    function removeRefs(datasetClientJson, next) {
+      var datasetId = datasetClientJson.datasetId;
+      var recordsCollection = mongoClient.collection(getDatasetRecordsCollectionName(datasetId));
+      recordsCollection.updateMany({'refs': datasetClientId}, {'$pull': {'refs': datasetClientId}}, function(err) {
+        return next(err, datasetClientJson);
       });
+    },
+    function deleteDatasetClient(datasetClientJson, next) {
+      var col = mongoClient.collection(DATASETCLIENTS_COLLECTION);
+      col.findOneAndDelete({'id': datasetClientId}, next);
     }
   ], function(err, result) {
     if (err) {
       debug('Failed to doRemoveDatasetClientWithRecords due to error %j', err);
+      return cb(err);
+    } else {
+      return cb(null, result && result.value);
     }
-    return cb(err, result.value);
+  });
+}
+
+/**
+ * 
+ * Remove unused records from the records collection for the given datasetId 
+ * @param {String} datasetId the datasetId 
+ * @param {Function} cb 
+ */
+function removeRecordsForDataset(datasetId, cb) {
+  debug('remove unused records from dataset %s', datasetId);
+  var recordsCollection = mongoClient.collection(getDatasetRecordsCollectionName(datasetId));
+  recordsCollection.deleteMany({'refs': {'$size': 0}}, function(err, result) {
+    if (err) {
+      debug('Failed to remove records from dataset %s due to error %j', datasetId, err);
+      return cb(err);
+    } else {
+      debug('Deleted %d unused records from dataset %s', result.deletedCount, datasetId);
+      return cb(null, result);
+    }
   });
 }
 
@@ -126,14 +157,8 @@ function upsertOrDeleteDatasetRecords(datasetId, datasetClientId, records, cb) {
     datasetRecordsCol.findOneAndUpdate({uid: record.uid}, update, {upsert: true, returnOriginal: false}, function(err, updated) {
       if (err) {
         return callback(err);
-      }
-      if (updated.value && (!updated.value.refs || (updated.value.refs && updated.value.refs.length === 0))) {
-        //no more references of the record, delete it
-        datasetRecordsCol.findOneAndDelete({uid: updated.value.uid}, function(err) {
-          return callback(err);
-        });
       } else {
-        datasetRecordsCol.findOne({uid: record.uid}, callback);
+        return callback(null, updated.value);
       }
     });
   }, function(err, updates) {
@@ -149,29 +174,26 @@ function upsertOrDeleteDatasetRecords(datasetId, datasetClientId, records, cb) {
 
 /**
  * List the local records for the given datasetClient from the `fhsync-<datasetId>-records` collection
- * @param {storage~DatasetClient} datasetClientJson the json object of the datasetClient. It should have the `datasetId` and `recordUids`
+ * @param {storage~DatasetClient} datasetClientJson the json object of the datasetClient. It should have the `datasetId` field
  * @param {Object} projection can be used to specify what fields should be returned for the records. Each record will have `uid`, 'hash' and `data` fields.
  * @param {Function} cb
  */
 function listDatasetClientRecords(datasetClientJson, projection, cb) {
   debug('listDatasetClientRecords datasetClientJson = %j', datasetClientJson);
   var datasetId = datasetClientJson.datasetId;
-  var recordUids = datasetClientJson.recordUids || [];
-  if (recordUids.length > 0) {
-    var datasetRecordsCol = mongoClient.collection(getDatasetRecordsCollectionName(datasetId));
-    var cursor = datasetRecordsCol.find({}).filter({'uid': {'$in': recordUids}});
-    if (projection) {
-      cursor = cursor.project(projection);
-    }
-    return cursor.toArray(function(err, records) {
-      if (err) {
-        debug('[%s] Failed to list datasetClient records due to error %j :: datasetClientJson = %j', err, datasetClientJson);
-      }
-      return cb(err, records);
-    });
+  var datasetRecordsCol = mongoClient.collection(getDatasetRecordsCollectionName(datasetId));
+  var cursor = datasetRecordsCol.find({'refs': datasetClientJson.id});
+  if (projection) {
+    cursor = cursor.project(projection);
   } else {
-    return cb(null, []);
+    cursor = cursor.project({'refs': 0});
   }
+  return cursor.toArray(function(err, records) {
+    if (err) {
+      debug('[%s] Failed to list datasetClient records due to error %j :: datasetClientJson = %j', err, datasetClientJson);
+    }
+    return cb(err, records);
+  });
 }
 
 /**
@@ -321,6 +343,7 @@ function createIndexForCollection(collectionName, indexField, indexOpts) {
  */
 function ensureIndexesForDataset(datasetId) {
   createIndexForCollection(getDatasetRecordsCollectionName(datasetId), {'uid': 1}, {});
+  createIndexForCollection(getDatasetRecordsCollectionName(datasetId), {'refs': 1}, {});
   createIndexForCollection(require('./sync-updates').getDatasetUpdatesCollectionName(datasetId), {'cuid': 1, 'hash': 1}, {});
 }
 
@@ -362,9 +385,13 @@ function diffRecords(localRecords, newRecords) {
 function doUpdateDatasetClientWithRecords(datasetClientId, fields, records, callback) {
   debug('doUpdateDatasetClientWithRecords datasetClientId = %s :: records.length = %d', datasetClientId, records.length);
   async.waterfall([
-    async.apply(doUpdateDatasetClient, datasetClientId, fields, false),
+    async.apply(doReadDatasetClient, datasetClientId),
+    function createIndex(datasetClientJson, next) {
+      ensureIndexesForDataset(datasetClientJson.datasetId);
+      return next(null, datasetClientJson);
+    },
     function listRecords(datasetClientJson, next) {
-      //we don't need to data field here as it will not be used
+      //we don't need the data field here as it will not be used
       listDatasetClientRecords(datasetClientJson, {uid: 1, hash: 1}, function(err, localRecords) {
         return next(err, datasetClientJson, localRecords);
       });
@@ -382,8 +409,6 @@ function doUpdateDatasetClientWithRecords(datasetClientId, fields, records, call
     },
     //make sure we only update the dataset client at the end of the operation. Will should cause the globalHash value to be changed for the datasetClient, which should trigger clients to sync again.
     function updateDatasetClient(datasetClientJson, next) {
-      var recordUids = _.pluck(records, 'uid');
-      fields.recordUids = recordUids;
       doUpdateDatasetClient(datasetClientId, fields, false, next);
     },
     function invalidateCache(updatedDatasetClient, next) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "dependencies": {
     "async": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=7.0.2
+sonar.projectVersion=7.0.4
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
## Why

At the moment, when datasetClients are being deleted, we need to read all the datasetClient records that need to be deleted into memory, loop through them, and loop through each item in the `recordUids` array, find the corresponding record and update/remove each of them.

However, each datasetClient could have many `recordUids`. If all of the datasetClients are loaded into memory and processed at the same time, it could cause memory issue for the app. We can also process each datasetClient one by one, but the whole process will be too slow.

After a bit of investigation, I realise we actually don't need the `recordUids` fields on the datasetClients collection at all. This is because each record is keep tracking what datasetClients are referencing it via the `refs` field. In Mongodb, we can add an index on an array field and we will be able to find out what records belong to a datasetClient quite easily via a single Mongodb query. We can also perform batch updates and removes quite easily on the records collection.

## What

* Remove the `recordsUid` field from datasetClient collection
* Change the implementation for `removeDatasetClient`. Now it becomes:
** find and update all the records belong to the datasetClient to remove the reference in a single Mongodb query
** remove the datasetClient record
** remove all the unused records in a single query

ping @david-martin @aidenkeating for review



