### PR TITLE
Upgrade fh-sync to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -415,14 +415,19 @@
       }
     },
     "bson": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
-      "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
     },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1139,9 +1144,9 @@
       }
     },
     "es6-promise": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+      "version": "3.2.1",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
     },
     "es6-set": {
       "version": "0.1.5",
@@ -1828,7 +1833,7 @@
         },
         "lodash": {
           "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         }
       }
@@ -2403,7 +2408,7 @@
     "fh-mongodb-queue": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/fh-mongodb-queue/-/fh-mongodb-queue-3.3.0.tgz",
-      "integrity": "sha1-9sFght8GumTY8Xzl0GS+X23hoUE="
+      "integrity": "sha512-KJJSaPhPEL5//Au+BhfFUHkaXPDXY/bHXzKK9nXoSt3Ed69jbL0epjKrpWDNHqSNJN3ouDoTQA6oRF+Xk4m2YA=="
     },
     "fh-reportingclient": {
       "version": "1.0.1",
@@ -2479,16 +2484,16 @@
       }
     },
     "fh-sync": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fh-sync/-/fh-sync-2.0.0.tgz",
-      "integrity": "sha1-f7+dMhnUKDVJ1PmigxcQo/YoQTo=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fh-sync/-/fh-sync-2.0.1.tgz",
+      "integrity": "sha512-SY5j7nD0aY/HGAmjV6nyqlo0nS+AyS6NhMkIbroVdtwq0wLTV05wpkXtQxXZOgBNcHsFUlFWITI9ep85iOFqOQ==",
       "requires": {
         "async": "2.6.1",
         "backoff": "2.5.0",
         "debug": "3.1.0",
         "fh-component-metrics": "2.7.0",
         "fh-mongodb-queue": "3.3.0",
-        "mongodb": "2.1.18",
+        "mongodb": "2.2.33",
         "mongodb-lock": "0.4.0",
         "parse-duration": "0.1.1",
         "redis": "2.8.0",
@@ -2498,7 +2503,7 @@
         "async": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
             "lodash": "^4.17.10"
           }
@@ -2506,7 +2511,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -2514,7 +2519,7 @@
         "underscore": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-          "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE="
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
         }
       }
     },
@@ -9779,34 +9784,55 @@
       "dev": true
     },
     "mongodb": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
-      "integrity": "sha1-KNQLUVsr5NWmn/3UxTXw30MuQJc=",
+      "version": "2.2.33",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
+      "integrity": "sha1-tTfEcdNKZlG0jzb9vyl1A0Dgi1A=",
       "requires": {
-        "es6-promise": "3.0.2",
-        "mongodb-core": "1.3.18",
-        "readable-stream": "1.0.31"
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.17",
+        "readable-stream": "2.2.7"
       },
       "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
         "readable-stream": {
-          "version": "1.0.31",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
-          "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
           "requires": {
+            "buffer-shims": "~1.0.0",
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }
     },
     "mongodb-core": {
-      "version": "1.3.18",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
-      "integrity": "sha1-kGhLO3xzVtZa41Y5HTCw8kiATHo=",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
+      "integrity": "sha1-pBizN6FKFJkPtRC5I97mqBMXPfg=",
       "requires": {
-        "bson": "~0.4.23",
+        "bson": "~1.0.4",
         "require_optional": "~1.0.0"
       }
     },
@@ -10677,7 +10703,7 @@
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fh-mbaas-express": "6.1.1",
     "fh-security": "0.4.0",
     "fh-statsc": "1.0.0",
-    "fh-sync": "2.0.0",
+    "fh-sync": "2.0.1",
     "lodash-contrib": "^393.0.1",
     "memcached": "^2.0.0",
     "mongodb-uri": "0.9.7",


### PR DESCRIPTION
# Jira link(s)

https://issues.jboss.org/browse/RHMAP-21743

# What

- Upgrade the fh-sync version from 2.0.0 to 2.0.1

# Why
- To solve CVEs

# How
`npm install --save --save-exact  fh-sync@2.0.1`

# Verification Steps

- Create a project based on the sync template ( https://github.com/feedhenry-templates/sync-cloud and https://github.com/feedhenry-templates/sync-cordova-app )
- Update fh-mbaas-api in the cloud app to use this version : fh-sync v2.0.1 ( which is `9.1.3-dev-1`)

<img width="1141" alt="screen shot 2018-10-05 at 09 22 53" src="https://user-images.githubusercontent.com/7708031/46524300-4b548700-c880-11e8-8ed6-b3d15910f4df.png">

- Deploy the changes
- Update the client app to use the latest version of SDK fh-js-SDK = 3.0.11.
- Go to connections inside of the project and link the sync client app with the cloud sync app

<img width="1640" alt="screen shot 2018-10-05 at 09 25 04" src="https://user-images.githubusercontent.com/7708031/46524407-a8503d00-c880-11e8-948a-b57ec6a8af32.png">
 
- Test if the sync is working.

<img width="1643" alt="screen shot 2018-10-05 at 09 26 45" src="https://user-images.githubusercontent.com/7708031/46524452-d03fa080-c880-11e8-89cf-e57f3d95848f.png">

Please feel free to check it [here]( https://rhmap.ocp4.skunkhenry.com/box/srv/1.1/wid/rhmap/studio/fxkysu6igc5b7fxcszgv5in6/file/www/index.html?fh_destination_code=studio&fh_apptitle=SyncApp&url=https://nodejs-syncclouddev5hwf-rhmap-rhmap-dev.ocp4.skunkhenry.com#!/tabs/main)

- Go to the databrowser and check that there are the data.

<img width="624" alt="screen shot 2018-10-05 at 09 28 06" src="https://user-images.githubusercontent.com/7708031/46524551-185ec300-c881-11e8-837a-89dfdab82fd5.png">

Please feel free to check it [here](https://rhmap.ocp4.skunkhenry.com/#projects/fxkysu6bcpwzhjq5u4bw2q7g/apps/fxkysu5vfhmsokno3uky5hwf/databrowser)

PS.: it is important to check it since the issue faced with the fh-supercore was faced when it got the mongodb version 2.2.18. This updated will make the lib start to use the version 2.2.33

## Checklist:

- [x] Code has been tested locally by PR requester ( I could not test it so far since I don't if we have a cluster in this condition available to test it )
- [ ] Changes have been successfully verified by another team member 