### PR TITLE
 🔖 bump version for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {


### PR DESCRIPTION
need to use 9.0.4 as 9.0.3 is not available anymore.