### PR TITLE
✅ Add MONGODB_VERSION env vars for MongoDB 2.4 & 3.2 to the travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_install:
   - npm install -g grunt-cli
   - npm config set strict-ssl false
 install: npm install
+env:
+  - MONGODB_VERSION=2.4
+  - MONGODB_VERSION=3.2
 script:
   - npm test
 matrix:

--- a/integration/sync/test_storage.js
+++ b/integration/sync/test_storage.js
@@ -194,7 +194,7 @@ module.exports = {
             callback();
           });
         },
-        async.apply(storage.updateDatasetClientWithRecords, datasetClient1.id, {}, updateRecords),
+        async.apply(storage.updateDatasetClientWithRecords, datasetClient1.id, {records: null}, updateRecords),
         function checkRecordIsRemovedFromTheDatasetClient(callback) {
           storage.readDatasetClientWithRecords(datasetClient1.id, function(err, datasetClient){
             assert.ok(!err);

--- a/scripts/posttest.sh
+++ b/scripts/posttest.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-docker rm -f $(docker ps -a -q  --filter name=mongodb2.4)
+docker rm -f $(docker ps -a -q  --filter name=mongodb-fh-mbaas-api)
 echo "Mongodb Stopped"
-docker rm -f $(docker ps -a -q  --filter name=redis2.6)
+docker rm -f $(docker ps -a -q  --filter name=redis-fh-mbaas-api)
 echo "Redis Stopped"

--- a/scripts/pretest.sh
+++ b/scripts/pretest.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-echo "Starting Redis-2.6"
-docker pull redis:2.6
-docker rm -f $(docker ps -a -q  --filter name=redis2.6)
-docker run -d -p 127.0.0.1:6379:6379 --name redis2.6 redis:2.6
-echo "Starting Mongodb-2.4"
-docker pull mongo:2.4
-docker rm -f $(docker ps -a -q  --filter name=mongodb2.4)
-docker run -d -p 127.0.0.1:27017:27017 --name mongodb2.4 mongo:2.4 mongod --smallfiles
+
+REDIS_VERSION=${REDIS_VERSION:-2.6}
+MONGODB_VERSION=${MONGODB_VERSION:-2.4}
+
+echo "Starting Redis-$REDIS_VERSION"
+docker pull redis:$REDIS_VERSION
+docker rm -f $(docker ps -a -q  --filter name=redis-fh-mbaas-api)
+docker run -d -p 127.0.0.1:6379:6379 --name redis-fh-mbaas-api redis:$REDIS_VERSION
+
+echo "Starting Mongodb-$MONGODB_VERSION"
+docker pull mongo:$MONGODB_VERSION
+docker rm -f $(docker ps -a -q  --filter name=mongodb-fh-mbaas-api)
+docker run -d -p 127.0.0.1:27017:27017 --name mongodb-fh-mbaas-api mongo:$MONGODB_VERSION mongod --smallfiles
 #give it some time to complete starting
 sleep 30s


### PR DESCRIPTION
See https://github.com/feedhenry/fh-mbaas-api/pull/143 for rationale
for doing this.