### PR TITLE
bump unifiedpush-node-sender version to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "request": "2.74.0",
     "stack-trace": "0.0.9",
     "underscore": "1.7.0",
-    "unifiedpush-node-sender": "0.12.1",
+    "unifiedpush-node-sender": "0.16.0",
     "xtend": "4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
When calling `fh.push()` from a nodeJS cloud app in RHMAP I am getting this weird exception:
```
[2017-06-28T16:06:55.859Z] uncaughtException: [TypeError: Cannot read property 'toString' of undefined]
[2017-06-28T16:06:55.860Z] Internal error: [TypeError: Cannot read property 'toString' of undefined]
TypeError: Cannot read property 'toString' of undefined
    at ServerResponse.writeHead (_http_server.js:190:44)
    at ServerResponse._implicitHeader (_http_server.js:157:8)
    at ServerResponse.OutgoingMessage.end (_http_outgoing.js:573:10)
    at ServerResponse.res.send (/home/fh/.fh-npm-node4/express/4.0.0/lib/response.js:150:8)
    at /home/fh/apps/testing-l2k3v4lam2ky442ejgpv2up2-qed1-mbaas1-live/src/src/service/api-callback-factory.js:15:49
    at doEvent (/home/fh/.fh-npm-node4/fh-mbaas-api/7.0.11/node_modules/unifiedpush-node-sender/lib/unifiedpush-node-sender.js:31:9)
    at Request._callback (/home/fh/.fh-npm-node4/fh-mbaas-api/7.0.11/node_modules/unifiedpush-node-sender/lib/unifiedpush-node-sender.js:42:17)
    at Request.self.callback (/home/fh/.fh-npm-node4/fh-mbaas-api/7.0.11/node_modules/unifiedpush-node-sender/node_modules/request/request.js:188:22)
    at emitTwo (events.js:87:13)
    at Request.emit (events.js:172:7)
    at Request.<anonymous> (/home/fh/.fh-npm-node4/fh-mbaas-api/7.0.11/node_modules/unifiedpush-node-sender/node_modules/request/request.js:1171:10)
    at emitOne (events.js:77:13)
    at Request.emit (events.js:169:7)
    at IncomingMessage.<anonymous> (/home/fh/.fh-npm-node4/fh-mbaas-api/7.0.11/node_modules/unifiedpush-node-sender/node_modules/request/request.js:1091:12)
    at IncomingMessage.g (events.js:260:16)
    at emitNone (events.js:72:20)
```
That may be caused because fh-mbaas-api is using an old version of unifiedpush-node-sender.