### PR TITLE
Change the default sync worker interval & backoff settings

### DIFF
--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -64,15 +64,13 @@ var DEFAULT_SYNC_CONF = {
    * The other valid strategy is `fib` (fibonacci). Set it to anything else will disable the backoff behavior  */
   ackWorkerBackoff: {strategy: 'exp', max: 60*1000},
   /** @type {Number} how often sync workers should check for the next job, in ms. Default: 100 */
-  syncWorkerInterval: 100,
+  syncWorkerInterval: 1,
   /** @type {Number} the concurrency value of the sync workers. Default is 1. Can set to 0 to disable the syncWorker completely. */
   syncWorkerConcurrency: 1,
   /** @type {Object} the backoff strategy for the sync worker to use. 
-   * Default strategy is `none`, which means it's turned off for the sync worker.
-   * This is to ensure when there is a sync request on the queue, it will be processed as soon as possible.
-   * The backoff could delay the process of the request significantly.
-   * Other valid strategies are `exp` (exponential) and `fib` (fibonacci).*/
-  syncWorkerBackoff: {strategy: 'none'},
+   * Default strategy is `exp` (exponential) with a max delay of 1s. The min value will always be the same as `syncWorkerInterval`
+   * Other valid strategies are `none` and `fib` (fibonacci).*/
+  syncWorkerBackoff: {strategy: 'exp', max: 1000},
   /** @type {Number} how often the scheduler should check the datasetClients, in ms. Default: 500 */
   schedulerInterval: 500,
   /** @type {Number} the max time a scheduler can hold the lock for, in ms. Default: 20000 */

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "dependencies": {
     "async": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=7.0.7
+sonar.projectVersion=7.0.8
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
The default is to use an exponential backoff, ranging from 1ms to 1000ms.
    These values are based on load tests. The idea is to take full advantage of
    CPU when the sync queue is busy and to allow the CPU to be used for other
    things when the sync queue is not busy. Setting a max of 1000ms will ensure
    then should the server get busy again, there won't be a significant delay
    in ramping up.