### PR TITLE
Fh 3561 map uids

### DIFF
--- a/integration/sync/test_storage.js
+++ b/integration/sync/test_storage.js
@@ -265,6 +265,25 @@ module.exports = {
         assert.ok(!err);
         done();
       });
+    },
+    'test operations on record mapping': function(done) {
+      var clientUid = "testClientUid";
+      var serverUid = "testServerUid";
+      async.series([
+        function saveMapping(callback) {
+          storage.saveRecordUidMapping(DATASETID, clientUid, serverUid, function(err){
+            assert.ok(!err);
+            return callback();
+          });
+        },
+        function lookupUid(callback) {
+          storage.lookupRecordUidByClientUid(DATASETID, clientUid, function(err, foundUid){
+            assert.ok(!err);
+            assert.equal(foundUid, serverUid);
+            callback();
+          });
+        }
+      ], done);
     }
   }
 };

--- a/integration/sync/test_uid_change.js
+++ b/integration/sync/test_uid_change.js
@@ -82,7 +82,7 @@ module.exports = {
           });
         },
         function wait(callback) {
-          setTimeout(callback, 80);
+          setTimeout(callback, 1000);
         },
         function checkDataUpdated(callback) {
           collection.findOne({'user': '1'}, function(err, found){

--- a/integration/sync/test_uid_change.js
+++ b/integration/sync/test_uid_change.js
@@ -1,0 +1,154 @@
+var sync = require('../../lib/sync');
+var assert = require('assert');
+var async = require('async');
+var helper = require('./helper');
+var util = require('util');
+
+var mongoDBUrl = 'mongodb://127.0.0.1:27017/test_sync_uid_change';
+var redisUrl = 'redis://127.0.0.1:6379';
+var DATASETID = 'syncUidChangeTest';
+var TESTCUID = 'syncUidChangeTestCuid';
+
+var mongodb;
+
+module.exports = {
+  'test sync data uid change': {
+    'before': function(done) {
+       sync.api.setConfig({
+        pendingWorkerInterval: 10, 
+        pendingWorkerBackoff: {strategy: 'none'},
+        ackWorkerInterval: 100, 
+        schedulerInterval: 100
+      });
+
+      async.series([
+        async.apply(sync.api.connect, mongoDBUrl, null, redisUrl),
+        async.apply(sync.api.init, DATASETID, {syncFrequency: 1}),
+        function resetdb(callback) {
+          helper.resetDb(mongoDBUrl, DATASETID, function(err, db){
+            if (err) {
+              return callback(err);
+            }
+            mongodb = db;
+            return callback();
+          });
+        }
+      ], done);
+    },
+
+    'after': function(done) {
+      sync.api.stopAll(done);
+    },
+
+    'data uid change': function(done) {
+      var clientUid = 'a1';
+      var params = {
+        fn: 'sync',
+        query_params: {user: '1'},
+        meta_data: {token: 'testtoken'},
+        __fh: {
+          cuid: TESTCUID
+        },
+        pending: [{
+          action: 'create',
+          uid: clientUid,
+          hash: 'a1',
+          post: {
+            'user': '1',
+            'a': '1'
+          }
+        }, {
+          action: 'update',
+          uid: clientUid,
+          hash: 'a2',
+          pre: {
+            'user': '1',
+            'a': '1'
+          },
+          post: {
+            'user': '1',
+            'a': '2'
+          }
+        }]
+      };
+      var serverUid;
+      var collection = mongodb.collection(DATASETID);
+      async.series([
+        function invokeSync(callback) {
+          sync.api.invoke(DATASETID, params, function(err, response){
+            assert.ok(!err, util.inspect(err));
+            assert.ok(response);
+            callback();
+          });
+        },
+        function wait(callback) {
+          setTimeout(callback, 100);
+        },
+        function checkDataUpdated(callback) {
+          collection.findOne({'user': '1'}, function(err, found){
+            assert.ok(!err);
+            assert.equal(found.a, '2');
+            serverUid = found._id.toString();
+            callback();
+          });
+        },
+        function newUpdateWithNewUid(callback) {
+          params.pending = [{
+            action: 'update',
+            uid: serverUid,
+            hash: 'a3',
+            pre: {
+              'user': '1',
+              'a': '2'
+            },
+            post : {
+              'user': '1',
+              'a': '3'
+            }
+          }];
+          sync.api.invoke(DATASETID, params, function(err, response){
+            assert.ok(!err);
+            assert.ok(response);
+            callback();
+          });
+        },
+        function waitAgain(callback) {
+          setTimeout(callback, 20);
+        },
+        function checkDataUpdatedAgain(callback) {
+          collection.findOne({'user': '1'}, function(err, found){
+            assert.ok(!err);
+            assert.equal(found.a, '3');
+            callback();
+          });
+        },
+        function deleteWithOldUid(callback) {
+          params.pending = [{
+            action: 'delete',
+            uid: clientUid,
+            hash: 'a4',
+            pre: {
+              'user': '1',
+              'a': '3'
+            }
+          }];
+          sync.api.invoke(DATASETID, params, function(err, response){
+            assert.ok(!err);
+            assert.ok(response);
+            callback();
+          });
+        },
+        function waitForDelete(callback) {
+          setTimeout(callback, 20);
+        },
+        function checkDataDeleted(callback) {
+          collection.findOne({'user': '1'}, function(err, found){
+            assert.ok(!err);
+            assert.ok(!found);
+            callback();
+          });
+        },
+      ], done);
+    }
+  }
+};

--- a/integration/sync/test_uid_change.js
+++ b/integration/sync/test_uid_change.js
@@ -82,7 +82,7 @@ module.exports = {
           });
         },
         function wait(callback) {
-          setTimeout(callback, 200);
+          setTimeout(callback, 80);
         },
         function checkDataUpdated(callback) {
           collection.findOne({'user': '1'}, function(err, found){
@@ -113,7 +113,7 @@ module.exports = {
           });
         },
         function waitAgain(callback) {
-          setTimeout(callback, 50);
+          setTimeout(callback, 20);
         },
         function checkDataUpdatedAgain(callback) {
           collection.findOne({'user': '1'}, function(err, found){
@@ -139,7 +139,7 @@ module.exports = {
           });
         },
         function waitForDelete(callback) {
-          setTimeout(callback, 50);
+          setTimeout(callback, 20);
         },
         function checkDataDeleted(callback) {
           collection.findOne({'user': '1'}, function(err, found){

--- a/integration/sync/test_uid_change.js
+++ b/integration/sync/test_uid_change.js
@@ -82,7 +82,7 @@ module.exports = {
           });
         },
         function wait(callback) {
-          setTimeout(callback, 100);
+          setTimeout(callback, 200);
         },
         function checkDataUpdated(callback) {
           collection.findOne({'user': '1'}, function(err, found){
@@ -113,7 +113,7 @@ module.exports = {
           });
         },
         function waitAgain(callback) {
-          setTimeout(callback, 20);
+          setTimeout(callback, 50);
         },
         function checkDataUpdatedAgain(callback) {
           collection.findOne({'user': '1'}, function(err, found){
@@ -139,7 +139,7 @@ module.exports = {
           });
         },
         function waitForDelete(callback) {
-          setTimeout(callback, 20);
+          setTimeout(callback, 50);
         },
         function checkDataDeleted(callback) {
           collection.findOne({'user': '1'}, function(err, found){

--- a/lib/sync/pending-processor.js
+++ b/lib/sync/pending-processor.js
@@ -65,6 +65,7 @@ function doCreate(datasetId, pendingChange, callback) {
   var record = pendingChange.post;
   var metaData = pendingChange.meta_data;
   debug('[%s] CREATE Start data = %j', datasetId, record);
+  var tasks = [];
   dataHandlers.doCreate(datasetId, record, metaData, function(err, data) {
     if (err) {
       debugError('[%s] CREATE Failed - : err = %j', datasetId, err);
@@ -73,10 +74,16 @@ function doCreate(datasetId, pendingChange, callback) {
       pendingChange.oldUid = pendingChange.uid;
       pendingChange.uid = data.uid;
       if (pendingChange.oldUid !== data.uid) {
-        syncStorage.saveRecordUidMapping(datasetId, pendingChange.oldUid, data.uid, function(){});
+        tasks.push(function(cb){
+          syncStorage.saveRecordUidMapping(datasetId, pendingChange.oldUid, data.uid, cb);
+        });
       }
     }
-    return saveUpdate(datasetId, pendingChange, err ? SYNC_UPDATE_TYPES.FAILED : SYNC_UPDATE_TYPES.APPLIED, err ? util.inspect(err) : null, callback);
+    tasks.push(function(cb){
+      saveUpdate(datasetId, pendingChange, err ? SYNC_UPDATE_TYPES.FAILED : SYNC_UPDATE_TYPES.APPLIED, err ? util.inspect(err) : null, cb);
+    });
+
+    return async.series(tasks, callback);
   });
 }
 
@@ -205,7 +212,7 @@ function doDelete(datasetId, pendingChange, callback) {
 function replaceUidIfRequired(datasetId, pendingChange, callback) {
   syncStorage.lookupRecordUidByClientUid(datasetId, pendingChange.uid, function(err, serverUid){
     if (err) {
-      debug('[%s] Failed to look up recordUid due to error %j', datasetId, err);
+      debugError('[%s] Failed to look up recordUid due to error %j', datasetId, err);
     }
     if (serverUid) {
       debug('[%s] replacing pendingChange uid from %s to %s', pendingChange.uid, serverUid);

--- a/lib/sync/pending-processor.js
+++ b/lib/sync/pending-processor.js
@@ -3,6 +3,7 @@ var debug = syncUtil.debug;
 var debugError = syncUtil.debugError;
 var metrics = require('./sync-metrics');
 var util = require('util');
+var async = require('async');
 
 var syncStorage, dataHandlers, hashProvider, metricsClient;
 
@@ -71,6 +72,9 @@ function doCreate(datasetId, pendingChange, callback) {
       debug('[%s] CREATE Success - uid = %s', datasetId, data.uid);
       pendingChange.oldUid = pendingChange.uid;
       pendingChange.uid = data.uid;
+      if (pendingChange.oldUid !== data.uid) {
+        syncStorage.saveRecordUidMapping(datasetId, pendingChange.oldUid, data.uid, function(){});
+      }
     }
     return saveUpdate(datasetId, pendingChange, err ? SYNC_UPDATE_TYPES.FAILED : SYNC_UPDATE_TYPES.APPLIED, err ? util.inspect(err) : null, callback);
   });
@@ -198,6 +202,20 @@ function doDelete(datasetId, pendingChange, callback) {
   });
 }
 
+function replaceUidIfRequired(datasetId, pendingChange, callback) {
+  syncStorage.lookupRecordUidByClientUid(datasetId, pendingChange.uid, function(err, serverUid){
+    if (err) {
+      debug('[%s] Failed to look up recordUid due to error %j', datasetId, err);
+    }
+    if (serverUid) {
+      debug('[%s] replacing pendingChange uid from %s to %s', pendingChange.uid, serverUid);
+      pendingChange.uid = serverUid;
+    }
+    //even if there is an error, we can still try to apply the change.
+    return callback();
+  });
+}
+
 /**
  * apply the given pending change to the backend using the dataHandlers
  * @param {Object} pendingChange the pending change object
@@ -226,7 +244,6 @@ function applyPendingChange(pendingChange, tries, callback) {
     return saveUpdate(datasetId, pendingChange, SYNC_UPDATE_TYPES.FAILED, "crashed", callback);
   }
   var action = pendingChange.action.toLowerCase();
-
   var timer = metrics.startTimer();
 
   function onComplete(err) {
@@ -239,10 +256,24 @@ function applyPendingChange(pendingChange, tries, callback) {
       doCreate(datasetId, pendingChange, onComplete);
       break;
     case "update":
-      doUpdate(datasetId, pendingChange, onComplete);
+      async.series([
+        function(cb) {
+          replaceUidIfRequired(datasetId, pendingChange, cb);
+        },
+        function(cb) {
+          doUpdate(datasetId, pendingChange, cb);
+        }
+      ], onComplete);
       break;
     case "delete":
-      doDelete(datasetId, pendingChange, onComplete);
+      async.series([
+        function(cb) {
+          replaceUidIfRequired(datasetId, pendingChange, cb);
+        },
+        function(cb) {
+          doDelete(datasetId, pendingChange, cb);
+        }
+      ], onComplete);
       break;
     default:
       debugError("[%s] invalid pendingChange request dropped :: item = %j", datasetId, pendingChange);

--- a/lib/sync/storage/dataset-clients.js
+++ b/lib/sync/storage/dataset-clients.js
@@ -465,7 +465,7 @@ function doSaveRecordUidMapping(datasetId, clientUid, serverUid, callback) {
   var recordCollection = mongoClient.collection(getDatasetRecordsCollectionName(datasetId));
   recordCollection.updateOne({uid: serverUid}, {'$set': {uid: serverUid, clientUid: clientUid}}, {upsert: true}, function(err){
     if (err) {
-      debug('Failed to doSaveRecordUidMapping due to error %j', err);
+      debugError('Failed to doSaveRecordUidMapping due to error %j', err);
     }
     return callback(err);
   });
@@ -482,7 +482,7 @@ function doLookupRecordUidByClientUid(datasetId, clientUid, callback) {
   var recordCollection = mongoClient.collection(getDatasetRecordsCollectionName(datasetId));
   recordCollection.findOne({clientUid: clientUid}, function(err, found){
     if (err) {
-      debug('Failed to doLookupRecordUidByClientUid due to error %j', err);
+      debugError('Failed to doLookupRecordUidByClientUid due to error %j', err);
       return callback(err);
     } else {
       return callback(null, found ? found.uid : null);

--- a/lib/sync/storage/dataset-clients.js
+++ b/lib/sync/storage/dataset-clients.js
@@ -91,6 +91,9 @@ function doRemoveDatasetClientWithRecords(datasetClientId, cb) {
   async.waterfall([
     async.apply(doReadDatasetClient, datasetClientId),
     function removeRefs(datasetClientJson, next) {
+      if (!datasetClientJson) {
+        return next(new Error('invalid datasetClient id ' + datasetClientId));
+      }
       var datasetId = datasetClientJson.datasetId;
       var recordsCollection = mongoClient.collection(getDatasetRecordsCollectionName(datasetId));
       recordsCollection.updateMany({'refs': datasetClientId}, {'$pull': {'refs': datasetClientId}}, function(err) {
@@ -345,6 +348,7 @@ function createIndexForCollection(collectionName, indexField, indexOpts) {
 function ensureIndexesForDataset(datasetId) {
   createIndexForCollection(getDatasetRecordsCollectionName(datasetId), {'uid': 1}, {});
   createIndexForCollection(getDatasetRecordsCollectionName(datasetId), {'refs': 1}, {});
+  createIndexForCollection(getDatasetRecordsCollectionName(datasetId), {'clientUid': 1}, {});
   createIndexForCollection(require('./sync-updates').getDatasetUpdatesCollectionName(datasetId), {'cuid': 1, 'hash': 1}, {});
 }
 
@@ -388,6 +392,9 @@ function doUpdateDatasetClientWithRecords(datasetClientId, fields, records, call
   async.waterfall([
     async.apply(doReadDatasetClient, datasetClientId),
     function createIndex(datasetClientJson, next) {
+      if (!datasetClientJson) {
+        return next(new Error('invalid datasetClient id ' + datasetClientId));
+      }
       ensureIndexesForDataset(datasetClientJson.datasetId);
       return next(null, datasetClientJson);
     },
@@ -434,6 +441,52 @@ function doUpdateManyDatasetClients(query, fields, callback) {
       return callback(err);
     }
     return callback(null, result);
+  });
+}
+
+/**
+ * 
+ * Save the record uid mappng in the database 
+ * @param {String} datasetId the datasetId 
+ * @param {String} clientUid the client uid
+ * @param {String} serverUid the server uid
+ * @param {Function} callback
+ */
+function doSaveRecordUidMapping(datasetId, clientUid, serverUid, callback) {
+  debug('doSaveRecordUidMapping datasetId = %s, clientUid = %s, serverUid= %s', datasetId, clientUid, serverUid);
+  if (!clientUid || !serverUid) {
+    debug('invalid clientUid or serverUid. Nothing to save');
+    return callback();
+  }
+  if (serverUid === clientUid) {
+    debug('serverUid and clientUid are the same. Nothing to save');
+    return callback();
+  }
+  var recordCollection = mongoClient.collection(getDatasetRecordsCollectionName(datasetId));
+  recordCollection.updateOne({uid: serverUid}, {'$set': {uid: serverUid, clientUid: clientUid}}, {upsert: true}, function(err){
+    if (err) {
+      debug('Failed to doSaveRecordUidMapping due to error %j', err);
+    }
+    return callback(err);
+  });
+}
+
+/**
+ * Look up the serverUid of the record based on its clientUid
+ * @param {String} datasetId dataId
+ * @param {String} clientUid clientUid of the record
+ * @param {Function} callback 
+ */
+function doLookupRecordUidByClientUid(datasetId, clientUid, callback) {
+  debug('doLookupRecordUidByClientUid datasetId = %s, clientUid = %s', datasetId, clientUid);
+  var recordCollection = mongoClient.collection(getDatasetRecordsCollectionName(datasetId));
+  recordCollection.findOne({clientUid: clientUid}, function(err, found){
+    if (err) {
+      debug('Failed to doLookupRecordUidByClientUid due to error %j', err);
+      return callback(err);
+    } else {
+      return callback(null, found ? found.uid : null);
+    }
   });
 }
 
@@ -512,6 +565,14 @@ module.exports = function(mongoClientImpl, cacheClientImpl) {
      */
     readDatasetClientWithRecords: function(datasetClientId, callback) {
       return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doReadDatasetClientWithRecordsUseCache)(datasetClientId, callback);
+    },
+
+    saveRecordUidMapping: function(datasetId, clientUid, serverUid, callback) {
+      return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doSaveRecordUidMapping)(datasetId, clientUid, serverUid, callback);
+    },
+
+    lookupRecordUidByClientUid: function(datasetId, clientUid, callback) {
+      return metrics.timeAsyncFunc(metrics.KEYS.MONGODB_OPERATION_TIME, doLookupRecordUidByClientUid)(datasetId, clientUid, callback);
     }
   };
 };


### PR DESCRIPTION
## Why

At the moment, if a record is being created on the client, and then updated, there is a chance that the update will not be applied because the update didn't get the server uid back to the client.

## What

The sync server will now save the record's client uid and server uid and replace the clientUid automatically if it's being used in the request.

ping @david-martin @aidenkeating @nialldonnellyfh  to review