### PR TITLE
docs: adds note to include JIRA ref in commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [8.1.4] - Fri Jan 19
+### Added
+- adds note to README to include JIRA/ issue reference in to commit messages
+
+
 ## [8.1.3] - Wed Jan 17
 ### Added
 - adds changelog to repo

--- a/README.md
+++ b/README.md
@@ -75,20 +75,22 @@ All PRs that involve a version bump to fh-mbaas-api to should also update the CH
 All commit messages should adhere to the following standard:
 
 ```
-<type>[optional scope]: <description>
+<type>[optional scope]: <description> [issue reference**]
  
 [optional body]
  
 [optional footer]
 ```
 
+** if commit relates to a specific JIRA/ issue ticket include the reference here.
+
 Examples of commits following this convention:
 
-- bug-fixes: `git commit -a -m "fix(parsing): fixed a bug in our parser"`
-- features: `git commit -a -m "feat(parser): we now have a parser \o/"`
+- bug-fixes: `git commit -a -m "fix(parsing): fixed a bug in our parser (RHMAP-1234)"`
+- features: `git commit -a -m "feat(parser): we now have a parser \o/ (FH-3456)"`
 - breaking changes: 
 ```
-git commit -a -m "feat(new-parser): introduces a new parsing library
+git commit -a -m "feat(new-parser): introduces a new parsing library (FH-6789)
 BREAKING CHANGE: new library does not support foo-construct"
 ```
 - other changes: `git commit -a -m "docs: fixed up the docs a bit"`

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "8.1.3",
+  "version": "8.1.4",
   "dependencies": {
     "async": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "8.1.3",
+  "version": "8.1.4",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas-api
 sonar.projectName=fh-mbaas-api-nightly-master
-sonar.projectVersion=8.1.3
+sonar.projectVersion=8.1.4
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
Update to README to include JIRA/ issue reference in commit messages. This small change echoes the one that is included in https://github.com/feedhenry/fh-fhc/pull/433 & is to maintain consistency

