### PR TITLE
Rhmap 21140

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Jira link(s)
+
+
+
+# What
+
+
+
+# Why
+
+
+
+
+# How
+
+
+
+# Verification Steps
+
+
+
+## Checklist:
+
+- [ ] Code has been tested locally by PR requester
+- [ ] Changes have been successfully verified by another team member 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [9.1.0] - Wed Sep 19, 2018
+### Changed
+- Upgraded `fh-mbaas-express` to `6.1.0` for updated caching of service calls.
+
 ## [9.0.0] - Thu Aug 16, 2018
 ### Changed
 - Removed support for Node4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "9.0.4",
+  "version": "9.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1783,7 +1783,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "node-uuid": {
@@ -2288,9 +2288,9 @@
       }
     },
     "fh-mbaas-express": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-6.0.3.tgz",
-      "integrity": "sha512-KgbeU3jfakhIm3AYH7aWIgg9qUs98kevw+JBV/QkkY1ttQ4CmGqJQr/EX0wcwpkwWpDUHWbMuWUQDNKf6uugMA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-6.1.0.tgz",
+      "integrity": "sha512-vUegxmsg7gWLpcISGfn8lCTcKBM7VlAub/2HAGJ9hYoRdTMTSGp6Rh2KGGaQEgzvjapXgyru6z5bz8q67eHZZw==",
       "requires": {
         "async": "0.2.9",
         "body-parser": "1.18.2",
@@ -2531,6 +2531,11 @@
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.1.tgz",
           "integrity": "sha1-0r3oF9F2/63olKtxRY5oKhS4bck="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -2557,7 +2562,7 @@
         },
         "request": {
           "version": "2.85.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+          "resolved": "http://registry.npmjs.org/request/-/request-2.85.0.tgz",
           "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -2583,6 +2588,11 @@
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.1.0"
           }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },
@@ -10611,7 +10621,7 @@
     },
     "readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -12212,11 +12222,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas-api",
-  "version": "9.0.4",
+  "version": "9.1.0",
   "description": "FeedHenry MBAAS Cloud APIs",
   "main": "lib/api.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "debug": "2.6.9",
     "fh-db": "3.3.1",
     "fh-mbaas-client": "1.1.4",
-    "fh-mbaas-express": "6.0.3",
+    "fh-mbaas-express": "6.1.0",
     "fh-security": "0.4.0",
     "fh-statsc": "1.0.0",
     "fh-sync": "2.0.0",


### PR DESCRIPTION
# Jira link(s)

https://issues.jboss.org/browse/RHMAP-21143

# What

Use updated version of fh-mbaas-express dependecy

# Why

Updating caching of unauthorised service requests added to fh-mbaas-express to prevent large numbers of requests by an unauthorised service bringing down the core

# How

Update fh-mbaas-express to use updated version

# Verification Steps



## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 