### PR TITLE
Prefix all metrics with a metricsKey

### DIFF
--- a/lib/sync/sync-metrics.js
+++ b/lib/sync/sync-metrics.js
@@ -49,7 +49,8 @@ var timeAsyncFunc = function(metricKey, targetFn) {
       var timer = new Timer();
       args.push(function() {
         var timing = timer.stop();
-        metricsClient.gauge(metricKey, {success: !arguments[0], fn: targetFn.name}, timing);
+        var prefixedMetricKey = [metricsTitle, '_', metricKey].join('');
+        metricsClient.gauge(prefixedMetricKey, {success: !arguments[0], fn: targetFn.name}, timing);
         return callback.apply(null, arguments);
       });
     }


### PR DESCRIPTION
Currently any timing metric made by sync is not namespaced, meaning
that if two apps are running in the same environment the metrics
coming from them will not be able to be distinguished.

This change prefixes the timing metrics with the same prefix as the CPU
and memory metrics.