### PR TITLE
Rhmap 19582

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [8.2.0] - Tue Feb 6
+## [8.2.1] - Tue Feb 27, 2018
+### Changed
+- updated fh-sync dependency to remove a direct link to github in its dependencies prior to v1.0.14 (RHMAP-19582)
+```git
+-    "fh-sync": "^1.0.5",
++    "fh-sync": "^1.0.14",
+```
+
+## [8.2.0] - Tue Feb 6, 2018
 ### Added
 - fix: update fh-mbaas-client to 1.1.1, to include bug fixes (FH-4374, RHMAP-18299)
 - fix: remove sonar-project.properties, as its no longer used (FH-4374)
@@ -16,12 +24,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - fix: package.json to reduce vulnerabilities (FH-4374)
 
 
-## [8.1.4] - Fri Jan 19
+## [8.1.4] - Fri Jan 19, 2018
 ### Added
 - adds note to README to include JIRA/ issue reference in to commit messages
 
 
-## [8.1.3] - Wed Jan 17
+## [8.1.3] - Wed Jan 17, 2018
 ### Added
 - adds changelog to repo
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "dependencies": {
     "async": {
       "version": "2.1.5",
@@ -240,15 +240,15 @@
           "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
         },
-        "require_optional": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz"
-        },
         "resolve-from": {
           "version": "2.0.0",
           "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+        },
+        "require_optional": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz"
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -2026,9 +2026,9 @@
       }
     },
     "fh-sync": {
-      "version": "1.0.13",
-      "from": "fh-sync@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fh-sync/-/fh-sync-1.0.13.tgz",
+      "version": "1.0.14",
+      "from": "fh-sync@>=1.0.14 <2.0.0",
+      "resolved": "https://registry.npmjs.org/fh-sync/-/fh-sync-1.0.14.tgz",
       "dependencies": {
         "backoff": {
           "version": "2.5.0",
@@ -2053,6 +2053,11 @@
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
             }
           }
+        },
+        "fh-mongodb-queue": {
+          "version": "3.3.0",
+          "from": "fh-mongodb-queue@3.3.0",
+          "resolved": "https://registry.npmjs.org/fh-mongodb-queue/-/fh-mongodb-queue-3.3.0.tgz"
         },
         "mongodb": {
           "version": "2.1.18",
@@ -2127,11 +2132,6 @@
           "from": "mongodb-lock@0.4.0",
           "resolved": "https://registry.npmjs.org/mongodb-lock/-/mongodb-lock-0.4.0.tgz"
         },
-        "mongodb-queue": {
-          "version": "3.1.0",
-          "from": "git+https://github.com/david-martin/mongodb-queue.git#ttl-index-01",
-          "resolved": "git+https://github.com/david-martin/mongodb-queue.git#3867a46ea028b0c327d583492b8c566460a8e7f8"
-        },
         "parse-duration": {
           "version": "0.1.1",
           "from": "parse-duration@0.1.1",
@@ -2148,9 +2148,9 @@
               "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
             },
             "redis-commands": {
-              "version": "1.3.1",
+              "version": "1.3.4",
               "from": "redis-commands@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.4.tgz"
             },
             "redis-parser": {
               "version": "2.6.0",
@@ -2230,9 +2230,9 @@
           "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
         },
         "redis-commands": {
-          "version": "1.3.1",
+          "version": "1.3.4",
           "from": "redis-commands@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.4.tgz"
         },
         "redis-parser": {
           "version": "2.6.0",
@@ -2262,9 +2262,9 @@
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
         },
         "combined-stream": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
@@ -2284,9 +2284,9 @@
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
-          "version": "2.3.1",
+          "version": "2.3.2",
           "from": "form-data@>=2.3.1 <2.4.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
           "dependencies": {
             "asynckit": {
               "version": "0.4.0",
@@ -2311,9 +2311,9 @@
                   "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
                 },
                 "fast-deep-equal": {
-                  "version": "1.0.0",
+                  "version": "1.1.0",
                   "from": "fast-deep-equal@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz"
                 },
                 "fast-json-stable-stringify": {
                   "version": "2.0.0",
@@ -2340,9 +2340,9 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
           "dependencies": {
             "hoek": {
-              "version": "4.2.0",
+              "version": "4.2.1",
               "from": "hoek@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz"
             },
             "boom": {
               "version": "4.3.1",
@@ -2467,14 +2467,14 @@
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
-          "version": "2.1.17",
+          "version": "2.1.18",
           "from": "mime-types@>=2.1.17 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
           "dependencies": {
             "mime-db": {
-              "version": "1.30.0",
-              "from": "mime-db@>=1.30.0 <1.31.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+              "version": "1.33.0",
+              "from": "mime-db@>=1.33.0 <1.34.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz"
             }
           }
         },
@@ -2504,9 +2504,9 @@
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
-          "version": "2.3.3",
+          "version": "2.3.4",
           "from": "tough-cookie@>=2.3.3 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
@@ -2582,15 +2582,15 @@
           "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
         },
-        "caseless": {
-          "version": "0.12.0",
-          "from": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-        },
         "boom": {
           "version": "2.10.1",
           "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "from": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
         },
         "co": {
           "version": "4.6.0",
@@ -2662,15 +2662,15 @@
           "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
         },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-        },
         "isstream": {
           "version": "0.1.2",
           "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "jodid25519": {
           "version": "1.0.2",
@@ -2722,15 +2722,15 @@
           "from": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
         },
-        "qs": {
-          "version": "6.4.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-        },
         "punycode": {
           "version": "1.4.1",
           "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+        },
+        "qs": {
+          "version": "6.4.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -2784,10 +2784,10 @@
             }
           }
         },
-        "getpass": {
-          "version": "0.1.6",
-          "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+        "jsprim": {
+          "version": "1.4.0",
+          "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -2796,10 +2796,10 @@
             }
           }
         },
-        "jsprim": {
-          "version": "1.4.0",
-          "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+        "getpass": {
+          "version": "0.1.6",
+          "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fh-mbaas-express": "^5.10.0",
     "fh-security": "0.2.1",
     "fh-statsc": "0.3.0",
-    "fh-sync": "^1.0.5",
+    "fh-sync": "^1.0.14",
     "lodash-contrib": "^393.0.1",
     "memcached": "^2.0.0",
     "mongodb-uri": "0.9.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "8.2.0",
+  "version": "8.2.1",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {


### PR DESCRIPTION
## Jira link
https://issues.jboss.org/browse/RHMAP-19582

### What
Update fh-sync dependency to use updated version of fh-sync

## Why
fh-sync needed to be updated so it did not rely on any github-hosted dependencies. fh-mbaas-api relied on fh-sync & now needs to be updated to use updated published version of fh-sync that doesn't rely on any github-hosted dependencies

## How
Update dependency to point to updated published version of fh-sync

## Verification steps
<to-be-added>