### PR TITLE
Upgrade mejor version - lib/dep redis to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [9.1.2] - Thu Set 26, 2018
+### Change
+- Upgrade the redis lib to 2.8.0 ( Menor version )
+
 ## [9.1.1] - Thu Set 26, 2018
 ### Change
 - Upgrade unifiedpush-node-sender dependency to 0.16.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -10526,7 +10526,7 @@
     "redis": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
-      "integrity": "sha1-ICKI4/WMSfYHnZevehDhMDrhSwI=",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "requires": {
         "double-ended-queue": "^2.1.0-0",
         "redis-commands": "^1.2.0",
@@ -10536,7 +10536,7 @@
     "redis-commands": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.5.tgz",
-      "integrity": "sha1-RJWIlBTx6IYmEYCxRC5ylWAtg6I="
+      "integrity": "sha512-foGF8u6MXGFF++1TZVC6icGXuMYPftKXt1FBT2vrfU9ZATNtZJ8duRC5d1lEfE8hyVe3jhelHGB91oB7I6qLsA=="
     },
     "redis-parser": {
       "version": "2.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "memcached": "^2.0.0",
     "mongodb-uri": "0.9.7",
     "optval": "1.0.1",
-    "redis": "^2.6.5",
+    "redis": "2.8.0",
     "request": "2.88.0",
     "underscore": "1.7.0",
     "unifiedpush-node-sender": "0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "9.1.1",
+  "version": "9.1.2",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21576

# What
- Upgrade the redis lib to 2.8.0 ( Menor version )


# Why
Ensure that all places in RHMAP will are using the latest version exactly. The Redis image will be upgraded see here https://github.com/fheng/redis-container/pull/77 and solve CVEs

# How
`npm install --save --save-exact redis@2.8.0`

# Verification Steps
- Create a new project
- deploy the cloud upp
- Change the cloud app to use this lib (tag development: 9.1.2-dev-1  )
- Check if all is ok. 
For further test the project (https://github.com/feedhenry/testing-cloud-app)

<img width="975" alt="screen shot 2018-10-02 at 15 47 17" src="https://user-images.githubusercontent.com/7708031/46356401-95f4ba00-c65a-11e8-862e-73a6dd355f74.png">

PS.: IHMO no test here are required since the change was from `^2.6.5` to `2.8.0`.  Pass in the CI process shows enough. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 