### PR TITLE
🐛 FH-3592 Ensure connect is finished before continuing to invoke sync

### DIFF
--- a/integration/sync/test_index.js
+++ b/integration/sync/test_index.js
@@ -186,45 +186,6 @@ module.exports = {
           return finish();
         });
       });
-    },
-
-    'should init & stop': function(done) {
-      var TESTCUID = 'testcuid';
-      var params = {
-        fn: 'sync',
-        query_params: {},
-        meta_data: {},
-        __fh: {
-          cuid: TESTCUID
-        },
-        pending: [{
-          action: 'create',
-          hash: 'a1',
-          uid: 'client-a1',
-          post: {
-            'a': '1',
-            'user': '1'
-          }
-        }]
-      };
-      async.series([
-        async.apply(sync.api.connect, mongoDBUrl, {}, null),
-        async.apply(sync.api.init, DATASETID, {}),
-        async.apply(sync.api.invoke, DATASETID, params),
-        async.apply(sync.api.stop, DATASETID),
-        function checkSyncCallFailed(callback){
-          sync.api.invoke(DATASETID, params, function(err){
-            assert.ok(err);
-            assert.ok(err.message.match(/stopped/ig));
-            callback();
-          });
-        },
-        async.apply(sync.api.init, DATASETID, {}),
-        async.apply(sync.api.invoke, DATASETID, params)
-      ], function(err){
-        assert.ok(!err, util.inspect(err));
-        done();
-      });
     }
   }
 };

--- a/lib/sync/index.js
+++ b/lib/sync/index.js
@@ -9,6 +9,7 @@ var async = require('async');
 var eventEmitter = new (require('events').EventEmitter)();
 var debug=syncUtil.debug;
 var debugError = syncUtil.debugError;
+var syncConnected = false;
 
 function toJSON(dataset_id, returnData, cb) {
   debug('[%s] toJSON',dataset_id);
@@ -35,25 +36,26 @@ function connect(mongoDBConnectionUrl, mongoDBConnectionOption, redisUrl, cb) {
       MongoClient.connect(mongoDBConnectionUrl, mongoDBConnectionOption || {}, callback);
     },
     function connectToRedis(callback) {
-      if (redisUrl) {
-        var redisOpts = {
-          url: redisUrl
-        };
-        var client = redis.createClient(redisOpts);
-        // We don't want the app to crash if Redis is not available.
-        client.on('error', handleRedisError);
-        return callback(null, client);
-      } else {
-        return callback();
-      }
+      var redisOpts = {
+        url: redisUrl
+      };
+      var client = redis.createClient(redisOpts);
+      // We don't want the app to crash if Redis is not available.
+      client.on('error', handleRedisError);
+      return callback(null, client);
     }
   ], function(err, results) {
-    if (err) return cb(err);
+    if (err) {
+      // If there was any problem with connecting to mongo or redis on startup,
+      // the app should crash as its in an unknown state.
+      throw err;
+    }
     var mongoDbClient = results[0];
     var redisClient = results[1];
 
     server.setClients(mongoDbClient, redisClient);
 
+    syncConnected = true;
     eventEmitter.emit('sync:ready');
     return cb(null, mongoDbClient, redisClient);
   });
@@ -90,7 +92,7 @@ function invoke(dataset_id, params, callback) {
 
   // Verify that fn param has been passed
   if (!params || !params.fn) {
-    var err = 'no fn parameter provided in params "' + util.inspect(params) + '"';
+    var err = new Error('no fn parameter provided in params "' + util.inspect(params) + '"');
     debugError('[%s] warn %s %j', dataset_id, err, params);
     return callback(err, null);
   }
@@ -99,15 +101,17 @@ function invoke(dataset_id, params, callback) {
 
   // Verify that fn param is valid
   if (invokeFunctions.indexOf(fn) < 0) {
-    return callback('invalid fn parameter provided in params "' + fn + '"', null);
+    return callback(new Error('invalid fn parameter provided in params "' + fn + '"'), null);
+  }
+
+  // We can only continue if sync has connected to its dependencies i.e. mongo & redis
+  if (!syncConnected) {
+    return callback(new Error('Sync not connected'));
   }
 
   var fnHandler =  module.exports[fn] || server[fn] || server.api[fn];
 
-  server.api.start(function(err) {
-    if (err) {
-      return callback(err);
-    }
+  server.api.start(function() {
     return fnHandler(dataset_id, params, callback);
   });
 }

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -156,7 +156,7 @@ function start(cb) {
   syncStarted = true;
 
   if (mongoDbClient === null || redisClient === null) {
-    return cb(new Error('MongoDB Client & Redis Client are not connected. Ensure connect() is called before calling start'));
+    throw new Error('MongoDB Client & Redis Client are not connected. Ensure connect() is called before calling start');
   }
 
   metricsClient = metricsModule.init(syncConfig, redisClient);
@@ -233,7 +233,12 @@ function start(cb) {
       datasetClientCleaner.start(true, callback);
     }
   ], function(err) {
-    if (err) return cb(err);
+    if (err) {
+      // If there is any problem setting up the necessary sync internals,
+      // throw an error to crash the app.
+      // This is necessary as it is in an unknown state.
+      throw err;
+    }
     return cb();
   });
 }

--- a/test/sync/test_index.js
+++ b/test/sync/test_index.js
@@ -28,7 +28,7 @@ module.exports = {
 
   'test invoke with missing fn': function(finish) {
     sync.api.invoke('test_dataset_id', {}, function(err) {
-      assert.equal(err, 'no fn parameter provided in params "{}"');
+      assert.equal(err.message, 'no fn parameter provided in params "{}"');
       return finish();
     });
   },
@@ -39,7 +39,7 @@ module.exports = {
     };
 
     sync.api.invoke('test_dataset_id', params, function(err) {
-      assert.equal(err, 'invalid fn parameter provided in params "some_invalid_fn"');
+      assert.equal(err.message, 'invalid fn parameter provided in params "some_invalid_fn"');
       return finish();
     });
   },


### PR DESCRIPTION
https://issues.jboss.org/browse/FH-3592

This change is to prevent a scenario where the application is
    starting and a client is sending a sync request to it.
    In that case, the `connect()` function may still be executing,
    so sync is not ready to `start` yet. To prevent `start` being
    executing in this case, an error will be sent to the sync client.
    This will cause a 'crashed' notification and the client will retry
    later.
