### PR TITLE
Fh 3588 db pruning optimise

### DIFF
--- a/integration/sync/test_datasetClientCleaner.js
+++ b/integration/sync/test_datasetClientCleaner.js
@@ -47,7 +47,7 @@ module.exports = {
         mongodb = db;
         storage = storageModule(mongodb, null);
         lock = lockModule(mongodb);
-        cleaner = datasetClientCleanerModule(storage, lock)({retentionPeriod: '50ms'});
+        cleaner = datasetClientCleanerModule(storage, lock)({retentionPeriod: '50ms', cleanerLockName: 'test_datasetCleaner_lock'});
         done();
       });
     },

--- a/integration/sync/test_datasetClientCleaner.js
+++ b/integration/sync/test_datasetClientCleaner.js
@@ -1,4 +1,5 @@
 var storageModule = require('../../lib/sync/storage');
+var lockModule = require('../../lib/sync/lock');
 var async = require('async');
 var assert = require('assert');
 var _ = require('underscore');
@@ -32,6 +33,7 @@ activeDCJson.active = true;
 
 var mongodb;
 var storage;
+var lock;
 
 var cleaner;
 
@@ -44,7 +46,8 @@ module.exports = {
         }
         mongodb = db;
         storage = storageModule(mongodb, null);
-        cleaner = datasetClientCleanerModule(storage)({retentionPeriod: '50ms'});
+        lock = lockModule(mongodb);
+        cleaner = datasetClientCleanerModule(storage, lock)({retentionPeriod: '50ms'});
         done();
       });
     },

--- a/integration/sync/test_mongodbQueue.js
+++ b/integration/sync/test_mongodbQueue.js
@@ -3,12 +3,15 @@ var metrics = require('../../lib/sync/sync-metrics').init({}, null);
 var async = require('async');
 var assert = require('assert');
 var helper = require('./helper');
+var lockModule = require('../../lib/sync/lock');
 
 var queueName = 'test_mongodb_queue';
 var mongoDBUrl = 'mongodb://127.0.0.1:27017/' + queueName;
 
 var mongodb;
 var queue;
+var lock;
+
 module.exports = {
   'test mongodb queue': {
     'before': function(done) {
@@ -17,6 +20,7 @@ module.exports = {
           return done(err);
         }
         mongodb = db;
+        lock = lockModule(mongodb);
         return done();
       });
     },
@@ -26,7 +30,7 @@ module.exports = {
     },
 
     'test mongo queue add, get, search and prune': function(done) {
-      queue = new MongodbQueue(queueName, metrics, {mongodb: mongodb, messagesToKeep: {time: '1s'}, visibility: 1});
+      queue = new MongodbQueue(queueName, metrics, lock, {mongodb: mongodb, messagesToKeep: {time: '1s'}, visibility: 1});
       var messageToAck;
       async.series([
         async.apply(queue.create.bind(queue)),

--- a/integration/sync/test_mongodbQueue.js
+++ b/integration/sync/test_mongodbQueue.js
@@ -22,9 +22,6 @@ module.exports = {
     },
 
     'after': function(done) {
-      if (queue) {
-        queue.stopPruneJob();
-      }
       done();
     },
 
@@ -61,19 +58,6 @@ module.exports = {
           collection.count({}, function(err, size){
             assert.ok(!err);
             assert.equal(2, size);
-            callback();
-          });
-        },
-        function waitForMessagesInvisible(callback) {
-          setTimeout(callback, 2000);
-        },
-        async.apply(queue.prune.bind(queue)),
-        function verifyMessagesDeleted(callback) {
-          var collection = mongodb.collection(queueName);
-          collection.count({}, function(err, size){
-            assert.ok(!err);
-            //only 1 message is acked, so it should be deleted
-            assert.equal(1, size);
             callback();
           });
         }

--- a/lib/sync/api-syncRecords.js
+++ b/lib/sync/api-syncRecords.js
@@ -20,7 +20,7 @@ function listLocalDatasetClientData(datasetClient, cb) {
       return cb(err);
     }
     //no one sync loop has completed yet, return null
-    if (!datasetClientsWithRecords.syncCompleted) {
+    if (!datasetClientsWithRecords || !datasetClientsWithRecords.syncCompleted) {
       return cb(null, null);
     } else {
       return cb(null, datasetClientsWithRecords);

--- a/lib/sync/datasetClientsCleaner.js
+++ b/lib/sync/datasetClientsCleaner.js
@@ -6,6 +6,7 @@ var syncUtil = require('./util');
 var debug = syncUtil.debug;
 var debugError = syncUtil.debugError;
 
+var syncLock;
 var storage;
 
 /**
@@ -22,26 +23,42 @@ var storage;
 function DatasetClientsCleaner(opts) {
   this.retentionPeriod = opts.retentionPeriod || '24h';
   this.checkFrequency = opts.checkFrequency || '1h';
+  this.cleanerLockName = opts.cleanerLockName || 'locks:sync:DatasetCleaner';
+  this.lockTimeout = parseDuration(this.checkFrequency) / 2;
   this.job;
 }
 
-function cleanDatasetClients(retentionPeriod) {
-  var parsedTime = parseDuration(retentionPeriod);
-  async.waterfall([
-    async.apply(storage.listDatasetClients, {active: false}),
-    function filterDatasetClients(datasetClients, callback) {
-      var datasetClientsToRemove = _.filter(datasetClients, function(datasetClientJson) {
-        var datasetClient = DatasetClient.fromJSON(datasetClientJson);
-        return datasetClient.shouldBeRemoved(parsedTime);
-      });
-      return callback(null, datasetClientsToRemove);
-    },
-    async.apply(storage.removeDatasetClients)
-  ], function(err, deletedDatasetClients) {
+function cleanDatasetClients(retentionPeriod, lockName, lockTimeout) {
+  syncLock.acquire(lockName, lockTimeout, function(err, lockCode){
     if (err) {
-      debugError('Failed to cleanup dataset clients due to error %j', err);
+      debugError('Failed to acquire lock for key = %s : error = %s', lockName, err);
+    } else if(lockCode) {
+      debug('lock acquired for datasetClientCleaner code = %s. Start cleaning', lockCode);
+      var parsedTime = parseDuration(retentionPeriod);
+      async.waterfall([
+        async.apply(storage.listDatasetClients, {active: false}),
+        function filterDatasetClients(datasetClients, callback) {
+          var datasetClientsToRemove = _.filter(datasetClients, function(datasetClientJson) {
+            var datasetClient = DatasetClient.fromJSON(datasetClientJson);
+            return datasetClient.shouldBeRemoved(parsedTime);
+          });
+          return callback(null, datasetClientsToRemove);
+        },
+        async.apply(storage.removeDatasetClients)
+      ], function(err, deletedDatasetClients) {
+        syncLock.release(lockName, lockCode, function(unlockErr){
+          if (unlockErr) {
+            debugError('Failed to release lock due to error %s', unlockErr);
+          }
+        });
+        if (err) {
+          debugError('Failed to cleanup dataset clients due to error %j', err);
+        } else {
+          debug('Removed %d dataset clients',_.size(deletedDatasetClients));
+        }
+      });
     } else {
-      debug('Removed %d dataset clients',_.size(deletedDatasetClients));
+      debug('no lock acquired. Wait for the next one');
     }
   });
 }
@@ -52,11 +69,11 @@ function cleanDatasetClients(retentionPeriod) {
 DatasetClientsCleaner.prototype.start = function(immediately, cb) {
   var self = this;
   if (immediately) {
-    cleanDatasetClients(self.retentionPeriod);
+    cleanDatasetClients(self.retentionPeriod, self.cleanerLockName, self.lockTimeout);
   }
   if (!this.job) {
     this.job = setInterval(function() {
-      cleanDatasetClients(self.retentionPeriod);
+      cleanDatasetClients(self.retentionPeriod, self.cleanerLockName, self.lockTimeout);
     }, parseDuration(self.checkFrequency));
   }
   return cb && cb();
@@ -72,8 +89,9 @@ DatasetClientsCleaner.prototype.stop = function(cb) {
   return cb && cb();
 };
 
-module.exports = function(storageImpl) {
+module.exports = function(storageImpl, syncLockImpl) {
   storage = storageImpl;
+  syncLock = syncLockImpl;
   return function(opts) {
     return new DatasetClientsCleaner(opts);
   }

--- a/lib/sync/datasetClientsCleaner.js
+++ b/lib/sync/datasetClientsCleaner.js
@@ -52,7 +52,7 @@ function cleanDatasetClients(retentionPeriod, lockName, lockTimeout) {
           }
         });
         if (err) {
-          debugError('Failed to cleanup dataset clients due to error %j', err);
+          debugError('Failed to cleanup dataset clients due to error %s', err);
         } else {
           debug('Removed %d dataset clients',_.size(deletedDatasetClients));
         }

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -76,7 +76,14 @@ MongodbQueue.prototype.create = function(cb) {
             debug('[%s] creating queue indexes', self.queueName);
             self.queue.createIndexes(callback);
           },
-          
+          function addExtraIdIndex(callback) {
+            debug('[%s] adding extra _id index for queue', self.queueName);
+            collection.createIndex({ deleted : 1, visible : 1, _id : 1}, callback);
+          },
+          function addExtraAckIndex(callback) {
+            debug('[%s] adding extra ack index for queue', self.queueName);
+            collection.createIndex({ ack: 1, visible : 1, deleted : 1}, callback);
+          },
           function listIndexes(createdIndex, callback) {
             debug('[%s] list existing indexes', self.queueName);
             collection.indexInformation({full: true}, callback);

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -5,6 +5,7 @@ var syncUtil = require('./util');
 var debug = syncUtil.debug;
 var debugError = syncUtil.debugError;
 var parseDuration = require('parse-duration');
+var async = require('async');
 
 /**
  * Make sure the real queue is created. Otherwise throws an error.
@@ -22,8 +23,7 @@ function ensureQueueCreated(target) {
  * @param {Object} opts configuration options for the queue
  * @param {Object} opts.mongodb an instance of the mongodb connection. This is required.
  * @param {Number} opts.visibility see https://github.com/chilts/mongodb-queue#visibility---message-visibility-window
- * @param {Object} opts.messagesToKeep decide what messages should be kept on the queue after acknowledged. This could be useful as an audit log. Default: {time: '24h'}. Means only the messages in the last 24 hours will be kept.
- * @param {Number} opts.pruneFrequency decide how often the prune job should be runnning (in milliseconds). Default to every hour.
+ * @param {Object} opts.queueMessagesTTL The TTL (time to live) value for the messages on the queue. Default to 24 hours.
  */
 function MongodbQueue(name, metrics, opts) {
   if (!name) {
@@ -36,8 +36,7 @@ function MongodbQueue(name, metrics, opts) {
   this.metrics = metrics;
   this.mongodb = opts.mongodb;
   this.queueOptions = {visibility: opts.visibility || 30};
-  this.messagesToKeep = opts.messagesToKeep || {time: '24h'};
-  this.pruneFrequency = opts.pruneFrequency || 1 * 60 * 60 * 1000;
+  this.queueTTL = opts.queueMessagesTTL || 24*60*60;
   this.queue;
 }
 
@@ -55,8 +54,31 @@ MongodbQueue.prototype.create = function(cb) {
   var self = this;
   if (!self.queue) {
     self.queue = mongodbQ(self.mongodb, self.queueName, self.queueOptions);
-    self.queue.createIndexes(function(err) {
-      if (err) {
+    var collection = self.mongodb.collection(self.queueName);
+    async.series([
+      function createIndexes(callback) {
+        self.queue.createIndexes(callback);
+      },
+      //it's not allowed to add TTL index if there is an existing index on the field, so we drop it first.
+      //it also makes it easier to update the TTL value. Otherwise we will have to check the existence of the index and call a different command to update the index.
+      function dropDeletedIndexIfExists(callback) {
+        var indexName = 'deleted_1';
+        collection.indexExists(indexName, function(err, exists){
+          if (err) {
+            return callback(err);
+          }
+          if (exists) {
+            collection.dropIndex(indexName, callback);
+          } else {
+            return callback();
+          }
+        })
+      },
+      function addTTLIndex(callback) {
+        collection.createIndex({'deleted': 1}, {'expireAfterSeconds': self.queueTTL, 'background': true}, callback);
+      }
+    ], function(err){
+       if (err) {
         return cb(err);
       }
       return cb(null, self.queue);
@@ -117,54 +139,6 @@ MongodbQueue.prototype.search = function(searchFields, cb) {
     }
     return cb(null, _.pluck(docs, 'payload'));
   });
-};
-
-/**
- * Prune the queue to remove some of the completed messages from the queue.
- */
-MongodbQueue.prototype.prune = function(cb) {
-  var self = this;
-  var pruneQuery = {
-    deleted: {$exists: true}
-  }
-  var collection = self.mongodb.collection(self.queueName);
-  if (self.messagesToKeep && self.messagesToKeep.time) {
-    var since = new Date(Date.now() - parseDuration(self.messagesToKeep.time));
-    pruneQuery.visible = {$lt: since.toISOString()};
-  }
-  var timer = metrics.startTimer();
-  collection.deleteMany(pruneQuery, function(err, result){
-    self.metrics.gauge(metrics.KEYS.QUEUE_OPERATION_TIME, {method: 'prune', name: self.queueName}, timer.stop());
-    if (err) {
-      debugError('Failed to delete messages from queue %s due to error %j', self.queueName, err);
-    } else {
-      debug('Deleted %d messages from queue %s', result.deletedCount, self.queueName);
-    }
-    return cb && cb(err, result);
-  });
-};
-
-/**
- * Set an interval to prune the queue.
- */
-MongodbQueue.prototype.startPruneJob = function(immediately, cb) {
-  var self = this;
-  if (immediately) {
-    self.prune();
-  }
-  if (!self.pruneJob) {
-    self.pruneJob = setInterval(function() {
-      self.prune();
-    }, self.pruneFrequency);
-  }
-  return cb && cb();
-};
-
-MongodbQueue.prototype.stopPruneJob = function() {
-  var self = this;
-  if (self.pruneJob) {
-    clearInterval(self.pruneJob);
-  }
 };
 
 module.exports = MongodbQueue;

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -76,11 +76,11 @@ MongodbQueue.prototype.create = function(cb) {
             debug('[%s] creating queue indexes', self.queueName);
             self.queue.createIndexes(callback);
           },
-          function addExtraIdIndex(callback) {
+          function addExtraIdIndex(createdIndex, callback) {
             debug('[%s] adding extra _id index for queue', self.queueName);
             collection.createIndex({ deleted : 1, visible : 1, _id : 1}, callback);
           },
-          function addExtraAckIndex(callback) {
+          function addExtraAckIndex(createdIndex, callback) {
             debug('[%s] adding extra ack index for queue', self.queueName);
             collection.createIndex({ ack: 1, visible : 1, deleted : 1}, callback);
           },

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -2,6 +2,9 @@ var mongodbQ = require('mongodb-queue');
 var metrics = require('./sync-metrics');
 var _ = require('underscore');
 var async = require('async');
+var syncUtil = require('./util');
+var debug = syncUtil.debug;
+var debugError = syncUtil.debugError;
 
 /**
  * Make sure the real queue is created. Otherwise throws an error.
@@ -16,12 +19,13 @@ function ensureQueueCreated(target) {
  * construct a new queue that is backed by mongodb.
  * @param {String} name the name of the queue.
  * @param {Object} metrics an instance of fh-component-metrics client
+ * @param {Object} lock an instance of the lock service
  * @param {Object} opts configuration options for the queue
  * @param {Object} opts.mongodb an instance of the mongodb connection. This is required.
  * @param {Number} opts.visibility see https://github.com/chilts/mongodb-queue#visibility---message-visibility-window
  * @param {Object} opts.queueMessagesTTL The TTL (time to live) value for the messages on the queue. Default to 24 hours.
  */
-function MongodbQueue(name, metrics, opts) {
+function MongodbQueue(name, metrics, lock, opts) {
   if (!name) {
     throw new Error('name is required to create a mongodb queue');
   }
@@ -30,6 +34,9 @@ function MongodbQueue(name, metrics, opts) {
   }
   this.queueName = name;
   this.metrics = metrics;
+  this.lock = lock;
+  this.lockName = opts.lockName || ('lock:sync:' + this.queueName);
+  this.lockTimeout = opts.lockTimeout || 10000;
   this.mongodb = opts.mongodb;
   this.queueOptions = {visibility: opts.visibility || 30};
   this.queueTTL = opts.queueMessagesTTL || 24*60*60;
@@ -51,33 +58,73 @@ MongodbQueue.prototype.create = function(cb) {
   if (!self.queue) {
     self.queue = mongodbQ(self.mongodb, self.queueName, self.queueOptions);
     var collection = self.mongodb.collection(self.queueName);
-    async.series([
-      function createIndexes(callback) {
-        self.queue.createIndexes(callback);
-      },
-      //it's not allowed to add TTL index if there is an existing index on the field, so we drop it first.
-      //it also makes it easier to update the TTL value. Otherwise we will have to check the existence of the index and call a different command to update the index.
-      function dropDeletedIndexIfExists(callback) {
-        var indexName = 'deleted_1';
-        collection.indexExists(indexName, function(err, exists){
-          if (err) {
-            return callback(err);
-          }
-          if (exists) {
-            collection.dropIndex(indexName, callback);
-          } else {
-            return callback();
-          }
-        })
-      },
-      function addTTLIndex(callback) {
-        collection.createIndex({'deleted': 1}, {'expireAfterSeconds': self.queueTTL, 'background': true}, callback);
-      }
-    ], function(err){
+    var indexName = 'deleted_1';
+    self.lock.acquire(self.lockName, self.lockTimeout, function(err, lockCode){
       if (err) {
+        debugError('[%s] failed to acquire lock %s due to error : %s', self.queueName, self.lockName, err);
         return cb(err);
       }
-      return cb(null, self.queue);
+      if (lockCode) {
+        debug('[%s] lock %s acquired. Continue.', self.queueName, self.lockName);
+        async.waterfall([
+          function createIndexes(callback) {
+            debug('[%s] creating queue indexes', self.queueName);
+            self.queue.createIndexes(callback);
+          },
+          function listIndexes(createdIndex, callback) {
+            debug('[%s] list existing indexes', self.queueName);
+            collection.indexInformation({full: true}, callback);
+          },
+          function checkIndexTTL(indexInfo, callback) {
+            debug('[%s] found queue indexInfo : %j', self.queueName, indexInfo);
+            var existingIndex = _.findWhere(indexInfo, {name: indexName});
+            var needDrop = false;
+            var needCreate = false;
+
+            if (!existingIndex) {
+              needCreate = true;
+            } else if (existingIndex.expireAfterSeconds !== self.queueTTL) {
+              needDrop = true;
+              needCreate = true;
+            }
+            return callback(null, needDrop, needCreate);
+          },
+          function dropTTLIndex(needDrop, needCreate, callback) {
+            if (needDrop) {
+              debug('[%s] dropping ttl index: %s', self.queueName, indexName);
+              collection.dropIndex(indexName, function(err){
+                return callback(err, needCreate);
+              });
+            } else {
+              debug('[%s] skip dropping ttl index', self.queueName);
+              return callback(null, needCreate);
+            }
+          },
+          function createTTLIndex(needCreate, callback) {
+            if (needCreate) {
+              debug('[%s] creating ttl index: %s', self.queueName, indexName);
+              collection.createIndex({'deleted': 1}, {'expireAfterSeconds': self.queueTTL, 'backgroud': true}, callback);
+            } else {
+              debug('[%s] skip creating ttl index', self.queueName);
+              return callback();
+            }
+          }
+        ], function(err){
+          if (err) {
+            debugError('[%s] failed to create queue index due to error: %s', self.queueName, err);
+            return cb(err);
+          }
+          self.lock.release(self.lockName, lockCode, function(releaseErr){
+            if (releaseErr) {
+              debugError('[%s] failed to release lock due to error: %s', self.queueName, releaseErr);
+            }
+          });
+          return cb(null, self.queue);
+        });
+      } else {
+        debug('[%s] can not acquire lock. Skip creating queuing index.', self.queueName, self.lockName);
+        return cb(null, self.queue);
+      }
     });
   } else {
     return cb(null, self.queue);

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -1,10 +1,6 @@
 var mongodbQ = require('mongodb-queue');
 var metrics = require('./sync-metrics');
 var _ = require('underscore');
-var syncUtil = require('./util');
-var debug = syncUtil.debug;
-var debugError = syncUtil.debugError;
-var parseDuration = require('parse-duration');
 var async = require('async');
 
 /**
@@ -78,7 +74,7 @@ MongodbQueue.prototype.create = function(cb) {
         collection.createIndex({'deleted': 1}, {'expireAfterSeconds': self.queueTTL, 'background': true}, callback);
       }
     ], function(err){
-       if (err) {
+      if (err) {
         return cb(err);
       }
       return cb(null, self.queue);

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -71,6 +71,7 @@ MongodbQueue.prototype.create = function(cb) {
             debug('[%s] creating queue indexes', self.queueName);
             self.queue.createIndexes(callback);
           },
+          
           function listIndexes(createdIndex, callback) {
             debug('[%s] list existing indexes', self.queueName);
             collection.indexInformation({full: true}, callback);

--- a/lib/sync/mongodbQueue.js
+++ b/lib/sync/mongodbQueue.js
@@ -55,7 +55,9 @@ function MongodbQueue(name, metrics, lock, opts) {
  */
 MongodbQueue.prototype.create = function(cb) {
   var self = this;
-  if (!self.queue) {
+  if (self.queue) {
+    return cb(null, self.queue);
+  } else {
     self.queue = mongodbQ(self.mongodb, self.queueName, self.queueOptions);
     var collection = self.mongodb.collection(self.queueName);
     var indexName = 'deleted_1';
@@ -64,7 +66,10 @@ MongodbQueue.prototype.create = function(cb) {
         debugError('[%s] failed to acquire lock %s due to error : %s', self.queueName, self.lockName, err);
         return cb(err);
       }
-      if (lockCode) {
+      if (!lockCode) {
+        debug('[%s] can not acquire lock. Skip creating queuing index.', self.queueName, self.lockName);
+        return cb(null, self.queue);
+      } else {
         debug('[%s] lock %s acquired. Continue.', self.queueName, self.lockName);
         async.waterfall([
           function createIndexes(callback) {
@@ -122,13 +127,8 @@ MongodbQueue.prototype.create = function(cb) {
           });
           return cb(null, self.queue);
         });
-      } else {
-        debug('[%s] can not acquire lock. Skip creating queuing index.', self.queueName, self.lockName);
-        return cb(null, self.queue);
       }
     });
-  } else {
-    return cb(null, self.queue);
   }
 };
 

--- a/lib/sync/storage/dataset-clients.js
+++ b/lib/sync/storage/dataset-clients.js
@@ -252,7 +252,9 @@ function doReadDatasetClientWithRecordsUseCache(datasetClientId, callback) {
         if (err) {
           return callback(err);
         }
-        cacheClient.set(cacheKey, JSON.stringify(results));
+        if (results) {
+          cacheClient.set(cacheKey, JSON.stringify(results));
+        }
         return callback(null, results);
       });
     }

--- a/lib/sync/sync-metrics.js
+++ b/lib/sync/sync-metrics.js
@@ -175,6 +175,9 @@ var getStats = function(cb) {
 module.exports = {
   init: function(syncConfig, redisClientImpl) {
     var metricsConfig = {enabled: false};
+    if (process.env.FH_APPNAME) {
+      metricsConfig.baseTags = {appname: process.env.FH_APPNAME};
+    }
     if (syncConfig.collectStats && redisClientImpl) {
       redisClient = redisClientImpl;
       metricsConfig.enabled = true;

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -163,9 +163,9 @@ function start(cb) {
 
   async.series([
     function createQueues(callback) {
-      ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
-      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
-      syncQueue = new MongodbQueue('fhsync_queue', metricsClient, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
+      ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, syncLock, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
+      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, syncLock, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
+      syncQueue = new MongodbQueue('fhsync_queue', metricsClient, syncLock, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
 
       async.parallel([
         async.apply(ackQueue.create.bind(ackQueue)),
@@ -230,8 +230,7 @@ function start(cb) {
     function startDatasetClientCleaner(callback) {
        var datasetClientCleanerBuilder = datasetClientCleanerModule(syncStorage, syncLock);
        datasetClientCleaner = datasetClientCleanerBuilder({retentionPeriod: syncConfig.datasetClientCleanerRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
-       //datasetClientCleaner.start(true, callback);
-       return callback();
+       datasetClientCleaner.start(true, callback);
     }
   ], function(err) {
     if (err) return cb(err);

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -228,9 +228,10 @@ function start(cb) {
       return callback();
     },
     function startDatasetClientCleaner(callback) {
-      var datasetClientCleanerBuilder = datasetClientCleanerModule(syncStorage, syncLock);
-      datasetClientCleaner = datasetClientCleanerBuilder({retentionPeriod: syncConfig.datasetClientCleanerRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
-      datasetClientCleaner.start(true, callback);
+       var datasetClientCleanerBuilder = datasetClientCleanerModule(syncStorage, syncLock);
+       datasetClientCleaner = datasetClientCleanerBuilder({retentionPeriod: syncConfig.datasetClientCleanerRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
+       //datasetClientCleaner.start(true, callback);
+       return callback();
     }
   ], function(err) {
     if (err) return cb(err);

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -97,10 +97,8 @@ var DEFAULT_SYNC_CONF = {
    * Can be turned on if there are no records are shared between many different dataset clients. Default is false.
   */
   useCache: false,
-  /**@type {Object} specify how many messages to keep for the queues. By default it will keep the messages in the last 24 hours */
-  queueMessagesToKeep: {time: '24h'},
-  /**@type {Number} specify how often the queues should be checked to prune old message. By default it will run every hour. */
-  queuePruneFrequency: 1*60*60*1000,
+  /**@type {Number} the TTL (Time To Live) value for the messages on the queue. In seconds. Default to 24 hours. */
+  queueMessagesTTL: 24*60*60,
   /**@type {String} specify the maximum retention time of an inactive datasetClient. Any inactive datasetClient that is older than this period of time will be removed.*/
   datasetClientCleanerRetentionPeriod: '24h',
   /** @type {String} specify the frequency the datasetClient cleaner should run. Default every hour.*/
@@ -165,17 +163,14 @@ function start(cb) {
 
   async.series([
     function createQueues(callback) {
-      ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, {mongodb: mongoDbClient, messagesToKeep: syncConfig.queueMessagesToKeep, pruneFrequency: syncConfig.queuePruneFrequency});
-      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, {mongodb: mongoDbClient, messagesToKeep: syncConfig.queueMessagesToKeep, pruneFrequency: syncConfig.queuePruneFrequency});
-      syncQueue = new MongodbQueue('fhsync_queue', metricsClient, {mongodb: mongoDbClient, messagesToKeep: syncConfig.queueMessagesToKeep, pruneFrequency: syncConfig.queuePruneFrequency});
+      ackQueue = new MongodbQueue('fhsync_ack_queue', metricsClient, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
+      pendingQueue = new MongodbQueue('fhsync_pending_queue', metricsClient, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
+      syncQueue = new MongodbQueue('fhsync_queue', metricsClient, {mongodb: mongoDbClient, queueMessagesTTL: syncConfig.queueMessagesTTL});
 
       async.parallel([
         async.apply(ackQueue.create.bind(ackQueue)),
-        async.apply(ackQueue.startPruneJob.bind(ackQueue), true),
         async.apply(pendingQueue.create.bind(pendingQueue)),
-        async.apply(pendingQueue.startPruneJob.bind(pendingQueue), true),
-        async.apply(syncQueue.create.bind(syncQueue)),
-        async.apply(syncQueue.startPruneJob.bind(syncQueue), true),
+        async.apply(syncQueue.create.bind(syncQueue))
       ], callback);
     },
     function initApis(callback) {
@@ -282,9 +277,6 @@ function stopAll(cb) {
     return cb();
   }
   debug('stopAll syncs');
-  ackQueue.stopPruneJob();
-  pendingQueue.stopPruneJob();
-  syncQueue.stopPruneJob();
   datasetClientCleaner.stop();
   async.parallel([
     async.apply(syncStorage.updateManyDatasetClients, {}, {stopped: true}),

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -228,7 +228,7 @@ function start(cb) {
       return callback();
     },
     function startDatasetClientCleaner(callback) {
-      var datasetClientCleanerBuilder = datasetClientCleanerModule(syncStorage);
+      var datasetClientCleanerBuilder = datasetClientCleanerModule(syncStorage, syncLock);
       datasetClientCleaner = datasetClientCleanerBuilder({retentionPeriod: syncConfig.datasetClientCleanerRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
       datasetClientCleaner.start(true, callback);
     }

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -228,9 +228,9 @@ function start(cb) {
       return callback();
     },
     function startDatasetClientCleaner(callback) {
-       var datasetClientCleanerBuilder = datasetClientCleanerModule(syncStorage, syncLock);
-       datasetClientCleaner = datasetClientCleanerBuilder({retentionPeriod: syncConfig.datasetClientCleanerRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
-       datasetClientCleaner.start(true, callback);
+      var datasetClientCleanerBuilder = datasetClientCleanerModule(syncStorage, syncLock);
+      datasetClientCleaner = datasetClientCleanerBuilder({retentionPeriod: syncConfig.datasetClientCleanerRetentionPeriod, checkFrequency: syncConfig.datasetClientCleanerCheckFrequency});
+      datasetClientCleaner.start(true, callback);
     }
   ], function(err) {
     if (err) return cb(err);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "dependencies": {
     "async": {
       "version": "2.1.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,59 +4,59 @@
   "dependencies": {
     "async": {
       "version": "2.1.5",
-      "from": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+      "from": "async@2.1.5",
       "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "from": "lodash@>=4.14.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
         }
       }
     },
     "backoff": {
       "version": "2.5.0",
-      "from": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "from": "backoff@>=2.5.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
       "dependencies": {
         "precond": {
           "version": "0.2.3",
-          "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+          "from": "precond@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
         }
       }
     },
     "colors": {
       "version": "0.6.2",
-      "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "from": "colors@0.6.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
     },
     "cycle": {
       "version": "1.0.3",
-      "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "from": "cycle@1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
     },
     "debug": {
       "version": "2.6.3",
-      "from": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+      "from": "debug@2.6.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
       "dependencies": {
         "ms": {
           "version": "0.7.2",
-          "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "from": "ms@0.7.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
         }
       }
     },
     "eyes": {
       "version": "0.1.8",
-      "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "from": "eyes@0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
     },
     "fh-component-metrics": {
-      "version": "2.6.1",
-      "from": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.6.1.tgz",
-      "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.6.1.tgz",
+      "version": "2.7.0",
+      "from": "feedhenry/fh-component-metrics#support-base-tags",
+      "resolved": "git://github.com/feedhenry/fh-component-metrics.git#9b4f4c3ee7d4dde67ba54320834dcaad8ccf4fe0",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -359,7 +359,7 @@
     },
     "fh-mbaas-client": {
       "version": "0.15.0",
-      "from": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-0.15.0.tgz",
+      "from": "fh-mbaas-client@0.15.0",
       "resolved": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-0.15.0.tgz",
       "dependencies": {
         "fh-logger": {
@@ -539,7 +539,7 @@
     },
     "fh-mbaas-express": {
       "version": "5.7.0",
-      "from": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.7.0.tgz",
+      "from": "fh-mbaas-express@5.7.0",
       "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.7.0.tgz",
       "dependencies": {
         "async": {
@@ -1560,7 +1560,7 @@
     },
     "fh-security": {
       "version": "0.2.0",
-      "from": "https://registry.npmjs.org/fh-security/-/fh-security-0.2.0.tgz",
+      "from": "fh-security@0.2.0",
       "resolved": "https://registry.npmjs.org/fh-security/-/fh-security-0.2.0.tgz",
       "dependencies": {
         "node-rsa": {
@@ -1579,7 +1579,7 @@
     },
     "fh-statsc": {
       "version": "0.3.0",
-      "from": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz",
+      "from": "fh-statsc@0.3.0",
       "resolved": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz",
       "dependencies": {
         "async": {
@@ -1591,46 +1591,46 @@
     },
     "lodash-contrib": {
       "version": "393.0.1",
-      "from": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz",
+      "from": "lodash-contrib@>=393.0.1 <394.0.0",
       "resolved": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.9.3",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
+          "from": "lodash@3.9.3",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
         }
       }
     },
     "memcached": {
       "version": "2.2.2",
-      "from": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
+      "from": "memcached@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
       "dependencies": {
         "hashring": {
           "version": "3.2.0",
-          "from": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
+          "from": "hashring@>=3.2.0 <3.3.0",
           "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
           "dependencies": {
             "connection-parse": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
+              "from": "connection-parse@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz"
             },
             "simple-lru-cache": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
+              "from": "simple-lru-cache@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz"
             }
           }
         },
         "jackpot": {
           "version": "0.0.6",
-          "from": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+          "from": "jackpot@>=0.0.6",
           "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
           "dependencies": {
             "retry": {
               "version": "0.6.0",
-              "from": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+              "from": "retry@0.6.0",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
             }
           }
@@ -1639,42 +1639,42 @@
     },
     "moment": {
       "version": "2.15.2",
-      "from": "https://registry.npmjs.org/moment/-/moment-2.15.2.tgz",
+      "from": "moment@2.15.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.2.tgz"
     },
     "mongodb": {
       "version": "2.1.18",
-      "from": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
+      "from": "mongodb@2.1.18",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
       "dependencies": {
         "es6-promise": {
           "version": "3.0.2",
-          "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "from": "es6-promise@3.0.2",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
         },
         "mongodb-core": {
           "version": "1.3.18",
-          "from": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
+          "from": "mongodb-core@1.3.18",
           "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
           "dependencies": {
             "bson": {
               "version": "0.4.23",
-              "from": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+              "from": "bson@>=0.4.23 <0.5.0",
               "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
             },
             "require_optional": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
+              "from": "require_optional@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
               "dependencies": {
                 "semver": {
                   "version": "5.3.0",
-                  "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                  "from": "semver@>=5.1.0 <6.0.0",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                 },
                 "resolve-from": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                  "from": "resolve-from@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
                 }
               }
@@ -1683,27 +1683,27 @@
         },
         "readable-stream": {
           "version": "1.0.31",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+          "from": "readable-stream@1.0.31",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "from": "isarray@0.0.1",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "from": "inherits@>=2.0.1 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             }
           }
@@ -1712,109 +1712,109 @@
     },
     "mongodb-lock": {
       "version": "0.4.0",
-      "from": "https://registry.npmjs.org/mongodb-lock/-/mongodb-lock-0.4.0.tgz",
+      "from": "mongodb-lock@0.4.0",
       "resolved": "https://registry.npmjs.org/mongodb-lock/-/mongodb-lock-0.4.0.tgz"
     },
     "mongodb-queue": {
       "version": "2.2.0",
-      "from": "https://registry.npmjs.org/mongodb-queue/-/mongodb-queue-2.2.0.tgz",
+      "from": "mongodb-queue@2.2.0",
       "resolved": "https://registry.npmjs.org/mongodb-queue/-/mongodb-queue-2.2.0.tgz"
     },
     "mongodb-uri": {
       "version": "0.9.7",
-      "from": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
+      "from": "mongodb-uri@0.9.7",
       "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz"
     },
     "optval": {
       "version": "1.0.1",
-      "from": "https://registry.npmjs.org/optval/-/optval-1.0.1.tgz",
+      "from": "optval@1.0.1",
       "resolved": "https://registry.npmjs.org/optval/-/optval-1.0.1.tgz"
     },
     "parse-duration": {
       "version": "0.1.1",
-      "from": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.1.1.tgz",
+      "from": "parse-duration@0.1.1",
       "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.1.1.tgz"
     },
     "pkginfo": {
       "version": "0.2.3",
-      "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+      "from": "pkginfo@0.2.3",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
     },
     "redis": {
       "version": "2.7.1",
-      "from": "https://registry.npmjs.org/redis/-/redis-2.7.1.tgz",
+      "from": "redis@>=2.6.5 <3.0.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.7.1.tgz",
       "dependencies": {
         "double-ended-queue": {
           "version": "2.1.0-0",
-          "from": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+          "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
           "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
         },
         "redis-commands": {
           "version": "1.3.1",
-          "from": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
+          "from": "redis-commands@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
         },
         "redis-parser": {
           "version": "2.6.0",
-          "from": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+          "from": "redis-parser@>=2.5.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz"
         }
       }
     },
     "request": {
       "version": "2.74.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
+      "from": "request@2.74.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "from": "aws-sign2@>=0.6.0 <0.7.0",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
           "version": "1.6.0",
-          "from": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "from": "aws4@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
         },
         "bl": {
           "version": "1.1.2",
-          "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+          "from": "bl@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.6",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "from": "readable-stream@>=2.0.5 <2.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                  "from": "isarray@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -1823,136 +1823,136 @@
         },
         "caseless": {
           "version": "0.11.0",
-          "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+          "from": "caseless@>=0.11.0 <0.12.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "from": "combined-stream@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "from": "delayed-stream@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "extend": {
-          "version": "3.0.0",
-          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+          "version": "3.0.1",
+          "from": "extend@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "from": "forever-agent@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
+          "from": "form-data@>=1.0.0-rc4 <1.1.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz"
         },
         "har-validator": {
           "version": "2.0.6",
-          "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "from": "har-validator@>=2.0.6 <2.1.0",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "from": "chalk@>=1.1.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "commander": {
               "version": "2.9.0",
-              "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "from": "commander@>=2.9.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "dependencies": {
                 "graceful-readlink": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                  "from": "graceful-readlink@>=1.0.0",
                   "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                 }
               }
             },
             "is-my-json-valid": {
               "version": "2.16.0",
-              "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
               "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
               "dependencies": {
                 "generate-function": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                 },
                 "generate-object-property": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                   "dependencies": {
                     "is-property": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                      "from": "is-property@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                     }
                   }
                 },
                 "jsonpointer": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+                  "from": "jsonpointer@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
                 }
               }
             },
             "pinkie-promise": {
               "version": "2.0.1",
-              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
               "dependencies": {
                 "pinkie": {
                   "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                 }
               }
@@ -1961,116 +1961,116 @@
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "from": "hawk@>=3.1.3 <3.2.0",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
-              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "from": "hoek@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "from": "boom@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "from": "cryptiles@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "from": "sntp@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "from": "http-signature@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
-              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "from": "assert-plus@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.4.0",
-              "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+              "from": "jsprim@>=1.2.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "from": "assert-plus@1.0.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 },
                 "extsprintf": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                  "from": "extsprintf@1.0.2",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.3",
-                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                  "from": "json-schema@0.2.3",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
-                  "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                  "from": "verror@1.3.6",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 }
               }
             },
             "sshpk": {
-              "version": "1.11.0",
-              "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
+              "version": "1.13.0",
+              "from": "sshpk@>=1.7.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
-                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                  "from": "asn1@>=0.2.3 <0.3.0",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "from": "assert-plus@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 },
                 "dashdash": {
                   "version": "1.14.1",
-                  "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                  "from": "dashdash@>=1.12.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                 },
                 "getpass": {
-                  "version": "0.1.6",
-                  "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                  "version": "0.1.7",
+                  "from": "getpass@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
                 },
                 "jsbn": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.14.5",
-                  "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                  "from": "tweetnacl@>=0.14.0 <0.15.0",
                   "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                  "from": "jodid25519@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 },
                 "bcrypt-pbkdf": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
                 }
               }
@@ -2079,83 +2079,83 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "from": "is-typedarray@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "from": "isstream@>=0.1.2 <0.2.0",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "2.1.15",
-          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "from": "mime-types@>=2.1.7 <2.2.0",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.27.0",
-              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+              "from": "mime-db@>=1.27.0 <1.28.0",
               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
             }
           }
         },
         "node-uuid": {
           "version": "1.4.8",
-          "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "from": "node-uuid@>=1.4.7 <1.5.0",
           "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "from": "oauth-sign@>=0.8.1 <0.9.0",
           "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "qs": {
           "version": "6.2.3",
-          "from": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+          "from": "qs@>=6.2.0 <6.3.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "from": "stringstream@>=0.0.4 <0.1.0",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "from": "tough-cookie@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
-              "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "from": "punycode@>=1.4.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.4.3",
-          "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "from": "tunnel-agent@>=0.4.1 <0.5.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
     "stack-trace": {
       "version": "0.0.9",
-      "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "from": "stack-trace@0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
     },
     "underscore": {
       "version": "1.7.0",
-      "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "from": "underscore@1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
     },
     "unifiedpush-node-sender": {
       "version": "0.12.1",
-      "from": "https://registry.npmjs.org/unifiedpush-node-sender/-/unifiedpush-node-sender-0.12.1.tgz",
+      "from": "unifiedpush-node-sender@0.12.1",
       "resolved": "https://registry.npmjs.org/unifiedpush-node-sender/-/unifiedpush-node-sender-0.12.1.tgz",
       "dependencies": {
         "lodash": {
@@ -2445,7 +2445,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "from": "xtend@4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     }
   }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -55,8 +55,8 @@
     },
     "fh-component-metrics": {
       "version": "2.7.0",
-      "from": "feedhenry/fh-component-metrics#support-base-tags",
-      "resolved": "git://github.com/feedhenry/fh-component-metrics.git#9b4f4c3ee7d4dde67ba54320834dcaad8ccf4fe0",
+      "from": "fh-component-metrics@2.7.0",
+      "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.7.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.4",
@@ -2168,15 +2168,15 @@
           "from": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
         },
-        "ajv": {
-          "version": "4.11.5",
-          "from": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz"
-        },
         "asn1": {
           "version": "0.2.3",
           "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+        },
+        "ajv": {
+          "version": "4.11.5",
+          "from": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz"
         },
         "assert-plus": {
           "version": "0.2.0",
@@ -2198,15 +2198,15 @@
           "from": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
         },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
-        },
         "boom": {
           "version": "2.10.1",
           "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
         },
         "caseless": {
           "version": "0.12.0",
@@ -2378,15 +2378,15 @@
           "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
         },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-        },
         "uuid": {
           "version": "3.0.1",
           "from": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
         },
         "verror": {
           "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cycle": "1.0.3",
     "debug": "2.6.3",
     "eyes": "0.1.8",
-    "fh-component-metrics": "~2.6.1",
+    "fh-component-metrics": "feedhenry/fh-component-metrics#support-base-tags",
     "fh-db": "2.0.0",
     "fh-mbaas-client": "0.15.0",
     "fh-mbaas-express": "5.7.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cycle": "1.0.3",
     "debug": "2.6.3",
     "eyes": "0.1.8",
-    "fh-component-metrics": "feedhenry/fh-component-metrics#support-base-tags",
+    "fh-component-metrics": "2.7.0",
     "fh-db": "2.0.0",
     "fh-mbaas-client": "0.15.0",
     "fh-mbaas-express": "5.7.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=7.0.6
+sonar.projectVersion=7.0.7
 
 sonar.sources=./lib
 sonar.tests=./test

--- a/test/sync/test_mongodbQueue.js
+++ b/test/sync/test_mongodbQueue.js
@@ -3,11 +3,16 @@ var proxyquire = require('proxyquire');
 var sinon = require('sinon');
 var async = require('async');
 
+var mockLock = {
+  acquire: sinon.stub(),
+  release: sinon.stub()
+};
+
 module.exports = {
   'test mongodb queue methods': function(done) {
     var metrics = {gauge: function(){}};
     var MongodbQueue = require('../../lib/sync/mongodbQueue');
-    var queue = new MongodbQueue('test', metrics, {mongodb: {}});
+    var queue = new MongodbQueue('test', metrics, mockLock, {mongodb: {}});
     ['create', 'add', 'get', 'ack', 'ping', 'total', 'size', 'inFlight', 'done', 'clean'].forEach(function(method){
       assert.equal(typeof queue[method], 'function');
     });
@@ -31,6 +36,9 @@ module.exports = {
           },
           indexExists: function(name, cb) {
             return cb();
+          },
+          indexInformation: function(opts, cb) {
+            return cb(null, []);
           }
         }
       }
@@ -51,7 +59,10 @@ module.exports = {
     var metrics = {
       gauge: sinon.spy()
     };
-    var queue = new MongodbQueue('test-metrics-queue', metrics, {mongodb: mockMongodb});
+    mockLock.acquire.yieldsAsync(null, 'testlock');
+    mockLock.acquire.yieldsAsync();
+    
+    var queue = new MongodbQueue('test-metrics-queue', metrics, mockLock, {mongodb: mockMongodb});
     queue.create(function(){
       async.parallel([
         async.apply(queue.add.bind(queue)),

--- a/test/sync/test_mongodbQueue.js
+++ b/test/sync/test_mongodbQueue.js
@@ -28,6 +28,9 @@ module.exports = {
           },
           createIndex: function(name, opts, cb) {
             return cb();
+          },
+          indexExists: function(name, cb) {
+            return cb();
           }
         }
       }

--- a/test/sync/test_mongodbQueue.js
+++ b/test/sync/test_mongodbQueue.js
@@ -8,7 +8,7 @@ module.exports = {
     var metrics = {gauge: function(){}};
     var MongodbQueue = require('../../lib/sync/mongodbQueue');
     var queue = new MongodbQueue('test', metrics, {mongodb: {}});
-    ['create', 'add', 'get', 'ack', 'ping', 'total', 'size', 'inFlight', 'done', 'clean', 'prune', 'startPruneJob'].forEach(function(method){
+    ['create', 'add', 'get', 'ack', 'ping', 'total', 'size', 'inFlight', 'done', 'clean'].forEach(function(method){
       assert.equal(typeof queue[method], 'function');
     });
     done();
@@ -20,6 +20,18 @@ module.exports = {
         return cb();
       }
     };
+    var mockMongodb = {
+      collection: function() {
+        return {
+          dropIndex: function(name, cb) {
+            return cb();
+          },
+          createIndex: function(name, opts, cb) {
+            return cb();
+          }
+        }
+      }
+    }
     var methods = ['add', 'get', 'ack', 'ping', 'total', 'size', 'inFlight', 'done', 'clean'];
     methods.forEach(function(method){
       var fn = sinon.stub();
@@ -36,7 +48,7 @@ module.exports = {
     var metrics = {
       gauge: sinon.spy()
     };
-    var queue = new MongodbQueue('test-metrics-queue', metrics, {mongodb: {}});
+    var queue = new MongodbQueue('test-metrics-queue', metrics, {mongodb: mockMongodb});
     queue.create(function(){
       async.parallel([
         async.apply(queue.add.bind(queue)),


### PR DESCRIPTION
a few improvements & bug fixes

* use mongodb TTL feature to manage the removal of queue data
* make sure only 1 datasetCleaner will remove data from mongodb when there are multiple workers
* fix an error when a sync operation is being performed on a datasetClient that is removed
* add `appname` to all the metrics data if it's available

ping @david-martin @aidenkeating for review