### PR TITLE
RHMAP-21086 - Upgrade fh-security to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -849,7 +849,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1773,10 +1773,25 @@
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.7.tgz",
           "integrity": "sha1-RMXuFRrs5sS/U2TPx8KP5OWPGN8="
         },
+        "deep-extend": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+        },
         "lodash": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "node-uuid": {
           "version": "1.4.7",
@@ -1802,23 +1817,13 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
               "integrity": "sha1-ToCMLOFExsF4iRjgNNZ5e8bPYoE="
-            },
-            "optimist": {
-              "version": "0.3.7",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-              "requires": {
-                "wordwrap": "~0.0.2"
-              },
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-                }
-              }
             }
           }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
@@ -2610,28 +2615,11 @@
       }
     },
     "fh-security": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fh-security/-/fh-security-0.2.1.tgz",
-      "integrity": "sha1-Q4DQfsgrGz0Z4tsBU2lLJ/s2mP4=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/fh-security/-/fh-security-0.4.0.tgz",
+      "integrity": "sha512-reovo5WqcdhlsilxB29qUB2kv+eSy2VzqS0KPF3SUxMWPLUUsELqJTHzrQyc3egL7rGs8/niiRLJAeV9Gnya9A==",
       "requires": {
         "node-rsa": "0.3.2"
-      },
-      "dependencies": {
-        "node-rsa": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.3.2.tgz",
-          "integrity": "sha1-rZgz54R7Tm4S9bCpXOkF/68ZMa0=",
-          "requires": {
-            "asn1": "0.2.3"
-          },
-          "dependencies": {
-            "asn1": {
-              "version": "0.2.3",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-            }
-          }
-        }
       }
     },
     "fh-statsc": {
@@ -10082,6 +10070,21 @@
         "propagate": "0.2.x"
       }
     },
+    "node-rsa": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.3.2.tgz",
+      "integrity": "sha1-rZgz54R7Tm4S9bCpXOkF/68ZMa0=",
+      "requires": {
+        "asn1": "0.2.3"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+        }
+      }
+    },
     "node-uuid": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
@@ -10223,7 +10226,6 @@
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
       "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-      "dev": true,
       "requires": {
         "wordwrap": "~0.0.2"
       }
@@ -10678,7 +10680,7 @@
     "redis": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "integrity": "sha1-ICKI4/WMSfYHnZevehDhMDrhSwI=",
       "requires": {
         "double-ended-queue": "^2.1.0-0",
         "redis-commands": "^1.2.0",
@@ -10729,7 +10731,7 @@
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",
@@ -11970,7 +11972,7 @@
         "lodash": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ=="
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         },
         "mime-db": {
           "version": "1.26.0",
@@ -12321,8 +12323,7 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "fh-db": "3.3.1",
     "fh-mbaas-client": "1.1.4",
     "fh-mbaas-express": "6.0.1",
-    "fh-security": "0.2.1",
+    "fh-security": "0.4.0",
     "fh-statsc": "1.0.0",
     "fh-sync": "2.0.0",
     "lodash-contrib": "^393.0.1",


### PR DESCRIPTION
# JIRA:

https://issues.jboss.org/browse/RHMAP-21086

# WHAT:
* Upgrade fh-security to 0.4.0

# WHY:
* Get fixes/changes from the latest version for the next release

# HOW: 
* Run `npm install --save --save-exact <dep>@<version>`





