### PR TITLE
Update fh-sync dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.9",
+  "version": "7.0.11",
   "dependencies": {
     "async": {
       "version": "2.1.5",
@@ -1591,7 +1591,8 @@
     },
     "fh-sync": {
       "version": "1.0.1",
-      "from": "fh-sync@>=1.0.0 <1.1.0"
+      "from": "fh-sync@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/fh-sync/-/fh-sync-1.0.1.tgz"
     },
     "lodash-contrib": {
       "version": "393.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "7.0.10",
+  "version": "7.0.11",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {
@@ -16,7 +16,7 @@
     "fh-mbaas-express": "5.7.0",
     "fh-security": "0.2.0",
     "fh-statsc": "0.3.0",
-    "fh-sync": "~1.0.0",
+    "fh-sync": "~1.0.1",
     "lodash-contrib": "^393.0.1",
     "memcached": "^2.0.0",
     "moment": "2.15.2",


### PR DESCRIPTION
Found this bug when working on https://issues.jboss.org/browse/RHMAP-15493

Version 1.0.1 should be used instead since there is a typo https://github.com/feedhenry/fh-sync/blob/482679ad1a60baac6d323e630f05439253ede2d3/lib/mongodbQueue.js#L119 in version 1.0.0 (https://github.com/feedhenry/fh-sync/blob/482679ad1a60baac6d323e630f05439253ede2d3/package.json#L3). The typo was fixed in version 1.0.1 https://github.com/feedhenry/fh-sync/blob/master/lib/mongodbQueue.js#L119