### PR TITLE
Update CI process to use supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: node_js
 sudo: required
 node_js:
-  - "4.4.3"
-  - "6.9.1"
+  - 4
+  - 6
 services:
   - docker
 before_install:
   - sudo apt-get update
   - sudo apt-get install --assume-yes apache2-utils
-  - npm install -g npm@2.13.5
   - npm install -g grunt-cli
   - npm config set strict-ssl false
 install: npm install
@@ -16,4 +15,4 @@ env:
   - MONGODB_VERSION=2.4
   - MONGODB_VERSION=3.2
 script:
-  - npm test
+  - grunt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Update CI process to use supported versions
+
 ## [8.2.2] - Tue May 1, 2018
 ### Fix
 - Add eslint configuration and fix files 


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-20296

## WHAT
* Update to use NodeJS version to use 4, 6, and 8 as follows.

```
node_js:
  - '4'
  - '6'
```
* Remove the fixed npm version
* Update to call the grunt tasks

## WHY
Use in the CI the currently supported versions.

## Verification Steps:
Check if the all steps in Trevis are finishing with success. 

PS.: This lib is not working with NodeJS 8 which will be checked in the future. 
