### PR TITLE
Add error event listener for Redis client

### DIFF
--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -40,6 +40,8 @@ function connect(mongoDBConnectionUrl, mongoDBConnectionOption, redisUrl, cb) {
           url: redisUrl
         };
         var client = redis.createClient(redisOpts);
+        // We don't want the app to crash if Redis is not available.
+        client.on('error', handleRedisError);
         return callback(null, client);
       } else {
         return callback();
@@ -55,6 +57,16 @@ function connect(mongoDBConnectionUrl, mongoDBConnectionOption, redisUrl, cb) {
     eventEmitter.emit('sync:ready');
     return cb(null, mongoDbClient, redisClient);
   });
+}
+
+/**
+ * Handle any errors emitted by the Redis client. Without a listener
+ * for the error event the process will exit when an event is emitted
+ *
+ * @param {Error} err An error produced by the Redis client
+ */
+function handleRedisError(err) {
+  console.warn('Error in Redis %s', err);
 }
 
 function getEventEmitter() {
@@ -79,7 +91,7 @@ function invoke(dataset_id, params, callback) {
   // Verify that fn param has been passed
   if (!params || !params.fn) {
     var err = 'no fn parameter provided in params "' + util.inspect(params) + '"';
-    debugError('[%s] warn %s $j', dataset_id, err, params);
+    debugError('[%s] warn %s %j', dataset_id, err, params);
     return callback(err, null);
   }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "dependencies": {
     "async": {
       "version": "2.1.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -54,9 +54,9 @@
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
     },
     "fh-component-metrics": {
-      "version": "2.6.0",
-      "from": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.6.0.tgz",
-      "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.6.0.tgz",
+      "version": "2.6.1",
+      "from": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.6.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cycle": "1.0.3",
     "debug": "2.6.3",
     "eyes": "0.1.8",
-    "fh-component-metrics": "2.6.0",
+    "fh-component-metrics": "~2.6.1",
     "fh-db": "2.0.0",
     "fh-mbaas-client": "0.15.0",
     "fh-mbaas-express": "5.7.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=7.0.5
+sonar.projectVersion=7.0.6
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
Currently, when Redis goes down or is not available the Redis client will
emit an `error` event. In node, if an 'error' event does not have a
listener node will throw an Error and stop the process.

This change adds a listener that will produce a `console.warn` log, this
will prevent the app from crashing when the Redis client is down.